### PR TITLE
POC for using At to focus into tuples using non-overloaded method

### DIFF
--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -57,7 +57,6 @@ object At extends AtFunctions {
   implicit def atSet[A]: At[Set[A], A, Boolean] =
     At(a => Lens((_: Set[A]).contains(a))(b => set => if (b) set + a else set - a))
 
-
   implicit def at1_tuple2[A1, A2]: At[(A1, A2), 1, A1] =
     At(_ => Lens[(A1, A2), A1](_._1)(x => _.copy(_1 = x)))
 

--- a/core/shared/src/main/scala/monocle/function/At.scala
+++ b/core/shared/src/main/scala/monocle/function/At.scala
@@ -20,6 +20,9 @@ abstract class At[S, I, A] extends Serializable {
 trait AtFunctions {
   def at[S, I, A](i: I)(implicit ev: At[S, I, A]): Lens[S, A] = ev.at(i)
 
+  def at_[S, I <: Singleton, A](i: I)(implicit ev: At[S, I, A]): Lens[S, A] =
+    ev.at(i)
+
   /** delete a value associated with a key in a Map-like container */
   def remove[S, I, A](i: I)(s: S)(implicit ev: At[S, I, Option[A]]): S =
     ev.at(i).set(None)(s)
@@ -53,4 +56,20 @@ object At extends AtFunctions {
 
   implicit def atSet[A]: At[Set[A], A, Boolean] =
     At(a => Lens((_: Set[A]).contains(a))(b => set => if (b) set + a else set - a))
+
+
+  implicit def at1_tuple2[A1, A2]: At[(A1, A2), 1, A1] =
+    At(_ => Lens[(A1, A2), A1](_._1)(x => _.copy(_1 = x)))
+
+  implicit def at2_tuple2[A1, A2]: At[(A1, A2), 2, A2] =
+    At(_ => Lens[(A1, A2), A2](_._2)(x => _.copy(_2 = x)))
+
+  implicit def at1_tuple3[A1, A2, A3]: At[(A1, A2, A3), 1, A1] =
+    At(_ => Lens[(A1, A2, A3), A1](_._1)(x => _.copy(_1 = x)))
+
+  implicit def at2_tuple3[A1, A2, A3]: At[(A1, A2, A3), 2, A2] =
+    At(_ => Lens[(A1, A2, A3), A2](_._2)(x => _.copy(_2 = x)))
+
+  implicit def at3_tuple3[A1, A2, A3]: At[(A1, A2, A3), 3, A3] =
+    At(_ => Lens[(A1, A2, A3), A3](_._3)(x => _.copy(_3 = x)))
 }

--- a/test/shared/src/test/scala/monocle/function/AtSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/AtSpec.scala
@@ -15,4 +15,22 @@ class AtSpec extends MonocleSuite {
   checkAll("fromIso", AtTests[MMap[Int, String], Int, Option[String]])
 
   checkAll("ListMap", AtTests[ListMap[Int, String], Int, Option[String]])
+
+  test("at creates a Lens from a Map, SortedMap to an optional value") {
+    val map = Map("One" -> 1, "Two" -> 2)
+    assertEquals((map applyLens at("One")).set(Some(-1)), Map("One" -> -1, "Two" -> 2))
+    assertEquals((map applyLens at("Two")).get, Some(2))
+  }
+
+  test("at for tuples") {
+    val tuple2 = (true, "hello")
+    val tuple3 = (true, "hello", 5)
+
+    assertEquals((tuple2 applyLens at_(1)).get, true)
+    assertEquals((tuple2 applyLens at_(2)).get, "hello")
+
+    assertEquals((tuple3 applyLens at_(1)).get, true)
+    assertEquals((tuple3 applyLens at_(2)).get, "hello")
+    assertEquals((tuple3 applyLens at_(3)).get, 5)
+  }
 }


### PR DESCRIPTION
Thanks to @nafg for the idea! see #957

If we like the idea, I would like to:
1. deprecate First, Second, etc
1. generate At instances for more tuples. Where shall we stop?

Same idea than #959 but using `at_` for singleton index.
