### PR TITLE
Replace atOrElse by withDefault syntax on optics

### DIFF
--- a/core/shared/src/main/scala/monocle/Fold.scala
+++ b/core/shared/src/main/scala/monocle/Fold.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Foldable, Monoid}
+import cats.{Eq, Foldable, Monoid}
 import cats.arrow.Choice
 import cats.instances.int._
 import cats.instances.list._
@@ -91,6 +91,9 @@ abstract class Fold[S, A] extends Serializable { self =>
 
   def some[A1](implicit ev1: A =:= Option[A1]): Fold[S, A1] =
     adapt[Option[A1]] composePrism (std.option.pSome)
+
+  def withDefault[A1: Eq](defaultValue: A1)(implicit ev1: A =:= Option[A1]): Fold[S, A1] =
+    adapt[Option[A1]] composeIso (std.option.withDefault(defaultValue))
 
   private def adapt[A1](implicit evA: A =:= A1): Fold[S, A1] =
     evA.substituteCo[Fold[S, *]](this)

--- a/core/shared/src/main/scala/monocle/Getter.scala
+++ b/core/shared/src/main/scala/monocle/Getter.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Monoid, Semigroupal}
+import cats.{Eq, Monoid, Semigroupal}
 import cats.arrow.{Arrow, Choice}
 import cats.implicits._
 import monocle.function.Each
@@ -55,6 +55,9 @@ abstract class Getter[S, A] extends Serializable { self =>
 
   def some[A1](implicit ev1: A =:= Option[A1]): Fold[S, A1] =
     adapt[Option[A1]] composePrism (std.option.pSome)
+
+  def withDefault[A1: Eq](defaultValue: A1)(implicit ev1: A =:= Option[A1]): Getter[S, A1] =
+    adapt[Option[A1]] composeIso (std.option.withDefault(defaultValue))
 
   private def adapt[A1](implicit evA: A =:= A1): Getter[S, A1] =
     evA.substituteCo[Getter[S, *]](this)

--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -374,8 +374,8 @@ sealed abstract class IsoInstances {
 }
 
 /**
- * Extension methods for monomorphic Iso
- */
+  * Extension methods for monomorphic Iso
+  */
 final case class IsoSyntax[S, A](private val self: Iso[S, A]) extends AnyVal {
   def each[C](implicit evEach: Each[A, C]): Traversal[S, C] =
     self composeTraversal evEach.each

--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Applicative, Functor, Monoid}
+import cats.{Applicative, Eq, Functor, Monoid}
 import cats.arrow.Category
 import cats.evidence.{<~<, Is}
 import cats.syntax.either._
@@ -110,6 +110,9 @@ abstract class PIso[S, T, A, B] extends Serializable { self =>
 
   def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): PPrism[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]] composePrism (std.option.pSome)
+
+  def withDefault[A1: Eq](defaultValue: A1)(implicit evTS: T =:= S, evBA: B =:= A, evOpt: A =:= Option[A1]): Iso[S, A1] =
+    mono.adapt[Option[A1], Option[A1]] composeIso (std.option.withDefault(defaultValue))
 
   def mono(implicit evTS: T =:= S, evBA: B =:= A): Iso[S, A] =
     evTS.substituteCo[PIso[S, *, A, A]](evBA.substituteCo[PIso[S, T, A, *]](this))

--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -111,7 +111,9 @@ abstract class PIso[S, T, A, B] extends Serializable { self =>
   def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): PPrism[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]] composePrism (std.option.pSome)
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evTS: T =:= S, evBA: B =:= A, evOpt: A =:= Option[A1]): Iso[S, A1] =
+  def withDefault[A1: Eq](
+    defaultValue: A1
+  )(implicit evTS: T =:= S, evBA: B =:= A, evOpt: A =:= Option[A1]): Iso[S, A1] =
     mono.adapt[Option[A1], Option[A1]] composeIso (std.option.withDefault(defaultValue))
 
   def mono(implicit evTS: T =:= S, evBA: B =:= A): Iso[S, A] =

--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -87,21 +87,10 @@ abstract class PLens[S, T, A, B] extends Serializable { self =>
       }
     }
 
-  def each[C](implicit evTS: T =:= S, evBA: B =:= A, evEach: Each[A, C]): Traversal[S, C] =
-    mono composeTraversal evEach.each
-
   def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): POptional[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]] composePrism (std.option.pSome)
 
