### PR TITLE
add unsafe Iso[Map[K,V], List([K, V])] and Traversal[Map[K, V], (K, V)]

### DIFF
--- a/test/shared/src/test/scala/monocle/unsafe/MapTraversalSpec.scala
+++ b/test/shared/src/test/scala/monocle/unsafe/MapTraversalSpec.scala
@@ -1,0 +1,57 @@
+package monocle.unsafe
+
+import monocle.{Iso, MonocleSuite, Traversal}
+import monocle.law.{IsoLaws, TraversalLaws}
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
+import org.typelevel.discipline.Laws
+import cats.Eq
+import monocle.unsafe.MapTraversal.{mapKVTraversal, mapListIso}
+import monocle.law.discipline._
+import cats.instances.option._
+
+object MapListIsoTests extends Laws {
+  def apply[S: Arbitrary: Eq, A: Arbitrary: Eq](iso: Iso[S, A])(
+      implicit arbAA: Arbitrary[A => A]): RuleSet = {
+    val laws = new IsoLaws(iso)
+    new SimpleRuleSet(
+      "MapListIso",
+      "round trip one way" -> forAll((s: S) => laws.roundTripOneWay(s)),
+      // "round trip other way does not work because of key collision"
+      "modify id = id" -> forAll((s: S) => laws.modifyIdentity(s)),
+      // "compose modify does not work because of key collision"
+      "consistent set with modify" -> forAll(
+        (s: S, a: A) => laws.consistentSetModify(s, a)),
+      "consistent modify with modifyId" -> forAll(
+        (s: S, f: A => A) => laws.consistentModifyModifyId(s, f)),
+      "consistent get with modifyId" -> forAll(
+        (s: S) => laws.consistentGetModifyId(s))
+    )
+  }
+}
+
+object MapKVTraversalTests extends Laws {
+  def apply[S: Arbitrary: Eq, A: Arbitrary: Eq](traversal: Traversal[S, A])(
+      implicit arbAA: Arbitrary[A => A]): RuleSet =
+    apply[S, A, Unit](_ => traversal)
+
+  def apply[S: Arbitrary: Eq, A: Arbitrary: Eq, I: Arbitrary](
+      f: I => Traversal[S, A]
+  )(implicit arbAA: Arbitrary[A => A]): RuleSet = {
+    def laws(i: I): TraversalLaws[S, A] = new TraversalLaws(f(i))
+    new SimpleRuleSet(
+      "MapKVTraversal",
+      "headOption" -> forAll((s: S, i: I) => laws(i).headOption(s)),
+      // "get what you set does not work because of key collision"
+      "set idempotent" -> forAll(
+        (s: S, a: A, i: I) => laws(i).setIdempotent(s, a)),
+      "modify id = id" -> forAll((s: S, i: I) => laws(i).modifyIdentity(s)),
+      // "compose modify does not work because of key collision"
+    )
+  }
+}
+
+class MapTraversalSpec extends MonocleSuite {
+  checkAll("map list Iso", MapListIsoTests(mapListIso[String, Int]))
+  checkAll("map KV traversal", MapKVTraversalTests(mapKVTraversal[String, Int]))
+}

