### PR TITLE
Upgrade discipline and scala

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Publish
         run: |
           csbt ci-release
-          SCALAJS_VERSION=0.6.32 csbt clean ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -39,4 +39,3 @@ jobs:
       - name: Run tests and documentation
         run: |
           csbt +test packageSrc doc mdoc
-          SCALAJS_VERSION=0.6.32 csbt clean +monocleJS/test

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,6 @@ import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 import sbt.Keys._
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
-val scalaJSVersion06 = Option(System.getenv("SCALAJS_VERSION")).exists(_.startsWith("0.6"))
-
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 inThisBuild(List(
@@ -55,8 +53,8 @@ def scalaVersionSpecificFolders(srcName: String, srcBaseDir: java.io.File, scala
 }
 
 lazy val buildSettings = Seq(
-  scalaVersion       := "2.13.1",
-  crossScalaVersions := Seq("2.12.11", "2.13.1"),
+  scalaVersion       := "2.13.3",
+  crossScalaVersions := Seq("2.12.12", "2.13.3"),
   resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
   scalacOptions     ++= Seq(
     "-encoding", "UTF-8",
@@ -92,8 +90,8 @@ lazy val shapeless         = Def.setting("com.chuusai"       %%% "shapeless"    
 lazy val refinedDep        = Def.setting("eu.timepit"        %%% "refined"                  % "0.9.15")
 lazy val refinedScalacheck = Def.setting("eu.timepit"        %%% "refined-scalacheck"       % "0.9.15" % "test")
 
-lazy val discipline           = Def.setting("org.typelevel"  %%% "discipline-core"          % "1.0.2")
-lazy val discipline_scalatest = Def.setting("org.typelevel"  %%% "discipline-scalatest"     % "1.0.1")
+lazy val discipline           = Def.setting("org.typelevel"  %%% "discipline-core"          % "1.0.3")
+lazy val discipline_scalatest = Def.setting("org.typelevel"  %%% "discipline-scalatest"     % "2.0.0")
 
 lazy val macroVersion = "2.1.1"
 
@@ -128,7 +126,7 @@ lazy val scalajsSettings = Seq(
 )
 
 lazy val monocleSettings    = buildSettings
-lazy val monocleJvmSettings = monocleSettings ++ Seq(skip.in(publish) := scalaJSVersion06)
+lazy val monocleJvmSettings = monocleSettings
 lazy val monocleJsSettings  = monocleSettings ++ scalajsSettings
 
 lazy val monocle = project.in(file("."))

--- a/core/shared/src/main/scala/monocle/function/Index.scala
+++ b/core/shared/src/main/scala/monocle/function/Index.scala
@@ -85,7 +85,7 @@ object Index extends IndexFunctions with IndexInstancesScalaVersionSpecific {
             None
           else {
             val it = c.iterator.drop(i)
-            if (it.hasNext) Some(it.next)
+            if (it.hasNext) Some(it.next())
             else None
           }
         }(a =>


### PR DESCRIPTION
This PR updates scala and the versions of discipline used in the project
discipline is no longer published for scala.js 0.6.x so we need to follow suit