### PR TITLE
Add Iso involuton

### DIFF
--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -336,6 +336,13 @@ object Iso {
   /** alias for [[PIso]] id when S = T and A = B */
   def id[S]: Iso[S, S] =
     PIso.id[S, S]
+
+  /**
+    * create a [[PIso]] where S = T and A = B from
+    * a function that is its own inverse
+    */
+  def involuted[A](update: A => A): Iso[A, A] =
+    Iso(update)(update)
 }
 
 sealed abstract class IsoInstances {

--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -337,10 +337,7 @@ object Iso {
   def id[S]: Iso[S, S] =
     PIso.id[S, S]
 
-  /**
-    * create a [[PIso]] where S = T and A = B from
-    * a function that is its own inverse
-    */
+  /** create an [[Iso]] from a function that is its own inverse */
   def involuted[A](update: A => A): Iso[A, A] =
     Iso(update)(update)
 }

--- a/test/shared/src/test/scala/monocle/IsoSpec.scala
+++ b/test/shared/src/test/scala/monocle/IsoSpec.scala
@@ -39,6 +39,9 @@ class IsoSpec extends MonocleSuite {
   implicit def emptyCaseTypeEq[A]                               = Eq.fromUniversalEquals[EmptyCaseType[A]]
 
   val iso = Iso[IntWrapper, Int](_.i)(IntWrapper.apply)
+  val involutedListReverse =
+    Iso.involuted[List[Int]](_.reverse) // ∀ {T} -> List(ts: T*).reverse.reverse == List(ts: T*)
+  val involutedTwoMinusN = Iso.involuted[Int](2 - _) //  ∀ {n : Int} -> n == 2 - (2 - n)
 
   checkAll("apply Iso", IsoTests(iso))
   checkAll("GenIso", IsoTests(GenIso[IntWrapper, Int]))
@@ -48,6 +51,9 @@ class IsoSpec extends MonocleSuite {
   checkAll("GenIso.unit empty case class with type param", IsoTests(GenIso.unit[EmptyCaseType[Int]]))
 
   checkAll("Iso id", IsoTests(Iso.id[Int]))
+
+  checkAll("Iso involutedListReverse", IsoTests(involutedListReverse))
+  checkAll("Iso involutedTwoMinusN", IsoTests(involutedTwoMinusN))
 
   checkAll("Iso.asLens", LensTests(iso.asLens))
   checkAll("Iso.asPrism", PrismTests(iso.asPrism))
@@ -120,6 +126,20 @@ class IsoSpec extends MonocleSuite {
 
   test("modify") {
     iso.modify(_ + 1)(IntWrapper(0)) shouldEqual IntWrapper(1)
+  }
+
+  test("involuted") {
+    involutedListReverse.get(List(1, 2, 3)) shouldEqual List(3, 2, 1)
+    involutedListReverse.reverseGet(List(1, 2, 3)) shouldEqual List(3, 2, 1)
+
+    involutedListReverse.reverse.get(List(1, 2, 3)) shouldEqual involutedListReverse.get(List(1, 2, 3))
+    involutedListReverse.reverse.reverseGet(List(1, 2, 3)) shouldEqual involutedListReverse.reverseGet(List(1, 2, 3))
+
+    involutedTwoMinusN.get(5) shouldEqual -3
+    involutedTwoMinusN.reverseGet(5) shouldEqual -3
+
+    involutedTwoMinusN.reverse.get(5) shouldEqual involutedTwoMinusN.get(5)
+    involutedTwoMinusN.reverse.reverseGet(5) shouldEqual involutedTwoMinusN.reverseGet(5)
   }
 
   test("GenIso nullary equality") {


### PR DESCRIPTION
I took a quick stab at #868

I wasn't entirely sure whether `involuted` (I decided to pick that as opposed to `involution` to be consistent with [haskell](https://hackage.haskell.org/package/lens-4.19.2/docs/src/Control.Lens.Iso.html#involuted)) should live on the `Iso` object or somewhere else, happy to change it if we think it's better placed elsewhere.