-  def withDefault[A1: Eq](
-    defaultValue: A1
-  )(implicit evTS: T =:= S, evBA: B =:= A, evOpt: A =:= Option[A1]): Lens[S, A1] =
-    mono.adapt[Option[A1], Option[A1]] composeIso (std.option.withDefault(defaultValue))
-
-  def mono(implicit evTS: T =:= S, evBA: B =:= A): Lens[S, A] =
-    evTS.substituteCo[PLens[S, *, A, A]](evBA.substituteCo[PLens[S, T, A, *]](this))
-
-  private def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PLens[S, T, A1, B1] =
+  private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PLens[S, T, A1, B1] =
     evB.substituteCo[PLens[S, T, A1, *]](evA.substituteCo[PLens[S, T, *, B]](this))
 
   /** ********************************************************
@@ -261,6 +250,9 @@ object PLens extends LensInstances {
       def modify(f: A => B): S => T =
         s => _set(f(_get(s)))(s)
     }
+
+  implicit def lensSyntax[S, A](self: Lens[S, A]): LensSyntax[S, A] =
+    new LensSyntax(self)
 }
 
 object Lens {
@@ -286,4 +278,15 @@ sealed abstract class LensInstances {
     def compose[A, B, C](f: Lens[B, C], g: Lens[A, B]): Lens[A, C] =
       g composeLens f
   }
+}
+
+/**
+ * Extension methods for monomorphic Lens
+ */
+final case class LensSyntax[S, A](private val self: Lens[S, A]) extends AnyVal {
+  def each[C](implicit evEach: Each[A, C]): Traversal[S, C] =
+    self composeTraversal evEach.each
+
+  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Lens[S, A1] =
+    self.adapt[Option[A1], Option[A1]] composeIso (std.option.withDefault(defaultValue))
 }

--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Applicative, Functor, Monoid}
+import cats.{Applicative, Eq, Functor, Monoid}
 import cats.arrow.Choice
 import cats.syntax.either._
 import monocle.function.Each
@@ -92,6 +92,9 @@ abstract class PLens[S, T, A, B] extends Serializable { self =>
 
   def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): POptional[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]] composePrism (std.option.pSome)
+
+  def withDefault[A1: Eq](defaultValue: A1)(implicit evTS: T =:= S, evBA: B =:= A, evOpt: A =:= Option[A1]): Lens[S, A1] =
+    mono.adapt[Option[A1], Option[A1]] composeIso (std.option.withDefault(defaultValue))
 
   def mono(implicit evTS: T =:= S, evBA: B =:= A): Lens[S, A] =
     evTS.substituteCo[PLens[S, *, A, A]](evBA.substituteCo[PLens[S, T, A, *]](this))

--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -281,8 +281,8 @@ sealed abstract class LensInstances {
 }
 
 /**
- * Extension methods for monomorphic Lens
- */
+  * Extension methods for monomorphic Lens
+  */
 final case class LensSyntax[S, A](private val self: Lens[S, A]) extends AnyVal {
   def each[C](implicit evEach: Each[A, C]): Traversal[S, C] =
     self composeTraversal evEach.each

--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -93,7 +93,9 @@ abstract class PLens[S, T, A, B] extends Serializable { self =>
   def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): POptional[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]] composePrism (std.option.pSome)
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evTS: T =:= S, evBA: B =:= A, evOpt: A =:= Option[A1]): Lens[S, A1] =
+  def withDefault[A1: Eq](
+    defaultValue: A1
+  )(implicit evTS: T =:= S, evBA: B =:= A, evOpt: A =:= Option[A1]): Lens[S, A1] =
     mono.adapt[Option[A1], Option[A1]] composeIso (std.option.withDefault(defaultValue))
 
   def mono(implicit evTS: T =:= S, evBA: B =:= A): Lens[S, A] =

--- a/core/shared/src/main/scala/monocle/Optional.scala
+++ b/core/shared/src/main/scala/monocle/Optional.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Applicative, Monoid}
+import cats.{Applicative, Eq, Monoid}
 import cats.arrow.Choice
 import cats.syntax.either._
 import monocle.function.Each
@@ -102,16 +102,10 @@ abstract class POptional[S, T, A, B] extends Serializable { self =>
       }
     }
 
-  def each[C](implicit evTS: T =:= S, evBA: B =:= A, evEach: Each[A, C]): Traversal[S, C] =
-    mono composeTraversal evEach.each
-
   def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): POptional[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]] composePrism (std.option.pSome)
 
-  def mono(implicit evTS: T =:= S, evBA: B =:= A): Optional[S, A] =
-    evTS.substituteCo[POptional[S, *, A, A]](evBA.substituteCo[POptional[S, T, A, *]](this))
-
-  private def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): POptional[S, T, A1, B1] =
+  private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): POptional[S, T, A1, B1] =
     evB.substituteCo[POptional[S, T, A1, *]](evA.substituteCo[POptional[S, T, *, B]](this))
 
   /** ************************************************************
@@ -256,6 +250,9 @@ object POptional extends OptionalInstances {
       def modify(f: A => B): S => T =
         s => _getOrModify(s).fold(identity, a => _set(f(a))(s))
     }
+
+  implicit def optionalSyntax[S, A](self: Optional[S, A]): OptionalSyntax[S, A] =
+    new OptionalSyntax(self)
 }
 
 object Optional {
@@ -300,4 +297,15 @@ sealed abstract class OptionalInstances {
     def compose[A, B, C](f: Optional[B, C], g: Optional[A, B]): Optional[A, C] =
       g composeOptional f
   }
+}
+
+/**
+ * Extension methods for monomorphic Optional
+ */
+final case class OptionalSyntax[S, A](private val self: Optional[S, A]) extends AnyVal {
+  def each[C](implicit evEach: Each[A, C]): Traversal[S, C] =
+    self composeTraversal evEach.each
+
+  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Optional[S, A1] =
+    self.adapt[Option[A1], Option[A1]] composeIso (std.option.withDefault(defaultValue))
 }

