### PR TITLE
Lift arbitrary functions to Getters

### DIFF
--- a/core/shared/src/main/scala/monocle/Fold.scala
+++ b/core/shared/src/main/scala/monocle/Fold.scala
@@ -95,6 +95,9 @@ abstract class Fold[S, A] extends Serializable { self =>
         self.foldMap(other.foldMap(f)(_))(s)
     }
 
+  /** Compose with a function lifted into a Getter */
+  @inline def to[C](f: A => C): Fold[S, C] = composeGetter(Getter(f))
+
   /** compose a [[Fold]] with a [[Getter]] */
   @inline final def composeGetter[C](other: Getter[A, C]): Fold[S, C] =
     composeFold(other.asFold)

--- a/core/shared/src/main/scala/monocle/Getter.scala
+++ b/core/shared/src/main/scala/monocle/Getter.scala
@@ -56,6 +56,9 @@ abstract class Getter[S, A] extends Serializable { self =>
   @inline final def composeFold[B](other: Fold[A, B]): Fold[S, B] =
     asFold composeFold other
 
+  /** Compose with a function lifted into a Getter */
+  @inline def to[C](f: A => C): Getter[S, C] = composeGetter(Getter(f))
+
   /** compose a [[Getter]] with a [[Getter]] */
   @inline final def composeGetter[B](other: Getter[A, B]): Getter[S, B] =
     (s: S) => other.get(self.get(s))

--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -111,6 +111,9 @@ abstract class PIso[S, T, A, B] extends Serializable { self =>
   @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
     asFold composeFold other
 
+  /** Compose with a function lifted into a Getter */
+  @inline def to[C](f: A => C): Getter[S, C] = composeGetter(Getter(f))
+
   /** compose a [[PIso]] with a [[Getter]] */
   @inline final def composeGetter[C](other: Getter[A, C]): Getter[S, C] =
     asGetter composeGetter other

--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -93,6 +93,9 @@ abstract class PLens[S, T, A, B] extends Serializable { self =>
   @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
     asFold composeFold other
 
+  /** Compose with a function lifted into a Getter */
+  @inline def to[C](f: A => C): Getter[S, C] = composeGetter(Getter(f))
+
   /** compose a [[PLens]] with a [[Getter]] */
   @inline final def composeGetter[C](other: Getter[A, C]): Getter[S, C] =
     asGetter composeGetter other

--- a/core/shared/src/main/scala/monocle/Optional.scala
+++ b/core/shared/src/main/scala/monocle/Optional.scala
@@ -108,6 +108,9 @@ abstract class POptional[S, T, A, B] extends Serializable { self =>
   @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
     asFold composeFold other
 
+  /** Compose with a function lifted into a Getter */
+  @inline def to[C](f: A => C): Fold[S, C] = composeGetter(Getter(f))
+
   /** compose a [[POptional]] with a [[Getter]] */
   @inline final def composeGetter[C](other: Getter[A, C]): Fold[S, C] =
     asFold composeGetter other

--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -127,6 +127,9 @@ abstract class PPrism[S, T, A, B] extends Serializable { self =>
   @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
     asFold composeFold other
 
+  /** Compose with a function lifted into a Getter */
+  @inline def to[C](f: A => C): Fold[S, C] = composeGetter(Getter(f))
+
   /** compose a [[PPrism]] with a [[Getter]] */
   @inline final def composeGetter[C](other: Getter[A, C]): Fold[S, C] =
     asFold composeGetter other

--- a/core/shared/src/main/scala/monocle/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/Traversal.scala
@@ -111,6 +111,9 @@ abstract class PTraversal[S, T, A, B] extends Serializable { self =>
   @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
     asFold composeFold other
 
+  /** Compose with a function lifted into a Getter */
+  @inline def to[C](f: A => C): Fold[S, C] = composeGetter(Getter(f))
+
   /** compose a [[PTraversal]] with a [[Getter]] */
   @inline final def composeGetter[C](other: Getter[A, C]): Fold[S, C] =
     asFold composeGetter other

--- a/test/shared/src/test/scala/monocle/FoldSpec.scala
+++ b/test/shared/src/test/scala/monocle/FoldSpec.scala
@@ -84,4 +84,8 @@ class FoldSpec extends MonocleSuite {
     val select = Fold.select[List[Int]](_.endsWith(List(2, 3)))
     select.getAll(List(1, 2, 3, 4)) shouldEqual List()
   }
+
+  test("to") {
+    eachLi.to(_.toString()).getAll(List(1, 2, 3)) shouldEqual List("1", "2", "3")
+  }
 }

--- a/test/shared/src/test/scala/monocle/GetterSpec.scala
+++ b/test/shared/src/test/scala/monocle/GetterSpec.scala
@@ -57,4 +57,8 @@ class GetterSpec extends MonocleSuite {
     val upper  = Getter[String, String](_.toUpperCase)
     length.zip(upper).get("helloworld") shouldEqual ((10, "HELLOWORLD"))
   }
+
+  test("to") {
+    i.to(_.toString()).get(Bar(5)) shouldEqual "5"
+  }
 }

--- a/test/shared/src/test/scala/monocle/IsoSpec.scala
+++ b/test/shared/src/test/scala/monocle/IsoSpec.scala
@@ -157,4 +157,8 @@ class IsoSpec extends MonocleSuite {
   test("GenIso quintary equality") {
     GenIso.fields[Quintary] shouldEqual _quintary
   }
+
+  test("to") {
+    iso.to(_.toString()).get(IntWrapper(5)) shouldEqual "5"
+  }
 }

--- a/test/shared/src/test/scala/monocle/LensSpec.scala
+++ b/test/shared/src/test/scala/monocle/LensSpec.scala
@@ -90,4 +90,8 @@ class LensSpec extends MonocleSuite {
   test("modify") {
     x.modify(_ + 1)(Point(9, 2)) shouldEqual Point(10, 2)
   }
+
+  test("to") {
+    x.to(_.toString()).get(Point(1, 2)) shouldEqual "1"
+  }
 }

--- a/test/shared/src/test/scala/monocle/OptionalSpec.scala
+++ b/test/shared/src/test/scala/monocle/OptionalSpec.scala
@@ -96,4 +96,8 @@ class OptionalSpec extends MonocleSuite {
     headOptionI.modifyOption(_ + 1)(List(1, 2, 3, 4)) shouldEqual Some(List(2, 2, 3, 4))
     headOptionI.modifyOption(_ + 1)(Nil) shouldEqual None
   }
+
+  test("to") {
+    headOptionI.to(_.toString()).getAll(List(1, 2, 3)) shouldEqual List("1")
+  }
 }

--- a/test/shared/src/test/scala/monocle/PrismSpec.scala
+++ b/test/shared/src/test/scala/monocle/PrismSpec.scala
@@ -170,4 +170,8 @@ class PrismSpec extends MonocleSuite {
   test("GenPrism quintary equality") {
     GenPrism[Arities, Quintary] composeIso GenIso.fields[Quintary] shouldEqual _quintary
   }
+
+  test("to") {
+    i.to(_.toString()).getAll(I(1)) shouldEqual List("1")
+  }
 }

--- a/test/shared/src/test/scala/monocle/TraversalSpec.scala
+++ b/test/shared/src/test/scala/monocle/TraversalSpec.scala
@@ -146,4 +146,8 @@ class TraversalSpec extends MonocleSuite {
     // `Left` values should be accumulated through `Validated`.
     eachLi.parModifyF[Either[String, *]](_.toString.asLeft[Int])(List(1, 2, 3, 4)) shouldEqual Left("1234")
   }
+
+  test("to") {
+    eachLi.to(_.toString()).getAll(List(1, 2, 3)) shouldEqual List("1", "2", "3")
+  }
 }


### PR DESCRIPTION
Inspired by Haskell lens' `to :: (Profunctor p, Contravariant f) => (s -> a) -> Optic' p f s a ` which builds a `Getter` from an arbitrary function.