--- a/test/shared/src/test/scala/monocle/unsafe/MapTraversalSpec.scala
+++ b/test/shared/src/test/scala/monocle/unsafe/MapTraversalSpec.scala
@@ -17,9 +17,9 @@ object MapListIsoTests extends Laws {
     new SimpleRuleSet(
       "MapListIso",
       "round trip one way" -> forAll((s: S) => laws.roundTripOneWay(s)),
-      // "round trip other way does not work because of key collision"
+      // "round trip other way does not work because of key collision and unorderness"
       "modify id = id" -> forAll((s: S) => laws.modifyIdentity(s)),
-      // "compose modify does not work because of key collision"
+      // "compose modify does not work because of key collision and unorderness"
       "consistent set with modify" -> forAll(
         (s: S, a: A) => laws.consistentSetModify(s, a)),
       "consistent modify with modifyId" -> forAll(
@@ -42,11 +42,11 @@ object MapKVTraversalTests extends Laws {
     new SimpleRuleSet(
       "MapKVTraversal",
       "headOption" -> forAll((s: S, i: I) => laws(i).headOption(s)),
-      // "get what you set does not work because of key collision"
+      // "get what you set does not work because of key collision unorderness"
       "set idempotent" -> forAll(
         (s: S, a: A, i: I) => laws(i).setIdempotent(s, a)),
       "modify id = id" -> forAll((s: S, i: I) => laws(i).modifyIdentity(s)),
-      // "compose modify does not work because of key collision"
+      // "compose modify does not work because of key collision and unorderness"
     )
   }
 }

--- a/test/shared/src/test/scala/monocle/unsafe/MapTraversalSpec.scala
+++ b/test/shared/src/test/scala/monocle/unsafe/MapTraversalSpec.scala
@@ -6,7 +6,7 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
 import org.typelevel.discipline.Laws
 import cats.Eq
-import monocle.unsafe.MapTraversal.{mapKVTraversal, mapListIso}
+import monocle.unsafe.MapTraversal.{mapKVTraversal, allKeyValues}
 import monocle.law.discipline._
 import cats.instances.option._
 
@@ -52,6 +52,6 @@ object MapKVTraversalTests extends Laws {
 }
 
 class MapTraversalSpec extends MonocleSuite {
-  checkAll("map list Iso", MapListIsoTests(mapListIso[String, Int]))
+  checkAll("map list Iso", MapListIsoTests(allKeyValues[String, Int]))
   checkAll("map KV traversal", MapKVTraversalTests(mapKVTraversal[String, Int]))
 }

--- a/unsafe/src/main/scala/monocle/unsafe/MapTraversal.scala
+++ b/unsafe/src/main/scala/monocle/unsafe/MapTraversal.scala
@@ -6,7 +6,7 @@ import cats.instances.list._
 import cats.syntax.applicative._
 import cats.syntax.functor._
 import cats.syntax.traverse._
-import monocle.Traversal
+import monocle.{Iso, Traversal}
 import monocle.function.Each.fromTraverse
 import monocle.function.{Each, FilterIndex}
 
@@ -14,6 +14,18 @@ import scala.collection.immutable.Map
 
 object MapTraversal {
   implicit def mapEach[K, V]: Each[Map[K, V], V] = fromTraverse[Map[K, ?], V]
+
+  implicit def mapTraversal[K, V]: Traversal[Map[K, V], (K, V)] =
+    new Traversal[Map[K, V], (K, V)] {
+      def modifyF[F[_]: Applicative](f: ((K, V)) => F[(K, V)])(s: Map[K, V]): F[Map[K, V]] =
+        s.toList.traverse { case (k, v) => f(k, v) }.map(kvs => Map(kvs: _*))
+    }
+
+  implicit def mapListIso[K, V]: Iso[Map[K, V], List[(K, V)]] =
+    Iso[Map[K, V], List[(K, V)]](_.toList)(Map.from)
+
+  implicit def mapKVTraversal[K, V]: Traversal[Map[K, V], (K, V)] =
+    mapListIso.composeTraversal(Traversal.fromTraverse[List, (K, V)])
 
   implicit def mapMapFilterIndex[K, V]: FilterIndex[Map[K, V], K, V] =
     new FilterIndex[Map[K, V], K, V] {

--- a/unsafe/src/main/scala/monocle/unsafe/MapTraversal.scala
+++ b/unsafe/src/main/scala/monocle/unsafe/MapTraversal.scala
@@ -15,17 +15,11 @@ import scala.collection.immutable.Map
 object MapTraversal {
   implicit def mapEach[K, V]: Each[Map[K, V], V] = fromTraverse[Map[K, ?], V]
 
-  implicit def mapTraversal[K, V]: Traversal[Map[K, V], (K, V)] =
-    new Traversal[Map[K, V], (K, V)] {
-      def modifyF[F[_]: Applicative](f: ((K, V)) => F[(K, V)])(s: Map[K, V]): F[Map[K, V]] =
-        s.toList.traverse { case (k, v) => f(k, v) }.map(kvs => Map(kvs: _*))
-    }
+  def allKeyValues[K, V]: Iso[Map[K, V], List[(K, V)]] =
+    Iso[Map[K, V], List[(K, V)]](_.toList)(_.toMap)
 
-  implicit def mapListIso[K, V]: Iso[Map[K, V], List[(K, V)]] =
-    Iso[Map[K, V], List[(K, V)]](_.toList)(Map.from)
-
-  implicit def mapKVTraversal[K, V]: Traversal[Map[K, V], (K, V)] =
-    mapListIso.composeTraversal(Traversal.fromTraverse[List, (K, V)])
+  def mapKVTraversal[K, V]: Traversal[Map[K, V], (K, V)] =
+    allKeyValues.composeTraversal(Traversal.fromTraverse[List, (K, V)])
 
   implicit def mapMapFilterIndex[K, V]: FilterIndex[Map[K, V], K, V] =
     new FilterIndex[Map[K, V], K, V] {


### PR DESCRIPTION
I have a use case in which I need to rename the key of a json object, i.e. rename "_key" to "key".
I am pretty sure that I will not create any key collision. In my use case, creating unsafe instances of `Iso[Map[K,V], List([K, V])]` and `Traversal[Map[K, V], (K, V)]` is useful.