### PR TITLE
Fix doc task and skip publishing dotty for now

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,8 @@ lazy val buildSettings = Seq(
   scmInfo := Some(
     ScmInfo(url("https://github.com/optics-dev/Monocle"), "scm:git:git@github.com:optics-dev/Monocle.git")
   ),
-  useScala3doc := true,
+  skip.in(publish) := isDotty.value,
+  useScala3doc := false,
   testFrameworks += new TestFramework("munit.Framework"),
   Compile / doc / sources := { if (isDotty.value) Seq() else (Compile / doc / sources).value }
 )


### PR DESCRIPTION
This may fix the release failing task.
I'm disabling publishing for dotty, it is recommended not to publish with dependencies from scala 2. Though the code compiles and tests run it may cause dependency issues downstream