### PR TITLE
WIP add .lens syntax to Lens and Prism

### DIFF
--- a/macro/src/main/scala/monocle/macros/syntax/LensMacroSyntax.scala
+++ b/macro/src/main/scala/monocle/macros/syntax/LensMacroSyntax.scala
@@ -11,7 +11,7 @@ trait LensMacroSyntax {
 
 class LensMacroOps[S, A](private val value: Lens[S, A]) extends AnyVal {
   def lens[C](field: A => C): Lens[S, C] =
-     macro GenLensLensOpsImpl.lens_impl[S, A, C]
+    macro GenLensLensOpsImpl.lens_impl[S, A, C]
 }
 
 class GenLensLensOpsImpl(val c: blackbox.Context) {

--- a/macro/src/main/scala/monocle/macros/syntax/LensMacroSyntax.scala
+++ b/macro/src/main/scala/monocle/macros/syntax/LensMacroSyntax.scala
@@ -1,0 +1,31 @@
+package monocle.macros.syntax
+
+import monocle.Lens
+
+import scala.reflect.macros.blackbox
+
+trait LensMacroSyntax {
+  implicit def toLensMacroOps[S, A](value: Lens[S, A]): LensMacroOps[S, A] =
+    new LensMacroOps(value)
+}
+
+class LensMacroOps[S, A](private val value: Lens[S, A]) extends AnyVal {
+  def lens[C](field: A => C): Lens[S, C] =
+     macro GenLensLensOpsImpl.lens_impl[S, A, C]
+}
+
+class GenLensLensOpsImpl(val c: blackbox.Context) {
+  def lens_impl[S, A: c.WeakTypeTag, C](field: c.Expr[A => C]): c.Expr[Lens[S, C]] = {
+    import c.universe._
+
+    val subj = c.prefix.tree match {
+      case Apply(TypeApply(_, _), List(x)) => x
+      case t =>
+        c.abort(c.enclosingPosition, s"Invalid prefix tree ${show(t)}")
+    }
+
+    c.Expr[Lens[S, C]](
+      q"$subj.composeLens(_root_.monocle.macros.GenLens[${c.weakTypeOf[A]}](${field}))"
+    )
+  }
+}

--- a/macro/src/main/scala/monocle/macros/syntax/PrismMacroSyntax.scala
+++ b/macro/src/main/scala/monocle/macros/syntax/PrismMacroSyntax.scala
@@ -1,0 +1,31 @@
+package monocle.macros.syntax
+
+import monocle.{Optional, Prism}
+
+import scala.reflect.macros.blackbox
+
+trait PrismMacroSyntax {
+  implicit def toPrismMacroOps[S, A](value: Prism[S, A]): PrismMacroOps[S, A] =
+    new PrismMacroOps(value)
+}
+
+class PrismMacroOps[S, A](private val value: Prism[S, A]) extends AnyVal {
+  def lens[C](field: A => C): Optional[S, C] =
+  macro GenLensPrismOpsImpl.lens_impl[S, A, C]
+}
+
+class GenLensPrismOpsImpl(val c: blackbox.Context) {
+  def lens_impl[S, A: c.WeakTypeTag, C](field: c.Expr[A => C]): c.Expr[Optional[S, C]] = {
+    import c.universe._
+
+    val subj = c.prefix.tree match {
+      case Apply(TypeApply(_, _), List(x)) => x
+      case t =>
+        c.abort(c.enclosingPosition, s"Invalid prefix tree ${show(t)}")
+    }
+
+    c.Expr[Optional[S, C]](
+      q"$subj.composeLens(_root_.monocle.macros.GenLens[${c.weakTypeOf[A]}](${field}))"
+    )
+  }
+}

--- a/macro/src/main/scala/monocle/macros/syntax/PrismMacroSyntax.scala
+++ b/macro/src/main/scala/monocle/macros/syntax/PrismMacroSyntax.scala
@@ -11,7 +11,7 @@ trait PrismMacroSyntax {
 
 class PrismMacroOps[S, A](private val value: Prism[S, A]) extends AnyVal {
   def lens[C](field: A => C): Optional[S, C] =
-  macro GenLensPrismOpsImpl.lens_impl[S, A, C]
+    macro GenLensPrismOpsImpl.lens_impl[S, A, C]
 }
 
 class GenLensPrismOpsImpl(val c: blackbox.Context) {

--- a/macro/src/main/scala/monocle/macros/syntax/lens.scala
+++ b/macro/src/main/scala/monocle/macros/syntax/lens.scala
@@ -1,3 +1,7 @@
 package monocle.macros.syntax
 
-object lens extends GenApplyLensSyntax
+object all extends GenApplyLensSyntax with LensMacroSyntax with PrismMacroSyntax
+
+object lens extends GenApplyLensSyntax with LensMacroSyntax
+
+object prism extends PrismMacroSyntax

--- a/test/shared/src/test/scala/monocle/LensSpec.scala
+++ b/test/shared/src/test/scala/monocle/LensSpec.scala
@@ -2,6 +2,7 @@ package monocle
 
 import monocle.law.discipline.{LensTests, OptionalTests, SetterTests, TraversalTests}
 import monocle.macros.{GenLens, Lenses}
+import monocle.macros.syntax.lens._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 
@@ -47,6 +48,8 @@ class LensSpec extends MonocleSuite {
   checkAll("GenLens", LensTests(GenLens[Example](_.s)))
   checkAll("GenLens chain", LensTests(GenLens[Example](_.p.x)))
   checkAll("Lenses", LensTests(Example.s))
+
+  checkAll("lens extension method", LensTests(p.lens(_.x)))
 
   checkAll("lens.asOptional", OptionalTests(s.asOptional))
   checkAll("lens.asTraversal", TraversalTests(s.asTraversal))

--- a/test/shared/src/test/scala/monocle/PrismSpec.scala
+++ b/test/shared/src/test/scala/monocle/PrismSpec.scala
@@ -2,6 +2,7 @@ package monocle
 
 import monocle.law.discipline.{OptionalTests, PrismTests, SetterTests, TraversalTests}
 import monocle.macros.{GenIso, GenPrism}
+import monocle.macros.syntax.all._
 import cats.arrow.{Category, Compose}
 import cats.syntax.either._
 
@@ -36,6 +37,8 @@ class PrismSpec extends MonocleSuite {
 
   checkAll("apply Prism", PrismTests(_right[String, Int]))
   checkAll("apply partial Prism", PrismTests(_pright[String, Int]))
+
+  checkAll("lens extension method", OptionalTests(_right[String, (Int, String)].lens(_._1)))
 
   checkAll("prism.asTraversal", OptionalTests(_right[String, Int].asOptional))
   checkAll("prism.asTraversal", TraversalTests(_right[String, Int].asTraversal))


### PR DESCRIPTION
Add `lens` extension methods to all optics such that we can use `.lens(_.foo)` instead of `composeLens GenLens[Target](_.foo)`