### PR TITLE
Deprecate FieldX for At with a singleton index

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,13 @@ lazy val buildSettings = Seq(
     "-feature",
     "-unchecked",
     "-Xfatal-warnings",
-    "-deprecation"
+    "-deprecation",
+    "-Wconf:msg=class Field1 in package function is deprecated:i",
+    "-Wconf:msg=class Field2 in package function is deprecated:i",
+    "-Wconf:msg=class Field3 in package function is deprecated:i",
+    "-Wconf:msg=class Field4 in package function is deprecated:i",
+    "-Wconf:msg=class Field5 in package function is deprecated:i",
+    "-Wconf:msg=class Field6 in package function is deprecated:i",
   ),
   scalacOptions in (Compile, console) -= "-Ywarn-unused:imports",
   scalacOptions ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -50,18 +50,26 @@ lazy val buildSettings = Seq(
     "-unchecked",
     "-Xfatal-warnings",
     "-deprecation",
-    "-Wconf:msg=class Field1 in package function is deprecated:i",
-    "-Wconf:msg=class Field2 in package function is deprecated:i",
-    "-Wconf:msg=class Field3 in package function is deprecated:i",
-    "-Wconf:msg=class Field4 in package function is deprecated:i",
-    "-Wconf:msg=class Field5 in package function is deprecated:i",
-    "-Wconf:msg=class Field6 in package function is deprecated:i",
   ),
   scalacOptions in (Compile, console) -= "-Ywarn-unused:imports",
   scalacOptions ++= {
     if (isDotty.value)
       Seq("-source:3.0-migration", "-Ykind-projector", "-language:implicitConversions,higherKinds,postfixOps")
-    else Seq("-Ymacro-annotations", "-Ywarn-dead-code", "-Ywarn-value-discard", "-Ywarn-unused:imports", "-language:implicitConversions", "-language:higherKinds", "-language:postfixOps")
+    else Seq(
+      "-Ymacro-annotations",
+      "-Ywarn-dead-code",
+      "-Ywarn-value-discard",
+      "-Ywarn-unused:imports",
+      "-language:implicitConversions",
+      "-language:higherKinds",
+      "-language:postfixOps",
+      "-Wconf:msg=class Field1 in package function is deprecated:i",
+      "-Wconf:msg=class Field2 in package function is deprecated:i",
+      "-Wconf:msg=class Field3 in package function is deprecated:i",
+      "-Wconf:msg=class Field4 in package function is deprecated:i",
+      "-Wconf:msg=class Field5 in package function is deprecated:i",
+      "-Wconf:msg=class Field6 in package function is deprecated:i",
+    )
   },
   libraryDependencies ++= {
     if (isDotty.value) Seq.empty

--- a/core/shared/src/main/scala/monocle/function/All.scala
+++ b/core/shared/src/main/scala/monocle/function/All.scala
@@ -4,7 +4,6 @@ object all extends GenericOptics
 
 trait GenericOptics
     extends AtFunctions
-    with AtSingletonFunctions
     with ConsFunctions
     with Cons1Functions
     with CurryFunctions

--- a/core/shared/src/main/scala/monocle/function/All.scala
+++ b/core/shared/src/main/scala/monocle/function/All.scala
@@ -4,6 +4,7 @@ object all extends GenericOptics
 
 trait GenericOptics
     extends AtFunctions
+    with AtSingletonFunctions
     with ConsFunctions
     with Cons1Functions
     with CurryFunctions

--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -65,4 +65,49 @@ object At extends AtFunctions {
 
   implicit def at3_tuple3[A1, A2, A3]: At[(A1, A2, A3), 3, A3] =
     At(_ => Lens[(A1, A2, A3), A3](_._3)(x => _.copy(_3 = x)))
+
+  implicit def at1_tuple4[A1, A2, A3, A4]: At[(A1, A2, A3, A4), 1, A1] =
+    At(_ => Lens[(A1, A2, A3, A4), A1](_._1)(x => _.copy(_1 = x)))
+
+  implicit def at2_tuple4[A1, A2, A3, A4]: At[(A1, A2, A3, A4), 2, A2] =
+    At(_ => Lens[(A1, A2, A3, A4), A2](_._2)(x => _.copy(_2 = x)))
+
+  implicit def at3_tuple4[A1, A2, A3, A4]: At[(A1, A2, A3, A4), 3, A3] =
+    At(_ => Lens[(A1, A2, A3, A4), A3](_._3)(x => _.copy(_3 = x)))
+
+  implicit def at4_tuple4[A1, A2, A3, A4]: At[(A1, A2, A3, A4), 4, A4] =
+    At(_ => Lens[(A1, A2, A3, A4), A4](_._4)(x => _.copy(_4 = x)))
+
+  implicit def at1_tuple5[A1, A2, A3, A4, A5]: At[(A1, A2, A3, A4, A5), 1, A1] =
+    At(_ => Lens[(A1, A2, A3, A4, A5), A1](_._1)(x => _.copy(_1 = x)))
+
+  implicit def at2_tuple5[A1, A2, A3, A4, A5]: At[(A1, A2, A3, A4, A5), 2, A2] =
+    At(_ => Lens[(A1, A2, A3, A4, A5), A2](_._2)(x => _.copy(_2 = x)))
+
+  implicit def at3_tuple5[A1, A2, A3, A4, A5]: At[(A1, A2, A3, A4, A5), 3, A3] =
+    At(_ => Lens[(A1, A2, A3, A4, A5), A3](_._3)(x => _.copy(_3 = x)))
+
+  implicit def at4_tuple5[A1, A2, A3, A4, A5]: At[(A1, A2, A3, A4, A5), 4, A4] =
+    At(_ => Lens[(A1, A2, A3, A4, A5), A4](_._4)(x => _.copy(_4 = x)))
+
+  implicit def at5_tuple5[A1, A2, A3, A4, A5]: At[(A1, A2, A3, A4, A5), 5, A5] =
+    At(_ => Lens[(A1, A2, A3, A4, A5), A5](_._5)(x => _.copy(_5 = x)))
+
+  implicit def at1_tuple6[A1, A2, A3, A4, A5, A6]: At[(A1, A2, A3, A4, A5, A6), 1, A1] =
+    At(_ => Lens[(A1, A2, A3, A4, A5, A6), A1](_._1)(x => _.copy(_1 = x)))
+
+  implicit def at2_tuple6[A1, A2, A3, A4, A5, A6]: At[(A1, A2, A3, A4, A5, A6), 2, A2] =
+    At(_ => Lens[(A1, A2, A3, A4, A5, A6), A2](_._2)(x => _.copy(_2 = x)))
+
+  implicit def at3_tuple6[A1, A2, A3, A4, A5, A6]: At[(A1, A2, A3, A4, A5, A6), 3, A3] =
+    At(_ => Lens[(A1, A2, A3, A4, A5, A6), A3](_._3)(x => _.copy(_3 = x)))
+
+  implicit def at4_tuple6[A1, A2, A3, A4, A5, A6]: At[(A1, A2, A3, A4, A5, A6), 4, A4] =
+    At(_ => Lens[(A1, A2, A3, A4, A5, A6), A4](_._4)(x => _.copy(_4 = x)))
+
+  implicit def at5_tuple6[A1, A2, A3, A4, A5, A6]: At[(A1, A2, A3, A4, A5, A6), 5, A5] =
+    At(_ => Lens[(A1, A2, A3, A4, A5, A6), A5](_._5)(x => _.copy(_5 = x)))
+
+  implicit def at6_tuple6[A1, A2, A3, A4, A5, A6]: At[(A1, A2, A3, A4, A5, A6), 6, A6] =
+    At(_ => Lens[(A1, A2, A3, A4, A5, A6), A6](_._6)(x => _.copy(_6 = x)))
 }

--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -17,7 +17,7 @@ abstract class At[S, I, A] extends Serializable {
   def at(i: I): Lens[S, A]
 }
 
-abstract class AtSingleton[S, I <: Singleton, A] extends At[S, I, A]  {
+abstract class AtSingleton[S, I <: Singleton, A] extends At[S, I, A] {
   def at(i: I): Lens[S, A]
 }
 
@@ -46,9 +46,11 @@ object At extends AtFunctions {
       iso composeLens ev.at(_)
     )
 
-  /** ***************/
+  /** **************
+    */
   /** Std instances */
-  /** ***************/
+  /** **************
+    */
 
   implicit def atSortedMap[K, V]: At[SortedMap[K, V], K, Option[V]] =
     At(i => Lens((_: SortedMap[K, V]).get(i))(optV => map => optV.fold(map - i)(v => map + (i -> v))))

--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -17,12 +17,21 @@ abstract class At[S, I, A] extends Serializable {
   def at(i: I): Lens[S, A]
 }
 
+abstract class AtSingleton[S, I <: Singleton, A] extends At[S, I, A]  {
+  def at(i: I): Lens[S, A]
+}
+
 trait AtFunctions {
   def at[S, I, A](i: I)(implicit ev: At[S, I, A]): Lens[S, A] = ev.at(i)
 
   /** delete a value associated with a key in a Map-like container */
   def remove[S, I, A](i: I)(s: S)(implicit ev: At[S, I, Option[A]]): S =
     ev.at(i).set(None)(s)
+}
+
+trait AtSingletonFunctions {
+  def at[S, I <: Singleton, A](i: I)(implicit ev: AtSingleton[S, I, A]): Lens[S, A] =
+    ev.at(i)
 }
 
 object At extends AtFunctions {
@@ -37,11 +46,10 @@ object At extends AtFunctions {
       iso composeLens ev.at(_)
     )
 
-  /** *********************************************************************************************
-    */
+  /** ***************/
   /** Std instances */
-  /** *********************************************************************************************
-    */
+  /** ***************/
+
   implicit def atSortedMap[K, V]: At[SortedMap[K, V], K, Option[V]] =
     At(i => Lens((_: SortedMap[K, V]).get(i))(optV => map => optV.fold(map - i)(v => map + (i -> v))))
 
@@ -53,4 +61,23 @@ object At extends AtFunctions {
 
   implicit def atSet[A]: At[Set[A], A, Boolean] =
     At(a => Lens((_: Set[A]).contains(a))(b => set => if (b) set + a else set - a))
+}
+
+object AtSingleton extends AtSingletonFunctions {
+  def apply[S, I <: Singleton, A](lens: I => Lens[S, A]): AtSingleton[S, I, A] = (i: I) => lens(i)
+
+  implicit def at1_tuple2[A1, A2]: AtSingleton[(A1, A2), 1, A1] =
+    AtSingleton(_ => Lens[(A1, A2), A1](_._1)(x => _.copy(_1 = x)))
+
+  implicit def at2_tuple2[A1, A2]: AtSingleton[(A1, A2), 2, A2] =
+    AtSingleton(_ => Lens[(A1, A2), A2](_._2)(x => _.copy(_2 = x)))
+
+  implicit def at1_tuple3[A1, A2, A3]: AtSingleton[(A1, A2, A3), 1, A1] =
+    AtSingleton(_ => Lens[(A1, A2, A3), A1](_._1)(x => _.copy(_1 = x)))
+
+  implicit def at2_tuple3[A1, A2, A3]: AtSingleton[(A1, A2, A3), 2, A2] =
+    AtSingleton(_ => Lens[(A1, A2, A3), A2](_._2)(x => _.copy(_2 = x)))
+
+  implicit def at3_tuple3[A1, A2, A3]: AtSingleton[(A1, A2, A3), 3, A3] =
+    AtSingleton(_ => Lens[(A1, A2, A3), A3](_._3)(x => _.copy(_3 = x)))
 }

--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -13,25 +13,16 @@ import scala.collection.immutable.{ListMap, SortedMap}
 @implicitNotFound(
   "Could not find an instance of At[${S},${I},${A}], please check Monocle instance location policy to " + "find out which import is necessary"
 )
-abstract class At[S, I, A] extends Serializable {
-  def at(i: I): Lens[S, A]
-}
-
-abstract class AtSingleton[S, I <: Singleton, A] extends At[S, I, A] {
+abstract class At[S, -I, A] extends Serializable {
   def at(i: I): Lens[S, A]
 }
 
 trait AtFunctions {
-  def at[S, I, A](i: I)(implicit ev: At[S, I, A]): Lens[S, A] = ev.at(i)
+  def at[S, I, A](i: I)(implicit ev: At[S, i.type, A]): Lens[S, A] = ev.at(i)
 
   /** delete a value associated with a key in a Map-like container */
   def remove[S, I, A](i: I)(s: S)(implicit ev: At[S, I, Option[A]]): S =
     ev.at(i).set(None)(s)
-}
-
-trait AtSingletonFunctions {
-  def at[S, I <: Singleton, A](i: I)(implicit ev: AtSingleton[S, I, A]): Lens[S, A] =
-    ev.at(i)
 }
 
 object At extends AtFunctions {
@@ -42,15 +33,11 @@ object At extends AtFunctions {
 
   /** lift an instance of [[At]] using an [[Iso]] */
   def fromIso[S, U, I, A](iso: Iso[S, U])(implicit ev: At[U, I, A]): At[S, I, A] =
-    At(
-      iso composeLens ev.at(_)
-    )
+    At(iso composeLens ev.at(_))
 
-  /** **************
-    */
-  /** Std instances */
-  /** **************
-    */
+  /* ************** */
+  /* Std instances  */
+  /* ************** */
 
   implicit def atSortedMap[K, V]: At[SortedMap[K, V], K, Option[V]] =
     At(i => Lens((_: SortedMap[K, V]).get(i))(optV => map => optV.fold(map - i)(v => map + (i -> v))))
@@ -63,23 +50,19 @@ object At extends AtFunctions {
 
   implicit def atSet[A]: At[Set[A], A, Boolean] =
     At(a => Lens((_: Set[A]).contains(a))(b => set => if (b) set + a else set - a))
-}
 
-object AtSingleton extends AtSingletonFunctions {
-  def apply[S, I <: Singleton, A](lens: I => Lens[S, A]): AtSingleton[S, I, A] = (i: I) => lens(i)
+  implicit def at1_tuple2[A1, A2]: At[(A1, A2), 1, A1] =
+    At(_ => Lens[(A1, A2), A1](_._1)(x => _.copy(_1 = x)))
 
-  implicit def at1_tuple2[A1, A2]: AtSingleton[(A1, A2), 1, A1] =
-    AtSingleton(_ => Lens[(A1, A2), A1](_._1)(x => _.copy(_1 = x)))
+  implicit def at2_tuple2[A1, A2]: At[(A1, A2), 2, A2] =
+    At(_ => Lens[(A1, A2), A2](_._2)(x => _.copy(_2 = x)))
 
-  implicit def at2_tuple2[A1, A2]: AtSingleton[(A1, A2), 2, A2] =
-    AtSingleton(_ => Lens[(A1, A2), A2](_._2)(x => _.copy(_2 = x)))
+  implicit def at1_tuple3[A1, A2, A3]: At[(A1, A2, A3), 1, A1] =
+    At(_ => Lens[(A1, A2, A3), A1](_._1)(x => _.copy(_1 = x)))
 
-  implicit def at1_tuple3[A1, A2, A3]: AtSingleton[(A1, A2, A3), 1, A1] =
-    AtSingleton(_ => Lens[(A1, A2, A3), A1](_._1)(x => _.copy(_1 = x)))
+  implicit def at2_tuple3[A1, A2, A3]: At[(A1, A2, A3), 2, A2] =
+    At(_ => Lens[(A1, A2, A3), A2](_._2)(x => _.copy(_2 = x)))
 
-  implicit def at2_tuple3[A1, A2, A3]: AtSingleton[(A1, A2, A3), 2, A2] =
-    AtSingleton(_ => Lens[(A1, A2, A3), A2](_._2)(x => _.copy(_2 = x)))
-
-  implicit def at3_tuple3[A1, A2, A3]: AtSingleton[(A1, A2, A3), 3, A3] =
-    AtSingleton(_ => Lens[(A1, A2, A3), A3](_._3)(x => _.copy(_3 = x)))
+  implicit def at3_tuple3[A1, A2, A3]: At[(A1, A2, A3), 3, A3] =
+    At(_ => Lens[(A1, A2, A3), A3](_._3)(x => _.copy(_3 = x)))
 }

--- a/core/shared/src/main/scala/monocle/function/Cons.scala
+++ b/core/shared/src/main/scala/monocle/function/Cons.scala
@@ -1,6 +1,6 @@
 package monocle.function
 
-import monocle.function.fields._
+import monocle.function.At.at
 import monocle.{Iso, Optional, Prism}
 
 import scala.annotation.implicitNotFound
@@ -15,8 +15,8 @@ import scala.annotation.implicitNotFound
 abstract class Cons[S, A] extends Serializable {
   def cons: Prism[S, (A, S)]
 
-  def headOption: Optional[S, A] = cons composeLens first
-  def tailOption: Optional[S, S] = cons composeLens second
+  def headOption: Optional[S, A] = cons composeLens at(1)
+  def tailOption: Optional[S, S] = cons composeLens at(2)
 }
 
 trait ConsFunctions {

--- a/core/shared/src/main/scala/monocle/function/Cons1.scala
+++ b/core/shared/src/main/scala/monocle/function/Cons1.scala
@@ -1,6 +1,6 @@
 package monocle.function
 
-import monocle.function.fields._
+import monocle.function.At.at
 import monocle.{Iso, Lens}
 
 import scala.annotation.implicitNotFound
@@ -17,8 +17,8 @@ import scala.annotation.implicitNotFound
 abstract class Cons1[S, H, T] extends Serializable {
   def cons1: Iso[S, (H, T)]
 
-  def head: Lens[S, H] = cons1 composeLens first
-  def tail: Lens[S, T] = cons1 composeLens second
+  def head: Lens[S, H] = cons1 composeLens at(1)
+  def tail: Lens[S, T] = cons1 composeLens at(2)
 }
 
 trait Cons1Functions {

--- a/core/shared/src/main/scala/monocle/function/Field1.scala
+++ b/core/shared/src/main/scala/monocle/function/Field1.scala
@@ -11,11 +11,13 @@ import scala.annotation.implicitNotFound
 @implicitNotFound(
   "Could not find an instance of Field1[${S},${A}], please check Monocle instance location policy to " + "find out which import is necessary"
 )
+@deprecated("use monocle.function.At.at(1)", since = "3.0.0-M1")
 abstract class Field1[S, A] extends Serializable {
   def first: Lens[S, A]
 }
 
 trait Field1Functions {
+  @deprecated("use monocle.function.At.at(1)", since = "3.0.0-M1")
   def first[S, A](implicit ev: Field1[S, A]): Lens[S, A] = ev.first
 }
 

--- a/core/shared/src/main/scala/monocle/function/Field2.scala
+++ b/core/shared/src/main/scala/monocle/function/Field2.scala
@@ -11,11 +11,13 @@ import scala.annotation.implicitNotFound
 @implicitNotFound(
   "Could not find an instance of Field2[${S},${A}], please check Monocle instance location policy to " + "find out which import is necessary"
 )
+@deprecated("use monocle.function.At.at(2)", since = "3.0.0-M1")
 abstract class Field2[S, A] extends Serializable {
   def second: Lens[S, A]
 }
 
 trait Field2Functions {
+  @deprecated("use monocle.function.At.at(2)", since = "3.0.0-M1")
   def second[S, A](implicit ev: Field2[S, A]): Lens[S, A] = ev.second
 }
 

--- a/core/shared/src/main/scala/monocle/function/Field3.scala
+++ b/core/shared/src/main/scala/monocle/function/Field3.scala
@@ -11,11 +11,13 @@ import scala.annotation.implicitNotFound
 @implicitNotFound(
   "Could not find an instance of Field3[${S},${A}], please check Monocle instance location policy to " + "find out which import is necessary"
 )
+@deprecated("use monocle.function.At.at(3)", since = "3.0.0-M1")
 abstract class Field3[S, A] extends Serializable {
   def third: Lens[S, A]
 }
 
 trait Field3Functions {
+  @deprecated("use monocle.function.At.at(3)", since = "3.0.0-M1")
   def third[S, A](implicit ev: Field3[S, A]): Lens[S, A] = ev.third
 }
 

--- a/core/shared/src/main/scala/monocle/function/Field4.scala
+++ b/core/shared/src/main/scala/monocle/function/Field4.scala
@@ -11,11 +11,13 @@ import scala.annotation.implicitNotFound
 @implicitNotFound(
   "Could not find an instance of Field4[${S},${A}], please check Monocle instance location policy to " + "find out which import is necessary"
 )
+@deprecated("use monocle.function.At.at(4)", since = "3.0.0-M1")
 abstract class Field4[S, A] extends Serializable {
   def fourth: Lens[S, A]
 }
 
 trait Field4Functions {
+  @deprecated("use monocle.function.At.at(4)", since = "3.0.0-M1")
   def fourth[S, A](implicit ev: Field4[S, A]): Lens[S, A] = ev.fourth
 }
 

--- a/core/shared/src/main/scala/monocle/function/Field5.scala
+++ b/core/shared/src/main/scala/monocle/function/Field5.scala
@@ -11,11 +11,13 @@ import scala.annotation.implicitNotFound
 @implicitNotFound(
   "Could not find an instance of Field5[${S},${A}], please check Monocle instance location policy to " + "find out which import is necessary"
 )
+@deprecated("use monocle.function.At.at(5)", since = "3.0.0-M1")
 abstract class Field5[S, A] extends Serializable {
   def fifth: Lens[S, A]
 }
 
 trait Field5Functions {
+  @deprecated("use monocle.function.At.at(5)", since = "3.0.0-M1")
   def fifth[S, A](implicit ev: Field5[S, A]): Lens[S, A] = ev.fifth
 }
 

--- a/core/shared/src/main/scala/monocle/function/Field6.scala
+++ b/core/shared/src/main/scala/monocle/function/Field6.scala
@@ -11,11 +11,13 @@ import scala.annotation.implicitNotFound
 @implicitNotFound(
   "Could not find an instance of Field6[${S},${A}], please check Monocle instance location policy to " + "find out which import is necessary"
 )
+@deprecated("use monocle.function.At.at(6)", since = "3.0.0-M1")
 abstract class Field6[S, A] extends Serializable {
   def sixth: Lens[S, A]
 }
 
 trait Field6Functions {
+  @deprecated("use monocle.function.At.at(6)", since = "3.0.0-M1")
   def sixth[S, A](implicit ev: Field6[S, A]): Lens[S, A] = ev.sixth
 }
 

--- a/core/shared/src/main/scala/monocle/function/Snoc.scala
+++ b/core/shared/src/main/scala/monocle/function/Snoc.scala
@@ -1,6 +1,6 @@
 package monocle.function
 
-import monocle.function.fields._
+import monocle.function.At.at
 import monocle.{Iso, Optional, Prism}
 
 import scala.annotation.{implicitNotFound, tailrec}
@@ -18,8 +18,8 @@ import cats.syntax.either._
 abstract class Snoc[S, A] extends Serializable {
   def snoc: Prism[S, (S, A)]
 
-  def initOption: Optional[S, S] = snoc composeLens first
-  def lastOption: Optional[S, A] = snoc composeLens second
+  def initOption: Optional[S, S] = snoc composeLens at(1)
+  def lastOption: Optional[S, A] = snoc composeLens at(2)
 }
 
 trait SnocFunctions {

--- a/core/shared/src/main/scala/monocle/function/Snoc1.scala
+++ b/core/shared/src/main/scala/monocle/function/Snoc1.scala
@@ -1,6 +1,6 @@
 package monocle.function
 
-import monocle.function.fields._
+import monocle.function.At.at
 import monocle.{Iso, Lens}
 
 import scala.annotation.implicitNotFound
@@ -17,8 +17,8 @@ import scala.annotation.implicitNotFound
 abstract class Snoc1[S, I, L] extends Serializable {
   def snoc1: Iso[S, (I, L)]
 
-  def init: Lens[S, I] = snoc1 composeLens first
-  def last: Lens[S, L] = snoc1 composeLens second
+  def init: Lens[S, I] = snoc1 composeLens at(1)
+  def last: Lens[S, L] = snoc1 composeLens at(2)
 }
 
 trait Snoc1Functions {
@@ -90,6 +90,7 @@ object Snoc1 extends Snoc1Functions {
   /** *********************************************************************************************
     */
   import cats.data.{Chain, NonEmptyChain, NonEmptyList, NonEmptyVector}
+
   import scala.{List => IList, Vector => IVector}
 
   implicit def necSnoc1[A]: Snoc1[NonEmptyChain[A], Chain[A], A] =

--- a/core/shared/src/main/scala/monocle/syntax/Fields.scala
+++ b/core/shared/src/main/scala/monocle/syntax/Fields.scala
@@ -6,10 +6,16 @@ import monocle.function._
 object fields extends FieldsSyntax
 
 trait FieldsSyntax {
+  @deprecated("use monocle.function.At.at(1)", since = "3.0.0-M1")
   def _1[S, A](implicit ev: Field1[S, A]): Lens[S, A] = ev.first
+  @deprecated("use monocle.function.At.at(2)", since = "3.0.0-M1")
   def _2[S, A](implicit ev: Field2[S, A]): Lens[S, A] = ev.second
+  @deprecated("use monocle.function.At.at(3)", since = "3.0.0-M1")
   def _3[S, A](implicit ev: Field3[S, A]): Lens[S, A] = ev.third
+  @deprecated("use monocle.function.At.at(4)", since = "3.0.0-M1")
   def _4[S, A](implicit ev: Field4[S, A]): Lens[S, A] = ev.fourth
+  @deprecated("use monocle.function.At.at(5)", since = "3.0.0-M1")
   def _5[S, A](implicit ev: Field5[S, A]): Lens[S, A] = ev.fifth
+  @deprecated("use monocle.function.At.at(6)", since = "3.0.0-M1")
   def _6[S, A](implicit ev: Field6[S, A]): Lens[S, A] = ev.sixth
 }

--- a/example/src/test/scala/monocle/function/FieldsExample.scala
+++ b/example/src/test/scala/monocle/function/FieldsExample.scala
@@ -4,24 +4,24 @@ import monocle.MonocleSuite
 
 class FieldsExample extends MonocleSuite {
   test("_1 creates a Lens from a 2-6 tuple to its first element") {
-    assertEquals((("Hello", 3) applyLens first get), "Hello")
+    assertEquals((("Hello", 3) applyLens at(1) get), "Hello")
 
-    assertEquals((("Hello", 3, true) applyLens first set "World"), (("World", 3, true)))
+    assertEquals((("Hello", 3, true) applyLens at(1) set "World"), (("World", 3, true)))
 
-    assertEquals((("Hello", 3, true, 5.6, 7L, 'c') applyLens first get), "Hello")
+    assertEquals((("Hello", 3, true, 5.6, 7L, 'c') applyLens at(1) get), "Hello")
   }
 
   test("_2 creates a Lens from a 2-6 tuple to its second element") {
-    assertEquals((("Hello", 3) applyLens second get), 3)
+    assertEquals((("Hello", 3) applyLens at(2) get), 3)
 
-    assertEquals((("Hello", 3, true, 5.6, 7L, 'c') applyLens second set 4), (("Hello", 4, true, 5.6, 7L, 'c')))
+    assertEquals((("Hello", 3, true, 5.6, 7L, 'c') applyLens at(2) set 4), (("Hello", 4, true, 5.6, 7L, 'c')))
   }
 
   // ...
 
   test("_6 creates a Lens from a 6-tuple to its sixth element") {
-    assertEquals((("Hello", 3, true, 5.6, 7L, 'c') applyLens sixth get), 'c')
+    assertEquals((("Hello", 3, true, 5.6, 7L, 'c') applyLens at(6) get), 'c')
 
-    assertEquals((("Hello", 3, true, 5.6, 7L, 'c') applyLens sixth set 'a'), (("Hello", 3, true, 5.6, 7L, 'a')))
+    assertEquals((("Hello", 3, true, 5.6, 7L, 'c') applyLens at(6) set 'a'), (("Hello", 3, true, 5.6, 7L, 'a')))
   }
 }

--- a/example/src/test/scala/monocle/generic/HListExample.scala
+++ b/example/src/test/scala/monocle/generic/HListExample.scala
@@ -6,14 +6,6 @@ import shapeless.HNil
 class HListExample extends MonocleSuite {
   case class Example(i: Int, s: String, b: Boolean)
 
-  test("_1 to _6 creates a Lens from HList to ith element") {
-    assertEquals((1 :: "bla" :: true :: HNil applyLens first get), 1)
-    assertEquals((1 :: "bla" :: true :: HNil applyLens second get), "bla")
-    assertEquals((1 :: "bla" :: true :: 5f :: 'c' :: 7L :: HNil applyLens sixth get), 7L)
-
-    assertEquals((1 :: "bla" :: true :: HNil applyLens first modify (_ + 1)), 2 :: "bla" :: true :: HNil)
-  }
-
   test("toHList creates an Iso between a Generic (typically a case class) and HList") {
     assertEquals((Example(1, "bla", true) applyIso toHList get), (1 :: "bla" :: true :: HNil))
 

--- a/example/src/test/scala/other/ImportExample.scala
+++ b/example/src/test/scala/other/ImportExample.scala
@@ -1,6 +1,6 @@
 package other
 
-import monocle.TestInstances
+import monocle.{TestInstances, Traversal}
 import shapeless.test.illTyped
 import shapeless.{::, HNil}
 
@@ -8,10 +8,10 @@ case class Custom(value: Int)
 
 object Custom {
   import monocle.Lens
-  import monocle.function.Field1
+  import monocle.function.Each
 
-  implicit val customHead = new Field1[Custom, Int] {
-    def first = Lens((_: Custom).value)(v => c => c.copy(value = v))
+  implicit val customHead = new Each[Custom, Int] {
+    def each: Traversal[Custom, Int] = Lens((_: Custom).value)(v => c => c.copy(value = v)).asTraversal
   }
 }
 
@@ -25,8 +25,8 @@ class ImportExample extends munit.FunSuite with TestInstances {
 
     assertEquals(each[List[Int], Int].modify(_ + 1)(List(1, 2, 3)), List(2, 3, 4))
 
-    // also compile because Head instance for Custom is in the companion of Custom
-    assertEquals(first[Custom, Int].modify(_ + 1)(Custom(1)), Custom(2))
+    // also compile because Each instance for Custom is in the companion of Custom
+    assertEquals(each[Custom, Int].modify(_ + 1)(Custom(1)), Custom(2))
   }
 
   test("monocle.syntax.all._ permits to use optics as operator which improves type inference") {
@@ -54,7 +54,7 @@ class ImportExample extends munit.FunSuite with TestInstances {
     // do not compile because Each instance for List is not in scope
     illTyped("""each[List[Int], Int].modify(List(1,2,3), _ + 1)""")
 
-    assertEquals(first[Int :: HNil, Int].modify(_ + 1)(1 :: HNil), (2 :: HNil))
+    assertEquals(head[Int :: HNil, Int, HNil].modify(_ + 1)(1 :: HNil), (2 :: HNil))
   }
 
   test("monocle._, Monocle._ makes all Monocle core features available (no generic)") {

--- a/law/src/main/scala/monocle/law/discipline/function/AtTests.scala
+++ b/law/src/main/scala/monocle/law/discipline/function/AtTests.scala
@@ -13,5 +13,5 @@ object AtTests extends Laws {
     evAt: At[S, I, A],
     arbAA: Arbitrary[A => A]
   ): RuleSet =
-    new SimpleRuleSet("At", LensTests(at(_: I)(evAt)).props: _*)
+    new SimpleRuleSet("At", LensTests[S, A, I](at(_)).props: _*)
 }

--- a/test/shared/src/test/scala/monocle/function/AtSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/AtSpec.scala
@@ -16,6 +16,12 @@ class AtSpec extends MonocleSuite {
 
   checkAll("ListMap", AtTests[ListMap[Int, String], Int, Option[String]])
 
+  test("at creates a Lens from a Map, SortedMap to an optional value") {
+    val map = Map("One" -> 1, "Two" -> 2)
+    assertEquals((map applyLens at("One")).set(Some(-1)), Map("One" -> -1, "Two" -> 2))
+    assertEquals((map applyLens at("Two") .get), Some(2))
+  }
+
   test("at for tuples") {
     val tuple2 = (true, "hello")
     val tuple3 = (true, "hello", 5)

--- a/test/shared/src/test/scala/monocle/function/AtSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/AtSpec.scala
@@ -19,7 +19,7 @@ class AtSpec extends MonocleSuite {
   test("at creates a Lens from a Map, SortedMap to an optional value") {
     val map = Map("One" -> 1, "Two" -> 2)
     assertEquals((map applyLens at("One")).set(Some(-1)), Map("One" -> -1, "Two" -> 2))
-    assertEquals((map applyLens at("Two") .get), Some(2))
+    assertEquals((map applyLens at("Two")).get, Some(2))
   }
 
   test("at for tuples") {

--- a/test/shared/src/test/scala/monocle/function/AtSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/AtSpec.scala
@@ -15,4 +15,16 @@ class AtSpec extends MonocleSuite {
   checkAll("fromIso", AtTests[MMap[Int, String], Int, Option[String]])
 
   checkAll("ListMap", AtTests[ListMap[Int, String], Int, Option[String]])
+
+  test("at for tuples") {
+    val tuple2 = (true, "hello")
+    val tuple3 = (true, "hello", 5)
+
+    assertEquals((tuple2 applyLens at(1)).get, true)
+    assertEquals((tuple2 applyLens at(2)).get, "hello")
+
+    assertEquals((tuple3 applyLens at(1)).get, true)
+    assertEquals((tuple3 applyLens at(2)).get, "hello")
+    assertEquals((tuple3 applyLens at(3)).get, 5)
+  }
 }

--- a/test/shared/src/test/scala/monocle/generic/HListSpec.scala
+++ b/test/shared/src/test/scala/monocle/generic/HListSpec.scala
@@ -1,14 +1,13 @@
 package monocle.generic
 
-import monocle.MonocleSuite
-import monocle.law.discipline.{IsoTests, LensTests}
-import org.scalacheck.{Arbitrary, Cogen}
-import shapeless.HList._
-import shapeless.ops.hlist.{Init => HListInit, IsHCons}
-import shapeless.{::, HNil}
-
 import cats.Eq
 import cats.implicits._
+import monocle.MonocleSuite
+import monocle.law.discipline.IsoTests
+import org.scalacheck.{Arbitrary, Cogen}
+import shapeless.HList._
+import shapeless.ops.hlist.{IsHCons, Init => HListInit}
+import shapeless.{::, HNil}
 
 class HListSpec extends MonocleSuite {
   case class Example(i: Int, b: Boolean, c: Char, f: Float, l: Long, d: Double)
@@ -49,13 +48,6 @@ class HListSpec extends MonocleSuite {
   implicit val hInitCoGen    = Cogen.tuple5[Int, Boolean, Char, Float, Long].contramap[HInit](_.tupled)
 
   checkAll("toHList", IsoTests(toHList[Example, H]))
-
-  checkAll("first from HList", LensTests(first[H, Int]))
-  checkAll("second from HList", LensTests(second[H, Boolean]))
-  checkAll("third from HList", LensTests(third[H, Char]))
-  checkAll("fourth from HList", LensTests(fourth[H, Float]))
-  checkAll("fifth from HList", LensTests(fifth[H, Long]))
-  checkAll("sixth from HList", LensTests(sixth[H, Double]))
 
   checkAll("reverse HList", IsoTests(reverse[H, ReverseH]))
   checkAll("hcons HList", IsoTests(cons1[H, Int, HTail]))

--- a/test/shared/src/test/scala/monocle/std/Tuple1Spec.scala
+++ b/test/shared/src/test/scala/monocle/std/Tuple1Spec.scala
@@ -1,7 +1,7 @@
 package monocle.std
 
 import monocle.MonocleSuite
-import monocle.law.discipline.{IsoTests, LensTests}
+import monocle.law.discipline.IsoTests
 import monocle.law.discipline.function.ReverseTests
 import org.scalacheck.Arbitrary
 
@@ -9,7 +9,6 @@ class Tuple1Spec extends MonocleSuite {
   implicit def arbitraryTuple1[T](implicit arb: Arbitrary[T]): Arbitrary[Tuple1[T]] =
     Arbitrary(arb.arbitrary.map(Tuple1.apply))
 
-  checkAll("first tuple1", LensTests(first[Tuple1[Int], Int]))
   checkAll("reverse tuple1", ReverseTests[Tuple1[Int], Tuple1[Int]])
   checkAll("tuple1 iso", IsoTests[Tuple1[Int], Int](tuple1Iso))
 }

--- a/test/shared/src/test/scala/monocle/std/Tuple2Spec.scala
+++ b/test/shared/src/test/scala/monocle/std/Tuple2Spec.scala
@@ -1,12 +1,9 @@
 package monocle.std
 
 import monocle.MonocleSuite
-import monocle.law.discipline.LensTests
 import monocle.law.discipline.function.{Cons1Tests, EachTests, ReverseTests, Snoc1Tests}
 
 class Tuple2Spec extends MonocleSuite {
-  checkAll("first tuple2", LensTests(first[(Int, Char), Int]))
-  checkAll("second tuple2", LensTests(second[(Int, Char), Char]))
   checkAll("each tuple2", EachTests[(Int, Int), Int])
   checkAll("reverse tuple2", ReverseTests[(Int, Char), (Char, Int)])
   checkAll("cons1 tuple2", Cons1Tests[(Int, Char), Int, Char])

--- a/test/shared/src/test/scala/monocle/std/Tuple6Spec.scala
+++ b/test/shared/src/test/scala/monocle/std/Tuple6Spec.scala
@@ -1,17 +1,10 @@
 package monocle.std
 
 import monocle.MonocleSuite
-import monocle.law.discipline.LensTests
 import monocle.law.discipline.function.{Cons1Tests, EachTests, Snoc1Tests}
 
 class Tuple6Spec extends MonocleSuite {
   checkAll("each tuple6", EachTests[(Int, Int, Int, Int, Int, Int), Int])
-  checkAll("first tuple6", LensTests(first[(Int, Char, Boolean, String, Long, Float), Int]))
-  checkAll("second tuple6", LensTests(second[(Int, Char, Boolean, String, Long, Float), Char]))
-  checkAll("third tuple6", LensTests(third[(Int, Char, Boolean, String, Long, Float), Boolean]))
-  checkAll("fourth tuple6", LensTests(fourth[(Int, Char, Boolean, String, Long, Float), String]))
-  checkAll("fifth tuple6", LensTests(fifth[(Int, Char, Boolean, String, Long, Float), Long]))
-  checkAll("sixth tuple6", LensTests(sixth[(Int, Char, Boolean, String, Long, Float), Float]))
   checkAll(
     "cons1 tuple6",
     Cons1Tests[(Int, Char, Boolean, String, Long, Float), Int, (Char, Boolean, String, Long, Float)]


### PR DESCRIPTION
Thanks to @nafg for the idea! see #957 

If we like the idea, I would like to:
1. deprecate `First`, `Second`, etc
1. generate At instances for more tuples. Where shall we stop?