--- a/core/shared/src/main/scala/monocle/Optional.scala
+++ b/core/shared/src/main/scala/monocle/Optional.scala
@@ -300,8 +300,8 @@ sealed abstract class OptionalInstances {
 }
 
 /**
- * Extension methods for monomorphic Optional
- */
+  * Extension methods for monomorphic Optional
+  */
 final case class OptionalSyntax[S, A](private val self: Optional[S, A]) extends AnyVal {
   def each[C](implicit evEach: Each[A, C]): Traversal[S, C] =
     self composeTraversal evEach.each

--- a/core/shared/src/main/scala/monocle/Setter.scala
+++ b/core/shared/src/main/scala/monocle/Setter.scala
@@ -169,8 +169,8 @@ sealed abstract class SetterInstances {
 }
 
 /**
- * Extension methods for monomorphic Setter
- */
+  * Extension methods for monomorphic Setter
+  */
 final case class SetterSyntax[S, A](private val self: Setter[S, A]) extends AnyVal {
   def each[C](implicit evEach: Each[A, C]): Setter[S, C] =
     self composeTraversal evEach.each

--- a/core/shared/src/main/scala/monocle/Setter.scala
+++ b/core/shared/src/main/scala/monocle/Setter.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Contravariant, Functor}
+import cats.{Contravariant, Eq, Functor}
 import cats.arrow.Choice
 import cats.arrow.Profunctor
 import cats.syntax.either._
@@ -39,16 +39,10 @@ abstract class PSetter[S, T, A, B] extends Serializable { self =>
   @inline final def choice[S1, T1](other: PSetter[S1, T1, A, B]): PSetter[Either[S, S1], Either[T, T1], A, B] =
     PSetter[Either[S, S1], Either[T, T1], A, B](b => _.bimap(self.modify(b), other.modify(b)))
 
-  def each[C](implicit evTS: T =:= S, evBA: B =:= A, evEach: Each[A, C]): Setter[S, C] =
-    mono composeTraversal evEach.each
-
   def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): PSetter[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]] composePrism (std.option.pSome)
 
-  def mono(implicit evTS: T =:= S, evBA: B =:= A): Setter[S, A] =
-    evTS.substituteCo[PSetter[S, *, A, A]](evBA.substituteCo[PSetter[S, T, A, *]](this))
-
-  private def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PSetter[S, T, A1, B1] =
+  private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PSetter[S, T, A1, B1] =
     evB.substituteCo[PSetter[S, T, A1, *]](evA.substituteCo[PSetter[S, T, *, B]](this))
 
   /** **********************************************************
@@ -140,6 +134,9 @@ object PSetter extends SetterInstances {
   /** create a [[PSetter]] from a Profunctor */
   def fromProfunctor[P[_, _], A, B, C](implicit P: Profunctor[P]): PSetter[P[B, C], P[A, C], A, B] =
     PSetter[P[B, C], P[A, C], A, B](f => P.lmap(_)(f))
+
+  implicit def setterSyntax[S, A](self: Setter[S, A]): SetterSyntax[S, A] =
+    new SetterSyntax(self)
 }
 
 object Setter {
@@ -169,4 +166,15 @@ sealed abstract class SetterInstances {
     def choice[A, B, C](f1: Setter[A, C], f2: Setter[B, C]): Setter[Either[A, B], C] =
       f1 choice f2
   }
+}
+
+/**
+ * Extension methods for monomorphic Setter
+ */
+final case class SetterSyntax[S, A](private val self: Setter[S, A]) extends AnyVal {
+  def each[C](implicit evEach: Each[A, C]): Setter[S, C] =
+    self composeTraversal evEach.each
+
+  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Setter[S, A1] =
+    self.adapt[Option[A1], Option[A1]] composeIso (std.option.withDefault(defaultValue))
 }

--- a/core/shared/src/main/scala/monocle/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/Traversal.scala
@@ -317,8 +317,8 @@ sealed abstract class TraversalInstances {
 }
 
 /**
- * Extension methods for monomorphic Optional
- */
+  * Extension methods for monomorphic Traversal
+  */
 final case class TraversalSyntax[S, A](private val self: Traversal[S, A]) extends AnyVal {
   def each[C](implicit evEach: Each[A, C]): Traversal[S, C] =
     self composeTraversal evEach.each

--- a/core/shared/src/main/scala/monocle/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/Traversal.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Applicative, Functor, Id, Monoid, Parallel, Traverse}
+import cats.{Applicative, Eq, Functor, Id, Monoid, Parallel, Traverse}
 import cats.arrow.Choice
 import cats.data.Const
 import cats.instances.int._
@@ -105,16 +105,10 @@ abstract class PTraversal[S, T, A, B] extends Serializable { self =>
       modifyF(a => F.parallel(f(a)))(s)(F.applicative)
     )
 
-  def each[C](implicit evTS: T =:= S, evBA: B =:= A, evEach: Each[A, C]): Traversal[S, C] =
-    mono composeTraversal evEach.each
-
   def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): PTraversal[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]] composePrism (std.option.pSome)
 
-  def mono(implicit evTS: T =:= S, evBA: B =:= A): Traversal[S, A] =
-    evTS.substituteCo[PTraversal[S, *, A, A]](evBA.substituteCo[PTraversal[S, T, A, *]](this))
-
-  private def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PTraversal[S, T, A1, B1] =
+  private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PTraversal[S, T, A1, B1] =
     evB.substituteCo[PTraversal[S, T, A1, *]](evA.substituteCo[PTraversal[S, T, *, B]](this))
 
   /** *************************************************************
@@ -257,6 +251,9 @@ object PTraversal extends TraversalInstances {
           _set(_, _, _, _, _, _, s)
         )
     }
+
+  implicit def traversalSyntax[S, A](self: Traversal[S, A]): TraversalSyntax[S, A] =
+    new TraversalSyntax(self)
 }
 
 object Traversal {
@@ -317,4 +314,15 @@ sealed abstract class TraversalInstances {
     def choice[A, B, C](f1: Traversal[A, C], f2: Traversal[B, C]): Traversal[Either[A, B], C] =
       f1 choice f2
   }
+}
+
+/**
+ * Extension methods for monomorphic Optional
+ */
+final case class TraversalSyntax[S, A](private val self: Traversal[S, A]) extends AnyVal {
+  def each[C](implicit evEach: Each[A, C]): Traversal[S, C] =
+    self composeTraversal evEach.each
+
+  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Traversal[S, A1] =
+    self.adapt[Option[A1], Option[A1]] composeIso (std.option.withDefault(defaultValue))
 }

--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -1,8 +1,6 @@
 package monocle.function
 
-import cats.Eq
 import monocle.{Iso, Lens}
-import monocle.std.option.withDefault
 
 import scala.annotation.implicitNotFound
 import scala.collection.immutable.{ListMap, SortedMap}
@@ -22,36 +20,6 @@ abstract class At[S, I, A] extends Serializable {
 
 trait AtFunctions {
   def at[S, I, A](i: I)(implicit ev: At[S, I, A]): Lens[S, A] = ev.at(i)
-
-  /**
-    * Creates a Lens that zooms into an index `i` inside `S`.
-    * If `S` doesn't have any data at this index, `atOrElse` insert `defaultValue`.
-    * {{{
-    * val counters = Map("id1" -> 4, "id2" -> 2)
-    * def mapDefaultTo0(index: String): Lens[Map[String, Int], Int] =
-    *   atOrElse(index)(0)
-    *
-    * mapDefaultTo0("id1").get(counters) == 4
-    * mapDefaultTo0("id3").get(counters) == 0
-    *
-    * mapDefaultTo0("id1").modify(_ + 1)(counters) == Map("id1" -> 5, "id2" -> 2)
-    * mapDefaultTo0("id3").modify(_ + 1)(counters) == Map("id1" -> 4, "id2" -> 2, "id3" -> 1)
-    * }}}
-    *
-    * `atOrElse`` is a valid Lens only if `defaultValue` is not part of `S`.
-    * For example, `Map("id" -> 0)` breaks the get-set property of Lens:
-    * {{{
-    * val counters = Map("id" -> 0)
-    * val fromGet  = mapDefaultTo0("id").get(counters)          // 0
-    * val afterSet = mapDefaultTo0("id").set(fromGet)(counters) // Map()
-    *
-    * counters != afterSet
-    * }}}
-    *
-    * @see monocle.std.option.withDefault
-    */
-  def atOrElse[S, I, A: Eq](i: I)(defaultValue: A)(implicit ev: At[S, I, Option[A]]): Lens[S, A] =
-    ev.at(i) composeIso withDefault(defaultValue)
 
   /** delete a value associated with a key in a Map-like container */
   def remove[S, I, A](i: I)(s: S)(implicit ev: At[S, I, Option[A]]): S =

--- a/core/shared/src/main/scala/monocle/syntax/Apply.scala
+++ b/core/shared/src/main/scala/monocle/syntax/Apply.scala
@@ -1,7 +1,7 @@
 package monocle.syntax
 
 import monocle._
-import cats.{Applicative, Functor, Monoid}
+import cats.{Applicative, Eq, Functor, Monoid}
 import monocle.function.Each
 
 object apply extends ApplySyntax
@@ -104,6 +104,9 @@ case class ApplyFold[S, A](s: S, _fold: Fold[S, A]) {
   def some[A1](implicit ev1: A =:= Option[A1]): ApplyFold[S, A1] =
     adapt[Option[A1]] composePrism (std.option.pSome)
 
+  def withDefault[A1: Eq](defaultValue: A1)(implicit ev1: A =:= Option[A1]): ApplyFold[S, A1] =
+    adapt[Option[A1]] composeIso (std.option.withDefault(defaultValue))
+
   private def adapt[A1](implicit evA: A =:= A1): ApplyFold[S, A1] =
     evA.substituteCo[ApplyFold[S, *]](this)
 
@@ -153,6 +156,9 @@ final case class ApplyGetter[S, A](s: S, getter: Getter[S, A]) {
 
   def some[A1](implicit ev1: A =:= Option[A1]): ApplyFold[S, A1] =
     adapt[Option[A1]] composePrism (std.option.pSome)
+
+  def withDefault[A1: Eq](defaultValue: A1)(implicit ev1: A =:= Option[A1]): ApplyGetter[S, A1] =
+    adapt[Option[A1]] composeIso (std.option.withDefault(defaultValue))
 
   private def adapt[A1](implicit evA: A =:= A1): ApplyGetter[S, A1] =
     evA.substituteCo[ApplyGetter[S, *]](this)

--- a/example/src/test/scala/monocle/function/AtExample.scala
+++ b/example/src/test/scala/monocle/function/AtExample.scala
@@ -52,12 +52,4 @@ class AtExample extends MonocleSuite {
   test("remove deletes an element of a Map") {
     remove("Foo")(Map("Foo" -> 1, "Bar" -> 2)) shouldEqual Map("Bar" -> 2)
   }
-
-  test("atOrElse") {
-    (Map("One" -> 2, "Two" -> 2) applyLens atOrElse("foo")(0) modify (_ + 1)) shouldEqual Map(
-      "One" -> 2,
-      "Two" -> 2,
-      "foo" -> 1
-    )
-  }
 }

--- a/test/shared/src/test/scala/monocle/FoldSpec.scala
+++ b/test/shared/src/test/scala/monocle/FoldSpec.scala
@@ -2,7 +2,6 @@ package monocle
 
 import cats.Monoid
 import cats.arrow.{Category, Choice, Compose}
-import monocle.macros.GenLens
 
 class FoldSpec extends MonocleSuite {
   val eachLi: Fold[List[Int], Int]             = Fold.fromFoldable[List, Int]
@@ -95,22 +94,26 @@ class FoldSpec extends MonocleSuite {
   }
 
   test("some") {
-    case class SomeTest(x: Int, y: Option[Int])
-    val obj = SomeTest(1, Some(2))
+    val numbers = List(Some(1), None, Some(2), None)
+    val fold = Fold.fromFoldable[List, Option[Int]]
 
-    val fold = GenLens[SomeTest](_.y).asFold
+    fold.some.getAll(numbers) shouldEqual List(1,2)
+    numbers.applyFold(fold).some.getAll shouldEqual List(1,2)
+  }
 
-    fold.some.getAll(obj) shouldEqual List(2)
-    obj.applyFold(fold).some.getAll shouldEqual List(2)
+  test("withDefault") {
+    val numbers = List(Some(1), None, Some(2), None)
+    val fold = Fold.fromFoldable[List, Option[Int]]
+
+    fold.withDefault(0).getAll(numbers) shouldEqual List(1,0,2,0)
+    numbers.applyFold(fold).withDefault(0).getAll shouldEqual List(1,0,2,0)
   }
 
   test("each") {
-    case class SomeTest(x: Int, y: List[Int])
-    val obj = SomeTest(1, List(1, 2, 3))
+    val numbers = List(List(1,2,3), Nil, List(4), Nil)
+    val fold = Fold.fromFoldable[List, List[Int]]
 
-    val fold = GenLens[SomeTest](_.y).asFold
-
-    fold.each.getAll(obj) shouldEqual List(1, 2, 3)
-    obj.applyFold(fold).each.getAll shouldEqual List(1, 2, 3)
+    fold.each.getAll(numbers) shouldEqual List(1, 2, 3,4)
+    numbers.applyFold(fold).each.getAll shouldEqual List(1, 2, 3, 4)
   }
 }

--- a/test/shared/src/test/scala/monocle/FoldSpec.scala
+++ b/test/shared/src/test/scala/monocle/FoldSpec.scala
@@ -95,25 +95,25 @@ class FoldSpec extends MonocleSuite {
 
   test("some") {
     val numbers = List(Some(1), None, Some(2), None)
-    val fold = Fold.fromFoldable[List, Option[Int]]
+    val fold    = Fold.fromFoldable[List, Option[Int]]
 
-    fold.some.getAll(numbers) shouldEqual List(1,2)
-    numbers.applyFold(fold).some.getAll shouldEqual List(1,2)
+    fold.some.getAll(numbers) shouldEqual List(1, 2)
+    numbers.applyFold(fold).some.getAll shouldEqual List(1, 2)
   }
 
   test("withDefault") {
     val numbers = List(Some(1), None, Some(2), None)
-    val fold = Fold.fromFoldable[List, Option[Int]]
+    val fold    = Fold.fromFoldable[List, Option[Int]]
 
-    fold.withDefault(0).getAll(numbers) shouldEqual List(1,0,2,0)
-    numbers.applyFold(fold).withDefault(0).getAll shouldEqual List(1,0,2,0)
+    fold.withDefault(0).getAll(numbers) shouldEqual List(1, 0, 2, 0)
+    numbers.applyFold(fold).withDefault(0).getAll shouldEqual List(1, 0, 2, 0)
   }
 
   test("each") {
-    val numbers = List(List(1,2,3), Nil, List(4), Nil)
-    val fold = Fold.fromFoldable[List, List[Int]]
+    val numbers = List(List(1, 2, 3), Nil, List(4), Nil)
+    val fold    = Fold.fromFoldable[List, List[Int]]
 
-    fold.each.getAll(numbers) shouldEqual List(1, 2, 3,4)
+    fold.each.getAll(numbers) shouldEqual List(1, 2, 3, 4)
     numbers.applyFold(fold).each.getAll shouldEqual List(1, 2, 3, 4)
   }
 }

--- a/test/shared/src/test/scala/monocle/GetterSpec.scala
+++ b/test/shared/src/test/scala/monocle/GetterSpec.scala
@@ -76,6 +76,20 @@ class GetterSpec extends MonocleSuite {
     obj.applyGetter(getter).some.getAll shouldEqual List(2)
   }
 
+  test("withDefault") {
+    case class SomeTest(x: Int, y: Option[Int])
+    val objSome = SomeTest(1, Some(2))
+    val objNone = SomeTest(1, None)
+
+    val getter = Getter((_: SomeTest).y)
+
+    getter.withDefault(0).get(objSome) shouldEqual 2
+    getter.withDefault(0).get(objNone) shouldEqual 0
+
+    objSome.applyGetter(getter).withDefault(0).get shouldEqual 2
+    objNone.applyGetter(getter).withDefault(0).get shouldEqual 0
+  }
+
   test("each") {
     case class SomeTest(x: Int, y: List[Int])
     val obj = SomeTest(1, List(1, 2, 3))

--- a/test/shared/src/test/scala/monocle/IsoSpec.scala
+++ b/test/shared/src/test/scala/monocle/IsoSpec.scala
@@ -177,6 +177,19 @@ class IsoSpec extends MonocleSuite {
     obj.applyIso(iso).some.getOption shouldEqual Some(2)
   }
 
+  test("withDefault") {
+    case class SomeTest(y: Option[Int])
+    val objSome = SomeTest(Some(2))
+    val objNone = SomeTest(None)
+
+    val iso = Iso[SomeTest, Option[Int]](_.y)(SomeTest)
+
+    iso.withDefault(0).get(objSome) shouldEqual 2
+    iso.withDefault(0).get(objNone) shouldEqual 0
+
+    // TODO add applyIso test
+  }
+
   test("each") {
     case class SomeTest(y: List[Int])
     val obj = SomeTest(List(1, 2, 3))

--- a/test/shared/src/test/scala/monocle/LensSpec.scala
+++ b/test/shared/src/test/scala/monocle/LensSpec.scala
@@ -114,6 +114,8 @@ class LensSpec extends MonocleSuite {
 
     lens.withDefault(0).get(objSome) shouldEqual 2
     lens.withDefault(0).get(objNone) shouldEqual 0
+
+    // TODO add applyLens test
   }
 
   test("each") {

--- a/test/shared/src/test/scala/monocle/LensSpec.scala
+++ b/test/shared/src/test/scala/monocle/LensSpec.scala
@@ -105,6 +105,17 @@ class LensSpec extends MonocleSuite {
     obj.applyLens(lens).some.getOption shouldEqual Some(2)
   }
 
+  test("withDefault") {
+    case class SomeTest(x: Int, y: Option[Int])
+    val objSome = SomeTest(1, Some(2))
+    val objNone = SomeTest(1, None)
+
+    val lens = GenLens[SomeTest](_.y)
+
+    lens.withDefault(0).get(objSome) shouldEqual 2
+    lens.withDefault(0).get(objNone) shouldEqual 0
+  }
+
   test("each") {
     case class SomeTest(x: Int, y: List[Int])
     val obj = SomeTest(1, List(1, 2, 3))

--- a/test/shared/src/test/scala/monocle/OptionalSpec.scala
+++ b/test/shared/src/test/scala/monocle/OptionalSpec.scala
@@ -113,6 +113,19 @@ class OptionalSpec extends MonocleSuite {
     obj.applyOptional(optional).some.getOption shouldEqual Some(2)
   }
 
+  test("withDefault") {
+    case class SomeTest(x: Int, y: Option[Int])
+    val objSome = SomeTest(1, Some(2))
+    val objNone = SomeTest(1, None)
+
+    val optional = GenLens[SomeTest](_.y).asOptional
+
+    optional.withDefault(0).getOption(objSome) shouldEqual Some(2)
+    optional.withDefault(0).getOption(objNone) shouldEqual Some(0)
+
+    // TODO add applyOptional test
+  }
+
   test("each") {
     case class SomeTest(x: Int, y: List[Int])
     val obj = SomeTest(1, List(1, 2, 3))

--- a/test/shared/src/test/scala/monocle/PrismSpec.scala
+++ b/test/shared/src/test/scala/monocle/PrismSpec.scala
@@ -187,6 +187,19 @@ class PrismSpec extends MonocleSuite {
     obj.applyPrism(prism).some.getOption shouldEqual Some(2)
   }
 
+  test("withDefault") {
+    case class SomeTest(y: Option[Int])
+    val objSome = SomeTest(Some(2))
+    val objNone = SomeTest(None)
+
+    val prism = Iso[SomeTest, Option[Int]](_.y)(SomeTest).asPrism
+
+    prism.withDefault(0).getOption(objSome) shouldEqual Some(2)
+    prism.withDefault(0).getOption(objNone) shouldEqual Some(0)
+
+    // TODO add applyPrism test
+  }
+
   test("each") {
     case class SomeTest(y: List[Int])
     val obj = SomeTest(List(1, 2, 3))

--- a/test/shared/src/test/scala/monocle/SetterSpec.scala
+++ b/test/shared/src/test/scala/monocle/SetterSpec.scala
@@ -52,6 +52,19 @@ class SetterSpec extends MonocleSuite {
     obj.applySetter(setter).some.set(3) shouldEqual SomeTest(1, Some(3))
   }
 
+  test("withDefault") {
+    case class SomeTest(x: Int, y: Option[Int])
+    val objSome = SomeTest(1, Some(2))
+    val objNone = SomeTest(1, None)
+
+    val setter = GenLens[SomeTest](_.y).asSetter
+
+    setter.withDefault(0).set(3)(objSome) shouldEqual SomeTest(1, Some(3))
+    setter.withDefault(0).set(3)(objNone) shouldEqual SomeTest(1, Some(3))
+
+    // TODO add applySetter test
+  }
+
   test("each") {
     case class SomeTest(x: Int, y: List[Int])
     val obj = SomeTest(1, List(1, 2, 3))

--- a/test/shared/src/test/scala/monocle/TraversalSpec.scala
+++ b/test/shared/src/test/scala/monocle/TraversalSpec.scala
@@ -155,22 +155,27 @@ class TraversalSpec extends MonocleSuite {
   }
 
   test("some") {
-    case class SomeTest(x: Int, y: Option[Int])
-    val obj = SomeTest(1, Some(2))
+    val numbers = List(Some(1), None, Some(2), None)
+    val traversal = Traversal.fromTraverse[List, Option[Int]]
 
-    val traversal = GenLens[SomeTest](_.y).asTraversal
+    traversal.some.set(5)(numbers) shouldEqual List(Some(5), None, Some(5), None)
+    numbers.applyTraversal(traversal).some.set(5) shouldEqual List(Some(5), None, Some(5), None)
+  }
 
-    traversal.some.getAll(obj) shouldEqual List(2)
-    obj.applyTraversal(traversal).some.getAll shouldEqual List(2)
+  test("withDefault") {
+    val numbers = List(Some(1), None, Some(2), None)
+    val traversal = Traversal.fromTraverse[List, Option[Int]]
+
+    traversal.withDefault(0).modify(_ + 1)(numbers) shouldEqual List(Some(2), Some(1), Some(3), Some(1))
+
+    // TODO add applyTraversal test
   }
 
   test("each") {
-    case class SomeTest(x: Int, y: List[Int])
-    val obj = SomeTest(1, List(1, 2, 3))
+    val numbers = List(List(1,2,3), Nil, List(4), Nil)
+    val traversal = Traversal.fromTraverse[List, List[Int]]
 
-    val traversal = GenLens[SomeTest](_.y).asTraversal
-
-    traversal.each.getAll(obj) shouldEqual List(1, 2, 3)
-    obj.applyTraversal(traversal).each.getAll shouldEqual List(1, 2, 3)
+    traversal.each.getAll(numbers) shouldEqual List(1, 2, 3, 4)
+    numbers.applyTraversal(traversal).each.getAll shouldEqual List(1, 2, 3, 4)
   }
 }

--- a/test/shared/src/test/scala/monocle/TraversalSpec.scala
+++ b/test/shared/src/test/scala/monocle/TraversalSpec.scala
@@ -155,7 +155,7 @@ class TraversalSpec extends MonocleSuite {
   }
 
   test("some") {
-    val numbers = List(Some(1), None, Some(2), None)
+    val numbers   = List(Some(1), None, Some(2), None)
     val traversal = Traversal.fromTraverse[List, Option[Int]]
 
     traversal.some.set(5)(numbers) shouldEqual List(Some(5), None, Some(5), None)
@@ -163,7 +163,7 @@ class TraversalSpec extends MonocleSuite {
   }
 
   test("withDefault") {
-    val numbers = List(Some(1), None, Some(2), None)
+    val numbers   = List(Some(1), None, Some(2), None)
     val traversal = Traversal.fromTraverse[List, Option[Int]]
 
     traversal.withDefault(0).modify(_ + 1)(numbers) shouldEqual List(Some(2), Some(1), Some(3), Some(1))
@@ -172,7 +172,7 @@ class TraversalSpec extends MonocleSuite {
   }
 
   test("each") {
-    val numbers = List(List(1,2,3), Nil, List(4), Nil)
+    val numbers   = List(List(1, 2, 3), Nil, List(4), Nil)
     val traversal = Traversal.fromTraverse[List, List[Int]]
 
     traversal.each.getAll(numbers) shouldEqual List(1, 2, 3, 4)

--- a/test/shared/src/test/scala/monocle/function/AtSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/AtSpec.scala
@@ -1,7 +1,7 @@
 package monocle.function
 
 import cats.kernel.Eq
-import monocle.{Lens, MonocleSuite}
+import monocle.MonocleSuite
 import monocle.law.discipline.function.AtTests
 
 import scala.collection.immutable.ListMap

--- a/test/shared/src/test/scala/monocle/function/AtSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/AtSpec.scala
@@ -15,24 +15,4 @@ class AtSpec extends MonocleSuite {
   checkAll("fromIso", AtTests[MMap[Int, String], Int, Option[String]])
 
   checkAll("ListMap", AtTests[ListMap[Int, String], Int, Option[String]])
-
-  def mapDefaultTo0(index: String): Lens[Map[String, Int], Int] =
-    atOrElse(index)(0)
-
-  test("atOrElse") {
-    val counters = Map("id1" -> 4, "id2" -> 2)
-
-    assert(mapDefaultTo0("id1").get(counters) == 4)
-    assert(mapDefaultTo0("id3").get(counters) == 0)
-
-    assert(mapDefaultTo0("id1").modify(_ + 1)(counters) == Map("id1" -> 5, "id2" -> 2))
-    assert(
-      mapDefaultTo0("id3")
-        .modify(_ + 1)(counters) == Map("id1" -> 4, "id2" -> 2, "id3" -> 1)
-    )
-  }
-
-  test("atOrElse can break get-set property") {
-    assert(mapDefaultTo0("id").set(0)(Map("id" -> 0)) == Map.empty)
-  }
 }

--- a/test/shared/src/test/scala/monocle/std/OptionSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/OptionSpec.scala
@@ -1,7 +1,7 @@
 package monocle.std
 
 import cats.Eq
-import monocle.MonocleSuite
+import monocle.{Lens, MonocleSuite}
 import monocle.law.discipline.{IsoTests, PrismTests}
 import monocle.law.discipline.function.{EachTests, EmptyTests, PossibleTests}
 import org.scalacheck.{Arbitrary, Cogen}
@@ -26,4 +26,14 @@ class OptionSpec extends MonocleSuite {
   }
 
   checkAll("withDefault Int 0", IsoTests(withDefault(IntNoZero(0))))
+
+  test("withDefault can break get-set property") {
+    def mapAt(index: String): Lens[Map[String, Int], Option[Int]] =
+      at(index)
+
+    def mapDefaultTo0(index: String): Lens[Map[String, Int], Int] =
+      mapAt(index) composeIso withDefault(0)
+
+    assert(mapDefaultTo0("id").set(0)(Map("id" -> 0)) == Map.empty)
+  }
 }


### PR DESCRIPTION
The two most common operations on optics that point to an `Option` are:
1. focus only on `Some` which we can do with `some`
1. focus on `Some` or replace `None` by some default value

I propose to add `withDefault` method to all optics and apply optics similar to what we've done for `some`.
I removed `atOrElse`, it can easily be achieved by `at(x).withDefault(y)`

Main questions:
1. Is this use case worth the maintenace cost?
1. shall we add syntax for monorphic optics somewhere else? `implicit evTS: T =:= S, evBA: B =:= A, evOpt: A =:= Option[A1]` is not really readable.