### PR TITLE
add andThen on all optics

### DIFF
--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -110,44 +110,36 @@ abstract class PIso[S, T, A, B] extends Serializable { self =>
   private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PIso[S, T, A1, B1] =
     evB.substituteCo[PIso[S, T, A1, *]](evA.substituteCo[PIso[S, T, *, B]](this))
 
-  /** *******************************************************
-    */
-  /** Compose methods between a [[PIso]] and another Optics */
-  /** *******************************************************
-    */
   /** compose a [[PIso]] with a [[Fold]] */
-  @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
-    asFold composeFold other
-
-  /** Compose with a function lifted into a Getter */
-  @inline def to[C](f: A => C): Getter[S, C] = composeGetter(Getter(f))
+  final def andThen[C](other: Fold[A, C]): Fold[S, C] =
+    asFold.andThen(other)
 
   /** compose a [[PIso]] with a [[Getter]] */
-  @inline final def composeGetter[C](other: Getter[A, C]): Getter[S, C] =
-    asGetter composeGetter other
+  final def andThen[C](other: Getter[A, C]): Getter[S, C] =
+    asGetter.andThen(other)
 
   /** compose a [[PIso]] with a [[PSetter]] */
-  @inline final def composeSetter[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
-    asSetter composeSetter other
+  final def andThen[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
+    asSetter.andThen(other)
 
   /** compose a [[PIso]] with a [[PTraversal]] */
-  @inline final def composeTraversal[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
-    asTraversal composeTraversal other
+  final def andThen[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
+    asTraversal.andThen(other)
 
   /** compose a [[PIso]] with a [[POptional]] */
-  @inline final def composeOptional[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
-    asOptional composeOptional other
+  final def andThen[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
+    asOptional.andThen(other)
 
   /** compose a [[PIso]] with a [[PPrism]] */
-  @inline final def composePrism[C, D](other: PPrism[A, B, C, D]): PPrism[S, T, C, D] =
-    asPrism composePrism other
+  final def andThen[C, D](other: PPrism[A, B, C, D]): PPrism[S, T, C, D] =
+    asPrism.andThen(other)
 
   /** compose a [[PIso]] with a [[PLens]] */
-  @inline final def composeLens[C, D](other: PLens[A, B, C, D]): PLens[S, T, C, D] =
-    asLens composeLens other
+  final def andThen[C, D](other: PLens[A, B, C, D]): PLens[S, T, C, D] =
+    asLens.andThen(other)
 
-  /** compose a [[PIso]] with a [[PIso]] */
-  @inline final def composeIso[C, D](other: PIso[A, B, C, D]): PIso[S, T, C, D] =
+  /** compose a [[PIso]] with another [[PIso]] */
+  final def andThen[C, D](other: PIso[A, B, C, D]): PIso[S, T, C, D] =
     new PIso[S, T, C, D] { composeSelf =>
       def get(s: S): C =
         other.get(self.get(s))
@@ -168,6 +160,41 @@ abstract class PIso[S, T, A, B] extends Serializable { self =>
         }
     }
 
+  /** compose a [[PIso]] with a [[Fold]] */
+  @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
+    andThen(other)
+
+  /** Compose with a function lifted into a Getter */
+  @inline def to[C](f: A => C): Getter[S, C] = composeGetter(Getter(f))
+
+  /** compose a [[PIso]] with a [[Getter]] */
+  @inline final def composeGetter[C](other: Getter[A, C]): Getter[S, C] =
+    andThen(other)
+
+  /** compose a [[PIso]] with a [[PSetter]] */
+  @inline final def composeSetter[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PIso]] with a [[PTraversal]] */
+  @inline final def composeTraversal[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PIso]] with a [[POptional]] */
+  @inline final def composeOptional[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PIso]] with a [[PPrism]] */
+  @inline final def composePrism[C, D](other: PPrism[A, B, C, D]): PPrism[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PIso]] with a [[PLens]] */
+  @inline final def composeLens[C, D](other: PLens[A, B, C, D]): PLens[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PIso]] with a [[PIso]] */
+  @inline final def composeIso[C, D](other: PIso[A, B, C, D]): PIso[S, T, C, D] =
+    andThen(other)
+
   /** *****************************************
     */
   /** Experimental aliases of compose methods */
@@ -175,23 +202,23 @@ abstract class PIso[S, T, A, B] extends Serializable { self =>
     */
   /** alias to composeTraversal */
   @inline final def ^|->>[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
-    composeTraversal(other)
+    andThen(other)
 
   /** alias to composeOptional */
   @inline final def ^|-?[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
-    composeOptional(other)
+    andThen(other)
 
   /** alias to composePrism */
   @inline final def ^<-?[C, D](other: PPrism[A, B, C, D]): PPrism[S, T, C, D] =
-    composePrism(other)
+    andThen(other)
 
   /** alias to composeLens */
   @inline final def ^|->[C, D](other: PLens[A, B, C, D]): PLens[S, T, C, D] =
-    composeLens(other)
+    andThen(other)
 
   /** alias to composeIso */
   @inline final def ^<->[C, D](other: PIso[A, B, C, D]): PIso[S, T, C, D] =
-    composeIso(other)
+    andThen(other)
 
   /** *************************************************************
     */

--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -92,40 +92,32 @@ abstract class PLens[S, T, A, B] extends Serializable { self =>
   private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PLens[S, T, A1, B1] =
     evB.substituteCo[PLens[S, T, A1, *]](evA.substituteCo[PLens[S, T, *, B]](this))
 
-  /** ********************************************************
-    */
-  /** Compose methods between a [[PLens]] and another Optics */
-  /** ********************************************************
-    */
   /** compose a [[PLens]] with a [[Fold]] */
-  @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
-    asFold composeFold other
-
-  /** Compose with a function lifted into a Getter */
-  @inline def to[C](f: A => C): Getter[S, C] = composeGetter(Getter(f))
+  final def andThen[C](other: Fold[A, C]): Fold[S, C] =
+    asFold.andThen(other)
 
   /** compose a [[PLens]] with a [[Getter]] */
-  @inline final def composeGetter[C](other: Getter[A, C]): Getter[S, C] =
-    asGetter composeGetter other
+  final def andThen[C](other: Getter[A, C]): Getter[S, C] =
+    asGetter.andThen(other)
 
   /** compose a [[PLens]] with a [[PSetter]] */
-  @inline final def composeSetter[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
-    asSetter composeSetter other
+  final def andThen[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
+    asSetter.andThen(other)
 
   /** compose a [[PLens]] with a [[PTraversal]] */
-  @inline final def composeTraversal[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
-    asTraversal composeTraversal other
+  final def andThen[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
+    asTraversal.andThen(other)
 
   /** compose a [[PLens]] with an [[POptional]] */
-  @inline final def composeOptional[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
-    asOptional composeOptional other
+  final def andThen[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
+    asOptional.andThen(other)
 
   /** compose a [[PLens]] with a [[PPrism]] */
-  @inline final def composePrism[C, D](other: PPrism[A, B, C, D]): POptional[S, T, C, D] =
-    asOptional composeOptional other.asOptional
+  final def andThen[C, D](other: PPrism[A, B, C, D]): POptional[S, T, C, D] =
+    asOptional.andThen(other)
 
   /** compose a [[PLens]] with a [[PLens]] */
-  @inline final def composeLens[C, D](other: PLens[A, B, C, D]): PLens[S, T, C, D] =
+  final def andThen[C, D](other: PLens[A, B, C, D]): PLens[S, T, C, D] =
     new PLens[S, T, C, D] {
       def get(s: S): C =
         other.get(self.get(s))
@@ -141,8 +133,43 @@ abstract class PLens[S, T, A, B] extends Serializable { self =>
     }
 
   /** compose a [[PLens]] with an [[PIso]] */
+  @inline final def andThen[C, D](other: PIso[A, B, C, D]): PLens[S, T, C, D] =
+    andThen(other.asLens)
+
+  /** compose a [[PLens]] with a [[Fold]] */
+  @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
+    andThen(other)
+
+  /** Compose with a function lifted into a Getter */
+  @inline def to[C](f: A => C): Getter[S, C] = composeGetter(Getter(f))
+
+  /** compose a [[PLens]] with a [[Getter]] */
+  @inline final def composeGetter[C](other: Getter[A, C]): Getter[S, C] =
+    andThen(other)
+
+  /** compose a [[PLens]] with a [[PSetter]] */
+  @inline final def composeSetter[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PLens]] with a [[PTraversal]] */
+  @inline final def composeTraversal[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PLens]] with an [[POptional]] */
+  @inline final def composeOptional[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PLens]] with a [[PPrism]] */
+  @inline final def composePrism[C, D](other: PPrism[A, B, C, D]): POptional[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PLens]] with a [[PLens]] */
+  @inline final def composeLens[C, D](other: PLens[A, B, C, D]): PLens[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PLens]] with an [[PIso]] */
   @inline final def composeIso[C, D](other: PIso[A, B, C, D]): PLens[S, T, C, D] =
-    composeLens(other.asLens)
+    andThen(other)
 
   /** *****************************************
     */
@@ -151,23 +178,23 @@ abstract class PLens[S, T, A, B] extends Serializable { self =>
     */
   /** alias to composeTraversal */
   @inline final def ^|->>[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
-    composeTraversal(other)
+    andThen(other)
 
   /** alias to composeOptional */
   @inline final def ^|-?[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
-    composeOptional(other)
+    andThen(other)
 
   /** alias to composePrism */
   @inline final def ^<-?[C, D](other: PPrism[A, B, C, D]): POptional[S, T, C, D] =
-    composePrism(other)
+    andThen(other)
 
   /** alias to composeLens */
   @inline final def ^|->[C, D](other: PLens[A, B, C, D]): PLens[S, T, C, D] =
-    composeLens(other)
+    andThen(other)
 
   /** alias to composeIso */
   @inline final def ^<->[C, D](other: PIso[A, B, C, D]): PLens[S, T, C, D] =
-    composeIso(other)
+    andThen(other)
 
   /** *********************************************************************************************
     */

--- a/core/shared/src/main/scala/monocle/Optional.scala
+++ b/core/shared/src/main/scala/monocle/Optional.scala
@@ -154,7 +154,6 @@ abstract class POptional[S, T, A, B] extends Serializable { self =>
   @inline final def andThen[C, D](other: PIso[A, B, C, D]): POptional[S, T, C, D] =
     andThen(other.asOptional)
 
-
   /** compose a [[POptional]] with a [[Fold]] */
   @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
     andThen(other)

--- a/core/shared/src/main/scala/monocle/Optional.scala
+++ b/core/shared/src/main/scala/monocle/Optional.scala
@@ -105,32 +105,24 @@ abstract class POptional[S, T, A, B] extends Serializable { self =>
   private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): POptional[S, T, A1, B1] =
     evB.substituteCo[POptional[S, T, A1, *]](evA.substituteCo[POptional[S, T, *, B]](this))
 
-  /** ************************************************************
-    */
-  /** Compose methods between a [[POptional]] and another Optics */
-  /** ************************************************************
-    */
   /** compose a [[POptional]] with a [[Fold]] */
-  @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
-    asFold composeFold other
-
-  /** Compose with a function lifted into a Getter */
-  @inline def to[C](f: A => C): Fold[S, C] = composeGetter(Getter(f))
+  final def andThen[C](other: Fold[A, C]): Fold[S, C] =
+    asFold.andThen(other)
 
   /** compose a [[POptional]] with a [[Getter]] */
-  @inline final def composeGetter[C](other: Getter[A, C]): Fold[S, C] =
-    asFold composeGetter other
+  final def andThen[C](other: Getter[A, C]): Fold[S, C] =
+    asFold.andThen(other)
 
   /** compose a [[POptional]] with a [[PSetter]] */
-  @inline final def composeSetter[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
-    asSetter composeSetter other
+  final def andThen[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
+    asSetter.andThen(other)
 
   /** compose a [[POptional]] with a [[PTraversal]] */
-  @inline final def composeTraversal[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
-    asTraversal composeTraversal other
+  final def andThen[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
+    asTraversal.andThen(other)
 
   /** compose a [[POptional]] with a [[POptional]] */
-  @inline final def composeOptional[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
+  final def andThen[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
     new POptional[S, T, C, D] {
       def getOrModify(s: S): Either[T, C] =
         self
@@ -151,16 +143,52 @@ abstract class POptional[S, T, A, B] extends Serializable { self =>
     }
 
   /** compose a [[POptional]] with a [[PPrism]] */
+  final def andThen[C, D](other: PPrism[A, B, C, D]): POptional[S, T, C, D] =
+    andThen(other.asOptional)
+
+  /** compose a [[POptional]] with a [[PLens]] */
+  @inline final def andThen[C, D](other: PLens[A, B, C, D]): POptional[S, T, C, D] =
+    andThen(other.asOptional)
+
+  /** compose a [[POptional]] with a [[PIso]] */
+  @inline final def andThen[C, D](other: PIso[A, B, C, D]): POptional[S, T, C, D] =
+    andThen(other.asOptional)
+
+
+  /** compose a [[POptional]] with a [[Fold]] */
+  @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
+    andThen(other)
+
+  /** Compose with a function lifted into a Getter */
+  @inline def to[C](f: A => C): Fold[S, C] = composeGetter(Getter(f))
+
+  /** compose a [[POptional]] with a [[Getter]] */
+  @inline final def composeGetter[C](other: Getter[A, C]): Fold[S, C] =
+    andThen(other)
+
+  /** compose a [[POptional]] with a [[PSetter]] */
+  @inline final def composeSetter[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[POptional]] with a [[PTraversal]] */
+  @inline final def composeTraversal[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[POptional]] with a [[POptional]] */
+  @inline final def composeOptional[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[POptional]] with a [[PPrism]] */
   @inline final def composePrism[C, D](other: PPrism[A, B, C, D]): POptional[S, T, C, D] =
-    composeOptional(other.asOptional)
+    andThen(other)
 
   /** compose a [[POptional]] with a [[PLens]] */
   @inline final def composeLens[C, D](other: PLens[A, B, C, D]): POptional[S, T, C, D] =
-    composeOptional(other.asOptional)
+    andThen(other)
 
   /** compose a [[POptional]] with a [[PIso]] */
   @inline final def composeIso[C, D](other: PIso[A, B, C, D]): POptional[S, T, C, D] =
-    composeOptional(other.asOptional)
+    andThen(other)
 
   /** *****************************************
     */
@@ -169,23 +197,23 @@ abstract class POptional[S, T, A, B] extends Serializable { self =>
     */
   /** alias to composeTraversal */
   @inline final def ^|->>[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
-    composeTraversal(other)
+    andThen(other)
 
   /** alias to composeOptional */
   @inline final def ^|-?[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
-    composeOptional(other)
+    andThen(other)
 
   /** alias to composePrism */
   @inline final def ^<-?[C, D](other: PPrism[A, B, C, D]): POptional[S, T, C, D] =
-    composePrism(other)
+    andThen(other)
 
   /** alias to composeLens */
   @inline final def ^|->[C, D](other: PLens[A, B, C, D]): POptional[S, T, C, D] =
-    composeLens(other)
+    andThen(other)
 
   /** alias to composeIso */
   @inline final def ^<->[C, D](other: PIso[A, B, C, D]): POptional[S, T, C, D] =
-    composeIso(other)
+    andThen(other)
 
   /** ******************************************************************
     */

--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -124,40 +124,32 @@ abstract class PPrism[S, T, A, B] extends Serializable { self =>
   private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PPrism[S, T, A1, B1] =
     evB.substituteCo[PPrism[S, T, A1, *]](evA.substituteCo[PPrism[S, T, *, B]](this))
 
-  /** *********************************************************
-    */
-  /** Compose methods between a [[PPrism]] and another Optics */
-  /** *********************************************************
-    */
   /** compose a [[PPrism]] with a [[Fold]] */
-  @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
-    asFold composeFold other
-
-  /** Compose with a function lifted into a Getter */
-  @inline def to[C](f: A => C): Fold[S, C] = composeGetter(Getter(f))
+  final def andThen[C](other: Fold[A, C]): Fold[S, C] =
+    asFold.andThen(other)
 
   /** compose a [[PPrism]] with a [[Getter]] */
-  @inline final def composeGetter[C](other: Getter[A, C]): Fold[S, C] =
-    asFold composeGetter other
+  final def andThen[C](other: Getter[A, C]): Fold[S, C] =
+    asFold.andThen(other)
 
   /** compose a [[PPrism]] with a [[PSetter]] */
-  @inline final def composeSetter[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
-    asSetter composeSetter other
+  final def andThen[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
+    asSetter.andThen(other)
 
   /** compose a [[PPrism]] with a [[PTraversal]] */
-  @inline final def composeTraversal[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
-    asTraversal composeTraversal other
+  final def andThen[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
+    asTraversal.andThen(other)
 
   /** compose a [[PPrism]] with a [[POptional]] */
-  @inline final def composeOptional[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
-    asOptional composeOptional other
+  final def andThen[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
+    asOptional.andThen(other)
 
   /** compose a [[PPrism]] with a [[PLens]] */
-  @inline final def composeLens[C, D](other: PLens[A, B, C, D]): POptional[S, T, C, D] =
-    asOptional composeOptional other.asOptional
+  final def andThen[C, D](other: PLens[A, B, C, D]): POptional[S, T, C, D] =
+    asOptional.andThen(other.asOptional)
 
-  /** compose a [[PPrism]] with a [[PPrism]] */
-  @inline final def composePrism[C, D](other: PPrism[A, B, C, D]): PPrism[S, T, C, D] =
+  /** compose a [[PPrism]] with another [[PPrism]] */
+  final def andThen[C, D](other: PPrism[A, B, C, D]): PPrism[S, T, C, D] =
     new PPrism[S, T, C, D] {
       def getOrModify(s: S): Either[T, C] =
         self
@@ -172,8 +164,44 @@ abstract class PPrism[S, T, A, B] extends Serializable { self =>
     }
 
   /** compose a [[PPrism]] with a [[PIso]] */
+  final def andThen[C, D](other: PIso[A, B, C, D]): PPrism[S, T, C, D] =
+    andThen(other.asPrism)
+
+
+  /** compose a [[PPrism]] with a [[Fold]] */
+  @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
+    andThen(other)
+
+  /** Compose with a function lifted into a Getter */
+  @inline def to[C](f: A => C): Fold[S, C] = composeGetter(Getter(f))
+
+  /** compose a [[PPrism]] with a [[Getter]] */
+  @inline final def composeGetter[C](other: Getter[A, C]): Fold[S, C] =
+    andThen(other)
+
+  /** compose a [[PPrism]] with a [[PSetter]] */
+  @inline final def composeSetter[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PPrism]] with a [[PTraversal]] */
+  @inline final def composeTraversal[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PPrism]] with a [[POptional]] */
+  @inline final def composeOptional[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PPrism]] with a [[PLens]] */
+  @inline final def composeLens[C, D](other: PLens[A, B, C, D]): POptional[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PPrism]] with a [[PPrism]] */
+  @inline final def composePrism[C, D](other: PPrism[A, B, C, D]): PPrism[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PPrism]] with a [[PIso]] */
   @inline final def composeIso[C, D](other: PIso[A, B, C, D]): PPrism[S, T, C, D] =
-    composePrism(other.asPrism)
+    andThen(other)
 
   /** *****************************************
     */
@@ -182,23 +210,23 @@ abstract class PPrism[S, T, A, B] extends Serializable { self =>
     */
   /** alias to composeTraversal */
   @inline final def ^|->>[C, D](other: PTraversal[A, B, C, D]): PTraversal[S, T, C, D] =
-    composeTraversal(other)
+    andThen(other)
 
   /** alias to composeOptional */
   @inline final def ^|-?[C, D](other: POptional[A, B, C, D]): POptional[S, T, C, D] =
-    composeOptional(other)
+    andThen(other)
 
   /** alias to composePrism */
   @inline final def ^<-?[C, D](other: PPrism[A, B, C, D]): PPrism[S, T, C, D] =
-    composePrism(other)
+    andThen(other)
 
   /** alias to composeLens */
   @inline final def ^|->[C, D](other: PLens[A, B, C, D]): POptional[S, T, C, D] =
-    composeLens(other)
+    andThen(other)
 
   /** alias to composeIso */
   @inline final def ^<->[C, D](other: PIso[A, B, C, D]): PPrism[S, T, C, D] =
-    composeIso(other)
+    andThen(other)
 
   /** ***************************************************************
     */

--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -167,7 +167,6 @@ abstract class PPrism[S, T, A, B] extends Serializable { self =>
   final def andThen[C, D](other: PIso[A, B, C, D]): PPrism[S, T, C, D] =
     andThen(other.asPrism)
 
-
   /** compose a [[PPrism]] with a [[Fold]] */
   @inline final def composeFold[C](other: Fold[A, C]): Fold[S, C] =
     andThen(other)

--- a/core/shared/src/main/scala/monocle/Setter.scala
+++ b/core/shared/src/main/scala/monocle/Setter.scala
@@ -44,13 +44,8 @@ abstract class PSetter[S, T, A, B] extends Serializable { self =>
   private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PSetter[S, T, A1, B1] =
     evB.substituteCo[PSetter[S, T, A1, *]](evA.substituteCo[PSetter[S, T, *, B]](this))
 
-  /** **********************************************************
-    */
-  /** Compose methods between a [[PSetter]] and another Optics */
-  /** **********************************************************
-    */
-  /** compose a [[PSetter]] with a [[PSetter]] */
-  @inline final def composeSetter[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
+  /** compose a [[PSetter]] with another [[PSetter]] */
+  final def andThen[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
     new PSetter[S, T, C, D] {
       def modify(f: C => D): S => T =
         self.modify(other.modify(f))
@@ -60,24 +55,48 @@ abstract class PSetter[S, T, A, B] extends Serializable { self =>
     }
 
   /** compose a [[PSetter]] with a [[PTraversal]] */
+  final def andThen[C, D](other: PTraversal[A, B, C, D]): PSetter[S, T, C, D] =
+    andThen(other.asSetter)
+
+  /** compose a [[PSetter]] with a [[POptional]] */
+  final def andThen[C, D](other: POptional[A, B, C, D]): PSetter[S, T, C, D] =
+    andThen(other.asSetter)
+
+  /** compose a [[PSetter]] with a [[PPrism]] */
+  final def andThen[C, D](other: PPrism[A, B, C, D]): PSetter[S, T, C, D] =
+    andThen(other.asSetter)
+
+  /** compose a [[PSetter]] with a [[PLens]] */
+  final def andThen[C, D](other: PLens[A, B, C, D]): PSetter[S, T, C, D] =
+    andThen(other.asSetter)
+
+  /** compose a [[PSetter]] with a [[PIso]] */
+  final def andThen[C, D](other: PIso[A, B, C, D]): PSetter[S, T, C, D] =
+    andThen(other.asSetter)
+
+  /** compose a [[PSetter]] with a [[PSetter]] */
+  @inline final def composeSetter[C, D](other: PSetter[A, B, C, D]): PSetter[S, T, C, D] =
+    andThen(other)
+
+  /** compose a [[PSetter]] with a [[PTraversal]] */
   @inline final def composeTraversal[C, D](other: PTraversal[A, B, C, D]): PSetter[S, T, C, D] =
-    composeSetter(other.asSetter)
+    andThen(other)
 
   /** compose a [[PSetter]] with a [[POptional]] */
   @inline final def composeOptional[C, D](other: POptional[A, B, C, D]): PSetter[S, T, C, D] =
-    composeSetter(other.asSetter)
+    andThen(other)
 
   /** compose a [[PSetter]] with a [[PPrism]] */
   @inline final def composePrism[C, D](other: PPrism[A, B, C, D]): PSetter[S, T, C, D] =
-    composeSetter(other.asSetter)
+    andThen(other)
 
   /** compose a [[PSetter]] with a [[PLens]] */
   @inline final def composeLens[C, D](other: PLens[A, B, C, D]): PSetter[S, T, C, D] =
-    composeSetter(other.asSetter)
+    andThen(other)
 
   /** compose a [[PSetter]] with a [[PIso]] */
   @inline final def composeIso[C, D](other: PIso[A, B, C, D]): PSetter[S, T, C, D] =
-    composeSetter(other.asSetter)
+    andThen(other)
 
   /** *****************************************
     */
@@ -86,23 +105,23 @@ abstract class PSetter[S, T, A, B] extends Serializable { self =>
     */
   /** alias to composeTraversal */
   @inline final def ^|->>[C, D](other: PTraversal[A, B, C, D]): PSetter[S, T, C, D] =
-    composeTraversal(other)
+    andThen(other)
 
   /** alias to composeOptional */
   @inline final def ^|-?[C, D](other: POptional[A, B, C, D]): PSetter[S, T, C, D] =
-    composeOptional(other)
+    andThen(other)
 
   /** alias to composePrism */
   @inline final def ^<-?[C, D](other: PPrism[A, B, C, D]): PSetter[S, T, C, D] =
-    composePrism(other)
+    andThen(other)
 
   /** alias to composeLens */
   @inline final def ^|->[C, D](other: PLens[A, B, C, D]): PSetter[S, T, C, D] =
-    composeLens(other)
+    andThen(other)
 
   /** alias to composeIso */
   @inline final def ^<->[C, D](other: PIso[A, B, C, D]): PSetter[S, T, C, D] =
-    composeIso(other)
+    andThen(other)
 }
 
 object PSetter extends SetterInstances {

--- a/core/shared/src/main/scala/monocle/syntax/ApplyFold.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyFold.scala
@@ -44,22 +44,26 @@ case class ApplyFold[S, A](s: S, _fold: Fold[S, A]) {
   def andThen[B, C, D](other: PIso[A, B, C, D]): ApplyFold[S, C] =
     ApplyFold(s, _fold.andThen(other))
 
-  @inline def composeFold[B](other: Fold[A, B]): ApplyFold[S, B] = andThen(other)
-  @inline def composeGetter[B](other: Getter[A, B]): ApplyFold[S, B] = andThen(other)
+  @inline def composeFold[B](other: Fold[A, B]): ApplyFold[S, B]                        = andThen(other)
+  @inline def composeGetter[B](other: Getter[A, B]): ApplyFold[S, B]                    = andThen(other)
   @inline def composeTraversal[B, C, D](other: PTraversal[A, B, C, D]): ApplyFold[S, C] = andThen(other)
-  @inline def composeOptional[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C] = andThen(other)
-  @inline def composePrism[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C] = andThen(other)
-  @inline def composeLens[B, C, D](other: PLens[A, B, C, D]): ApplyFold[S, C] = andThen(other)
-  @inline def composeIso[B, C, D](other: PIso[A, B, C, D]): ApplyFold[S, C] = andThen(other)
+  @inline def composeOptional[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C]   = andThen(other)
+  @inline def composePrism[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C]         = andThen(other)
+  @inline def composeLens[B, C, D](other: PLens[A, B, C, D]): ApplyFold[S, C]           = andThen(other)
+  @inline def composeIso[B, C, D](other: PIso[A, B, C, D]): ApplyFold[S, C]             = andThen(other)
 
   /** alias to composeTraversal */
   @inline def ^|->>[B, C, D](other: PTraversal[A, B, C, D]): ApplyFold[S, C] = andThen(other)
+
   /** alias to composeOptional */
   @inline def ^|-?[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C] = andThen(other)
+
   /** alias to composePrism */
   @inline def ^<-?[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C] = andThen(other)
+
   /** alias to composeLens */
   @inline def ^|->[B, C, D](other: PLens[A, B, C, D]): ApplyFold[S, C] = andThen(other)
+
   /** alias to composeIso */
   @inline def ^<->[B, C, D](other: PIso[A, B, C, D]): ApplyFold[S, C] = andThen(other)
 }

--- a/core/shared/src/main/scala/monocle/syntax/ApplyFold.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyFold.scala
@@ -29,38 +29,37 @@ case class ApplyFold[S, A](s: S, _fold: Fold[S, A]) {
   private def adapt[A1](implicit evA: A =:= A1): ApplyFold[S, A1] =
     evA.substituteCo[ApplyFold[S, *]](this)
 
-  @inline def composeFold[B](other: Fold[A, B]): ApplyFold[S, B] =
-    ApplyFold(s, _fold composeFold other)
-  @inline def composeGetter[B](other: Getter[A, B]): ApplyFold[S, B] =
-    ApplyFold(s, _fold composeGetter other)
-  @inline def composeTraversal[B, C, D](other: PTraversal[A, B, C, D]): ApplyFold[S, C] =
-    ApplyFold(s, _fold composeTraversal other)
-  @inline def composeOptional[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C] =
-    ApplyFold(s, _fold composeOptional other)
-  @inline def composePrism[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C] =
-    ApplyFold(s, _fold composePrism other)
-  @inline def composeLens[B, C, D](other: PLens[A, B, C, D]): ApplyFold[S, C] =
-    ApplyFold(s, _fold composeLens other)
-  @inline def composeIso[B, C, D](other: PIso[A, B, C, D]): ApplyFold[S, C] =
-    ApplyFold(s, _fold composeIso other)
+  def andThen[B](other: Fold[A, B]): ApplyFold[S, B] =
+    ApplyFold(s, _fold.andThen(other))
+  def andThen[B](other: Getter[A, B]): ApplyFold[S, B] =
+    ApplyFold(s, _fold.andThen(other))
+  def andThen[B, C, D](other: PTraversal[A, B, C, D]): ApplyFold[S, C] =
+    ApplyFold(s, _fold.andThen(other))
+  def andThen[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C] =
+    ApplyFold(s, _fold.andThen(other))
+  def andThen[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C] =
+    ApplyFold(s, _fold.andThen(other))
+  def andThen[B, C, D](other: PLens[A, B, C, D]): ApplyFold[S, C] =
+    ApplyFold(s, _fold.andThen(other))
+  def andThen[B, C, D](other: PIso[A, B, C, D]): ApplyFold[S, C] =
+    ApplyFold(s, _fold.andThen(other))
+
+  @inline def composeFold[B](other: Fold[A, B]): ApplyFold[S, B] = andThen(other)
+  @inline def composeGetter[B](other: Getter[A, B]): ApplyFold[S, B] = andThen(other)
+  @inline def composeTraversal[B, C, D](other: PTraversal[A, B, C, D]): ApplyFold[S, C] = andThen(other)
+  @inline def composeOptional[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C] = andThen(other)
+  @inline def composePrism[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C] = andThen(other)
+  @inline def composeLens[B, C, D](other: PLens[A, B, C, D]): ApplyFold[S, C] = andThen(other)
+  @inline def composeIso[B, C, D](other: PIso[A, B, C, D]): ApplyFold[S, C] = andThen(other)
 
   /** alias to composeTraversal */
-  @inline def ^|->>[B, C, D](other: PTraversal[A, B, C, D]): ApplyFold[S, C] =
-    composeTraversal(other)
-
+  @inline def ^|->>[B, C, D](other: PTraversal[A, B, C, D]): ApplyFold[S, C] = andThen(other)
   /** alias to composeOptional */
-  @inline def ^|-?[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C] =
-    composeOptional(other)
-
+  @inline def ^|-?[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C] = andThen(other)
   /** alias to composePrism */
-  @inline def ^<-?[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C] =
-    composePrism(other)
-
+  @inline def ^<-?[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C] = andThen(other)
   /** alias to composeLens */
-  @inline def ^|->[B, C, D](other: PLens[A, B, C, D]): ApplyFold[S, C] =
-    composeLens(other)
-
+  @inline def ^|->[B, C, D](other: PLens[A, B, C, D]): ApplyFold[S, C] = andThen(other)
   /** alias to composeIso */
-  @inline def ^<->[B, C, D](other: PIso[A, B, C, D]): ApplyFold[S, C] =
-    composeIso(other)
+  @inline def ^<->[B, C, D](other: PIso[A, B, C, D]): ApplyFold[S, C] = andThen(other)
 }

--- a/core/shared/src/main/scala/monocle/syntax/ApplyGetter.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyGetter.scala
@@ -21,26 +21,31 @@ final case class ApplyGetter[S, A](s: S, getter: Getter[S, A]) {
   private def adapt[A1](implicit evA: A =:= A1): ApplyGetter[S, A1] =
     evA.substituteCo[ApplyGetter[S, *]](this)
 
-  @inline def composeFold[B](other: Fold[A, B]): ApplyFold[S, B] =
-    ApplyFold(s, getter composeFold other)
-  @inline def composeGetter[B](other: Getter[A, B]): ApplyGetter[S, B] =
-    ApplyGetter(s, getter composeGetter other)
-  @inline def composeTraversal[B, C, D](other: PTraversal[A, B, C, D]): ApplyFold[S, C] =
-    ApplyFold(s, getter composeTraversal other)
-  @inline def composeOptional[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C] =
-    ApplyFold(s, getter composeOptional other)
-  @inline def composePrism[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C] =
-    ApplyFold(s, getter composePrism other)
-  @inline def composeLens[B, C, D](other: PLens[A, B, C, D]): ApplyGetter[S, C] =
-    ApplyGetter(s, getter composeLens other)
-  @inline def composeIso[B, C, D](other: PIso[A, B, C, D]): ApplyGetter[S, C] =
-    ApplyGetter(s, getter composeIso other)
+  def andThen[B](other: Fold[A, B]): ApplyFold[S, B] =
+    ApplyFold(s, getter.andThen(other))
+  def andThen[B](other: Getter[A, B]): ApplyGetter[S, B] =
+    ApplyGetter(s, getter.andThen(other))
+  def andThen[B, C, D](other: PTraversal[A, B, C, D]): ApplyFold[S, C] =
+    ApplyFold(s, getter.andThen(other))
+  def andThen[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C] =
+    ApplyFold(s, getter.andThen(other))
+  def andThen[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C] =
+    ApplyFold(s, getter.andThen(other))
+  def andThen[B, C, D](other: PLens[A, B, C, D]): ApplyGetter[S, C] =
+    ApplyGetter(s, getter.andThen(other))
+  def andThen[B, C, D](other: PIso[A, B, C, D]): ApplyGetter[S, C] =
+    ApplyGetter(s, getter.andThen(other))
+
+  @inline def composeFold[B](other: Fold[A, B]): ApplyFold[S, B] = andThen(other)
+  @inline def composeGetter[B](other: Getter[A, B]): ApplyGetter[S, B] = andThen(other)
+  @inline def composeTraversal[B, C, D](other: PTraversal[A, B, C, D]): ApplyFold[S, C] = andThen(other)
+  @inline def composeOptional[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C] = andThen(other)
+  @inline def composePrism[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C] = andThen(other)
+  @inline def composeLens[B, C, D](other: PLens[A, B, C, D]): ApplyGetter[S, C] = andThen(other)
+  @inline def composeIso[B, C, D](other: PIso[A, B, C, D]): ApplyGetter[S, C] = andThen(other)
 
   /** alias to composeLens */
-  @inline def ^|->[B, C, D](other: PLens[A, B, C, D]): ApplyGetter[S, C] =
-    composeLens(other)
-
+  @inline def ^|->[B, C, D](other: PLens[A, B, C, D]): ApplyGetter[S, C] = andThen(other)
   /** alias to composeIso */
-  @inline def ^<->[B, C, D](other: PIso[A, B, C, D]): ApplyGetter[S, C] =
-    composeIso(other)
+  @inline def ^<->[B, C, D](other: PIso[A, B, C, D]): ApplyGetter[S, C] = andThen(other)
 }

--- a/core/shared/src/main/scala/monocle/syntax/ApplyGetter.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyGetter.scala
@@ -36,16 +36,17 @@ final case class ApplyGetter[S, A](s: S, getter: Getter[S, A]) {
   def andThen[B, C, D](other: PIso[A, B, C, D]): ApplyGetter[S, C] =
     ApplyGetter(s, getter.andThen(other))
 
-  @inline def composeFold[B](other: Fold[A, B]): ApplyFold[S, B] = andThen(other)
-  @inline def composeGetter[B](other: Getter[A, B]): ApplyGetter[S, B] = andThen(other)
+  @inline def composeFold[B](other: Fold[A, B]): ApplyFold[S, B]                        = andThen(other)
+  @inline def composeGetter[B](other: Getter[A, B]): ApplyGetter[S, B]                  = andThen(other)
   @inline def composeTraversal[B, C, D](other: PTraversal[A, B, C, D]): ApplyFold[S, C] = andThen(other)
-  @inline def composeOptional[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C] = andThen(other)
-  @inline def composePrism[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C] = andThen(other)
-  @inline def composeLens[B, C, D](other: PLens[A, B, C, D]): ApplyGetter[S, C] = andThen(other)
-  @inline def composeIso[B, C, D](other: PIso[A, B, C, D]): ApplyGetter[S, C] = andThen(other)
+  @inline def composeOptional[B, C, D](other: POptional[A, B, C, D]): ApplyFold[S, C]   = andThen(other)
+  @inline def composePrism[B, C, D](other: PPrism[A, B, C, D]): ApplyFold[S, C]         = andThen(other)
+  @inline def composeLens[B, C, D](other: PLens[A, B, C, D]): ApplyGetter[S, C]         = andThen(other)
+  @inline def composeIso[B, C, D](other: PIso[A, B, C, D]): ApplyGetter[S, C]           = andThen(other)
 
   /** alias to composeLens */
   @inline def ^|->[B, C, D](other: PLens[A, B, C, D]): ApplyGetter[S, C] = andThen(other)
+
   /** alias to composeIso */
   @inline def ^<->[B, C, D](other: PIso[A, B, C, D]): ApplyGetter[S, C] = andThen(other)
 }

--- a/core/shared/src/main/scala/monocle/syntax/ApplyIso.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyIso.scala
@@ -35,23 +35,27 @@ final case class ApplyIso[S, T, A, B](s: S, iso: PIso[S, T, A, B]) {
   def andThen[C, D](other: PIso[A, B, C, D]): ApplyIso[S, T, C, D] =
     ApplyIso(s, iso composeIso other)
 
-  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
-  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] =  andThen(other)
-  @inline def composeGetter[C](other: Getter[A, C]): ApplyGetter[S, C] =  andThen(other)
-  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =  andThen(other)
-  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =  andThen(other)
-  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] =  andThen(other)
-  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] =  andThen(other)
-  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyIso[S, T, C, D] = andThen(other)
+  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D]          = andThen(other)
+  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C]                                = andThen(other)
+  @inline def composeGetter[C](other: Getter[A, C]): ApplyGetter[S, C]                          = andThen(other)
+  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D]    = andThen(other)
+  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D]             = andThen(other)
+  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D]                = andThen(other)
+  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyIso[S, T, C, D]                   = andThen(other)
 
   /** alias to composeTraversal */
   @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+
   /** alias to composeOptional */
-  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =  andThen(other)
+  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+
   /** alias to composePrism */
   @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] = andThen(other)
+
   /** alias to composeLens */
   @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] = andThen(other)
+
   /** alias to composeIso */
   @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyIso[S, T, C, D] = andThen(other)
 }

--- a/core/shared/src/main/scala/monocle/syntax/ApplyIso.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyIso.scala
@@ -18,42 +18,42 @@ final case class ApplyIso[S, T, A, B](s: S, iso: PIso[S, T, A, B]) {
   private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): ApplyIso[S, T, A1, B1] =
     evB.substituteCo[ApplyIso[S, T, A1, *]](evA.substituteCo[ApplyIso[S, T, *, B]](this))
 
-  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] =
+  def andThen[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] =
     ApplySetter(s, iso composeSetter other)
-  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] =
+  def andThen[C](other: Fold[A, C]): ApplyFold[S, C] =
     ApplyFold(s, iso composeFold other)
-  @inline def composeGetter[C](other: Getter[A, C]): ApplyGetter[S, C] =
+  def andThen[C](other: Getter[A, C]): ApplyGetter[S, C] =
     ApplyGetter(s, iso composeGetter other)
-  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
+  def andThen[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
     ApplyTraversal(s, iso composeTraversal other)
-  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =
+  def andThen[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =
     ApplyOptional(s, iso composeOptional other)
-  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] =
+  def andThen[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] =
     ApplyPrism(s, iso composePrism other)
-  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] =
+  def andThen[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] =
     ApplyLens(s, iso composeLens other)
-  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyIso[S, T, C, D] =
+  def andThen[C, D](other: PIso[A, B, C, D]): ApplyIso[S, T, C, D] =
     ApplyIso(s, iso composeIso other)
 
+  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] =  andThen(other)
+  @inline def composeGetter[C](other: Getter[A, C]): ApplyGetter[S, C] =  andThen(other)
+  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =  andThen(other)
+  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =  andThen(other)
+  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] =  andThen(other)
+  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] =  andThen(other)
+  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyIso[S, T, C, D] = andThen(other)
+
   /** alias to composeTraversal */
-  @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    composeTraversal(other)
-
+  @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
   /** alias to composeOptional */
-  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    composeOptional(other)
-
+  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =  andThen(other)
   /** alias to composePrism */
-  @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] =
-    composePrism(other)
-
+  @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] = andThen(other)
   /** alias to composeLens */
-  @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] =
-    composeLens(other)
-
+  @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] = andThen(other)
   /** alias to composeIso */
-  @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyIso[S, T, C, D] =
-    composeIso(other)
+  @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyIso[S, T, C, D] = andThen(other)
 }
 
 object ApplyIso {

--- a/core/shared/src/main/scala/monocle/syntax/ApplyLens.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyLens.scala
@@ -35,23 +35,27 @@ final case class ApplyLens[S, T, A, B](s: S, lens: PLens[S, T, A, B]) {
   def andThen[C, D](other: PIso[A, B, C, D]): ApplyLens[S, T, C, D] =
     ApplyLens(s, lens.andThen(other))
 
-  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
-  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] = andThen(other)
-  @inline def composeGetter[C](other: Getter[A, C]): ApplyGetter[S, C] = andThen(other)
+  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D]          = andThen(other)
+  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C]                                = andThen(other)
+  @inline def composeGetter[C](other: Getter[A, C]): ApplyGetter[S, C]                          = andThen(other)
   @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
-  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
-  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
-  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] = andThen(other)
-  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyLens[S, T, C, D] = andThen(other)
+  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D]    = andThen(other)
+  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D]          = andThen(other)
+  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D]                = andThen(other)
+  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyLens[S, T, C, D]                  = andThen(other)
 
   /** alias to composeTraversal */
   @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+
   /** alias to composeOptional */
   @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+
   /** alias to composePrism */
   @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+
   /** alias to composeLens */
   @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] = andThen(other)
+
   /** alias to composeIso */
   @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyLens[S, T, C, D] = andThen(other)
 }

--- a/core/shared/src/main/scala/monocle/syntax/ApplyLens.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyLens.scala
@@ -18,42 +18,42 @@ final case class ApplyLens[S, T, A, B](s: S, lens: PLens[S, T, A, B]) {
   private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): ApplyLens[S, T, A1, B1] =
     evB.substituteCo[ApplyLens[S, T, A1, *]](evA.substituteCo[ApplyLens[S, T, *, B]](this))
 
-  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] =
-    ApplySetter(s, lens composeSetter other)
-  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] =
-    ApplyFold(s, lens composeFold other)
-  @inline def composeGetter[C](other: Getter[A, C]): ApplyGetter[S, C] =
-    ApplyGetter(s, lens composeGetter other)
-  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    ApplyTraversal(s, lens composeTraversal other)
-  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    ApplyOptional(s, lens composeOptional other)
-  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    ApplyOptional(s, lens composePrism other)
-  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] =
-    ApplyLens(s, lens composeLens other)
-  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyLens[S, T, C, D] =
-    ApplyLens(s, lens composeIso other)
+  def andThen[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] =
+    ApplySetter(s, lens.andThen(other))
+  def andThen[C](other: Fold[A, C]): ApplyFold[S, C] =
+    ApplyFold(s, lens.andThen(other))
+  def andThen[C](other: Getter[A, C]): ApplyGetter[S, C] =
+    ApplyGetter(s, lens.andThen(other))
+  def andThen[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
+    ApplyTraversal(s, lens.andThen(other))
+  def andThen[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =
+    ApplyOptional(s, lens.andThen(other))
+  def andThen[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] =
+    ApplyOptional(s, lens.andThen(other))
+  def andThen[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] =
+    ApplyLens(s, lens.andThen(other))
+  def andThen[C, D](other: PIso[A, B, C, D]): ApplyLens[S, T, C, D] =
+    ApplyLens(s, lens.andThen(other))
+
+  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] = andThen(other)
+  @inline def composeGetter[C](other: Getter[A, C]): ApplyGetter[S, C] = andThen(other)
+  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] = andThen(other)
+  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyLens[S, T, C, D] = andThen(other)
 
   /** alias to composeTraversal */
-  @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    composeTraversal(other)
-
+  @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
   /** alias to composeOptional */
-  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    composeOptional(other)
-
+  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
   /** alias to composePrism */
-  @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    composePrism(other)
-
+  @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
   /** alias to composeLens */
-  @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] =
-    composeLens(other)
-
+  @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyLens[S, T, C, D] = andThen(other)
   /** alias to composeIso */
-  @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyLens[S, T, C, D] =
-    composeIso(other)
+  @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyLens[S, T, C, D] = andThen(other)
 }
 
 object ApplyLens {

--- a/core/shared/src/main/scala/monocle/syntax/ApplyOptional.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyOptional.scala
@@ -28,40 +28,39 @@ final case class ApplyOptional[S, T, A, B](s: S, optional: POptional[S, T, A, B]
   private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): ApplyOptional[S, T, A1, B1] =
     evB.substituteCo[ApplyOptional[S, T, A1, *]](evA.substituteCo[ApplyOptional[S, T, *, B]](this))
 
-  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] =
-    ApplySetter(s, optional composeSetter other)
-  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] =
-    ApplyFold(s, optional composeFold other)
-  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    ApplyTraversal(s, optional composeTraversal other)
-  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    ApplyOptional(s, optional composeOptional other)
-  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    ApplyOptional(s, optional composePrism other)
-  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    ApplyOptional(s, optional composeLens other)
-  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    ApplyOptional(s, optional composeIso other)
+  def andThen[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] =
+    ApplySetter(s, optional.andThen(other))
+  def andThen[C](other: Fold[A, C]): ApplyFold[S, C] =
+    ApplyFold(s, optional.andThen(other))
+  def andThen[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
+    ApplyTraversal(s, optional.andThen(other))
+  def andThen[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =
+    ApplyOptional(s, optional.andThen(other))
+  def andThen[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] =
+    ApplyOptional(s, optional.andThen(other))
+  def andThen[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] =
+    ApplyOptional(s, optional.andThen(other))
+  def andThen[C, D](other: PIso[A, B, C, D]): ApplyOptional[S, T, C, D] =
+    ApplyOptional(s, optional.andThen(other))
+
+  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] = andThen(other)
+  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
 
   /** alias to composeTraversal */
-  @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    composeTraversal(other)
-
+  @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
   /** alias to composeOptional */
-  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    composeOptional(other)
-
+  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
   /** alias to composePrism */
-  @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    composePrism(other)
-
+  @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
   /** alias to composeLens */
-  @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    composeLens(other)
-
+  @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
   /** alias to composeIso */
-  @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    composeIso(other)
+  @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
 }
 
 object ApplyOptional {

--- a/core/shared/src/main/scala/monocle/syntax/ApplyOptional.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyOptional.scala
@@ -43,22 +43,26 @@ final case class ApplyOptional[S, T, A, B](s: S, optional: POptional[S, T, A, B]
   def andThen[C, D](other: PIso[A, B, C, D]): ApplyOptional[S, T, C, D] =
     ApplyOptional(s, optional.andThen(other))
 
-  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
-  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] = andThen(other)
+  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D]          = andThen(other)
+  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C]                                = andThen(other)
   @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
-  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
-  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
-  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
-  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D]    = andThen(other)
+  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D]          = andThen(other)
+  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D]            = andThen(other)
+  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyOptional[S, T, C, D]              = andThen(other)
 
   /** alias to composeTraversal */
   @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+
   /** alias to composeOptional */
   @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+
   /** alias to composePrism */
   @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+
   /** alias to composeLens */
   @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+
   /** alias to composeIso */
   @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
 }

--- a/core/shared/src/main/scala/monocle/syntax/ApplyPrism.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyPrism.scala
@@ -41,22 +41,26 @@ final case class ApplyPrism[S, T, A, B](s: S, prism: PPrism[S, T, A, B]) {
   def andThen[C, D](other: PIso[A, B, C, D]): ApplyPrism[S, T, C, D] =
     ApplyPrism(s, prism.andThen(other))
 
-  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
-  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] = andThen(other)
+  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D]          = andThen(other)
+  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C]                                = andThen(other)
   @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
-  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
-  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
-  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] = andThen(other)
-  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyPrism[S, T, C, D] = andThen(other)
+  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D]    = andThen(other)
+  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D]            = andThen(other)
+  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D]             = andThen(other)
+  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyPrism[S, T, C, D]                 = andThen(other)
 
   /** alias to composeTraversal */
   @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+
   /** alias to composeOptional */
   @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+
   /** alias to composePrism */
   @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] = andThen(other)
+
   /** alias to composeLens */
   @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+
   /** alias to composeIso */
   @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyPrism[S, T, C, D] = andThen(other)
 }

--- a/core/shared/src/main/scala/monocle/syntax/ApplyPrism.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyPrism.scala
@@ -26,40 +26,39 @@ final case class ApplyPrism[S, T, A, B](s: S, prism: PPrism[S, T, A, B]) {
   private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): ApplyPrism[S, T, A1, B1] =
     evB.substituteCo[ApplyPrism[S, T, A1, *]](evA.substituteCo[ApplyPrism[S, T, *, B]](this))
 
-  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] =
-    ApplySetter(s, prism composeSetter other)
-  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] =
-    ApplyFold(s, prism composeFold other)
-  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    ApplyTraversal(s, prism composeTraversal other)
-  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    ApplyOptional(s, prism composeOptional other)
-  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    ApplyOptional(s, prism composeLens other)
-  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] =
-    ApplyPrism(s, prism composePrism other)
-  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyPrism[S, T, C, D] =
-    ApplyPrism(s, prism composeIso other)
+  def andThen[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] =
+    ApplySetter(s, prism.andThen(other))
+  def andThen[C](other: Fold[A, C]): ApplyFold[S, C] =
+    ApplyFold(s, prism.andThen(other))
+  def andThen[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
+    ApplyTraversal(s, prism.andThen(other))
+  def andThen[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =
+    ApplyOptional(s, prism.andThen(other))
+  def andThen[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] =
+    ApplyOptional(s, prism.andThen(other))
+  def andThen[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] =
+    ApplyPrism(s, prism.andThen(other))
+  def andThen[C, D](other: PIso[A, B, C, D]): ApplyPrism[S, T, C, D] =
+    ApplyPrism(s, prism.andThen(other))
+
+  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] = andThen(other)
+  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
+  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] = andThen(other)
+  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyPrism[S, T, C, D] = andThen(other)
 
   /** alias to composeTraversal */
-  @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    composeTraversal(other)
-
+  @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
   /** alias to composeOptional */
-  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    composeOptional(other)
-
+  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
   /** alias to composePrism */
-  @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] =
-    composePrism(other)
-
+  @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyPrism[S, T, C, D] = andThen(other)
   /** alias to composeLens */
-  @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] =
-    composeLens(other)
-
+  @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyOptional[S, T, C, D] = andThen(other)
   /** alias to composeIso */
-  @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyPrism[S, T, C, D] =
-    composeIso(other)
+  @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyPrism[S, T, C, D] = andThen(other)
 }
 
 object ApplyPrism {

--- a/core/shared/src/main/scala/monocle/syntax/ApplySetter.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplySetter.scala
@@ -27,21 +27,25 @@ final case class ApplySetter[S, T, A, B](s: S, setter: PSetter[S, T, A, B]) {
   def andThen[C, D](other: PIso[A, B, C, D]): ApplySetter[S, T, C, D] =
     ApplySetter(s, setter.andThen(other))
 
-  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D]       = andThen(other)
   @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
-  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
-  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
-  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
-  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplySetter[S, T, C, D]   = andThen(other)
+  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplySetter[S, T, C, D]         = andThen(other)
+  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplySetter[S, T, C, D]           = andThen(other)
+  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplySetter[S, T, C, D]             = andThen(other)
 
   /** alias to composeTraversal */
   @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+
   /** alias to composeOptional */
   @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+
   /** alias to composePrism */
   @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+
   /** alias to composeLens */
   @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+
   /** alias to composeIso */
   @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
 }

--- a/core/shared/src/main/scala/monocle/syntax/ApplySetter.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplySetter.scala
@@ -14,38 +14,36 @@ final case class ApplySetter[S, T, A, B](s: S, setter: PSetter[S, T, A, B]) {
   private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): ApplySetter[S, T, A1, B1] =
     evB.substituteCo[ApplySetter[S, T, A1, *]](evA.substituteCo[ApplySetter[S, T, *, B]](this))
 
-  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] =
-    ApplySetter(s, setter composeSetter other)
-  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplySetter[S, T, C, D] =
-    ApplySetter(s, setter composeTraversal other)
-  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplySetter[S, T, C, D] =
-    ApplySetter(s, setter composeOptional other)
-  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplySetter[S, T, C, D] =
-    ApplySetter(s, setter composePrism other)
-  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplySetter[S, T, C, D] =
-    ApplySetter(s, setter composeLens other)
-  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplySetter[S, T, C, D] =
-    ApplySetter(s, setter composeIso other)
+  def andThen[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] =
+    ApplySetter(s, setter.andThen(other))
+  def andThen[C, D](other: PTraversal[A, B, C, D]): ApplySetter[S, T, C, D] =
+    ApplySetter(s, setter.andThen(other))
+  def andThen[C, D](other: POptional[A, B, C, D]): ApplySetter[S, T, C, D] =
+    ApplySetter(s, setter.andThen(other))
+  def andThen[C, D](other: PPrism[A, B, C, D]): ApplySetter[S, T, C, D] =
+    ApplySetter(s, setter.andThen(other))
+  def andThen[C, D](other: PLens[A, B, C, D]): ApplySetter[S, T, C, D] =
+    ApplySetter(s, setter.andThen(other))
+  def andThen[C, D](other: PIso[A, B, C, D]): ApplySetter[S, T, C, D] =
+    ApplySetter(s, setter.andThen(other))
+
+  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
 
   /** alias to composeTraversal */
-  @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplySetter[S, T, C, D] =
-    composeTraversal(other)
-
+  @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
   /** alias to composeOptional */
-  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplySetter[S, T, C, D] =
-    composeOptional(other)
-
+  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
   /** alias to composePrism */
-  @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplySetter[S, T, C, D] =
-    composePrism(other)
-
+  @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
   /** alias to composeLens */
-  @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplySetter[S, T, C, D] =
-    composeLens(other)
-
+  @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
   /** alias to composeIso */
-  @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplySetter[S, T, C, D] =
-    composeIso(other)
+  @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
 }
 
 object ApplySetter {

--- a/core/shared/src/main/scala/monocle/syntax/ApplyTraversal.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyTraversal.scala
@@ -26,40 +26,39 @@ final case class ApplyTraversal[S, T, A, B](s: S, traversal: PTraversal[S, T, A,
   private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): ApplyTraversal[S, T, A1, B1] =
     evB.substituteCo[ApplyTraversal[S, T, A1, *]](evA.substituteCo[ApplyTraversal[S, T, *, B]](this))
 
-  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] =
-    ApplySetter(s, traversal composeSetter other)
-  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] =
-    ApplyFold(s, traversal composeFold other)
-  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    ApplyTraversal(s, traversal composeTraversal other)
-  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    ApplyTraversal(s, traversal composeOptional other)
-  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    ApplyTraversal(s, traversal composePrism other)
-  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    ApplyTraversal(s, traversal composeLens other)
-  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    ApplyTraversal(s, traversal composeIso other)
+  def andThen[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] =
+    ApplySetter(s, traversal.andThen(other))
+  def andThen[C](other: Fold[A, C]): ApplyFold[S, C] =
+    ApplyFold(s, traversal.andThen(other))
+  def andThen[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
+    ApplyTraversal(s, traversal.andThen(other))
+  def andThen[C, D](other: POptional[A, B, C, D]): ApplyTraversal[S, T, C, D] =
+    ApplyTraversal(s, traversal.andThen(other))
+  def andThen[C, D](other: PPrism[A, B, C, D]): ApplyTraversal[S, T, C, D] =
+    ApplyTraversal(s, traversal.andThen(other))
+  def andThen[C, D](other: PLens[A, B, C, D]): ApplyTraversal[S, T, C, D] =
+    ApplyTraversal(s, traversal.andThen(other))
+  def andThen[C, D](other: PIso[A, B, C, D]): ApplyTraversal[S, T, C, D] =
+    ApplyTraversal(s, traversal.andThen(other))
+
+  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
+  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] = andThen(other)
+  @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
 
   /** alias to composeTraversal */
-  @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    composeTraversal(other)
-
+  @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
   /** alias to composeOptional */
-  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    composeOptional(other)
-
+  @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
   /** alias to composePrism */
-  @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    composePrism(other)
-
+  @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
   /** alias to composeLens */
-  @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    composeLens(other)
-
+  @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
   /** alias to composeIso */
-  @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyTraversal[S, T, C, D] =
-    composeIso(other)
+  @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
 }
 
 object ApplyTraversal {

--- a/core/shared/src/main/scala/monocle/syntax/ApplyTraversal.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyTraversal.scala
@@ -41,22 +41,26 @@ final case class ApplyTraversal[S, T, A, B](s: S, traversal: PTraversal[S, T, A,
   def andThen[C, D](other: PIso[A, B, C, D]): ApplyTraversal[S, T, C, D] =
     ApplyTraversal(s, traversal.andThen(other))
 
-  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D] = andThen(other)
-  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C] = andThen(other)
+  @inline def composeSetter[C, D](other: PSetter[A, B, C, D]): ApplySetter[S, T, C, D]          = andThen(other)
+  @inline def composeFold[C](other: Fold[A, C]): ApplyFold[S, C]                                = andThen(other)
   @inline def composeTraversal[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
-  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
-  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
-  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
-  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+  @inline def composeOptional[C, D](other: POptional[A, B, C, D]): ApplyTraversal[S, T, C, D]   = andThen(other)
+  @inline def composePrism[C, D](other: PPrism[A, B, C, D]): ApplyTraversal[S, T, C, D]         = andThen(other)
+  @inline def composeLens[C, D](other: PLens[A, B, C, D]): ApplyTraversal[S, T, C, D]           = andThen(other)
+  @inline def composeIso[C, D](other: PIso[A, B, C, D]): ApplyTraversal[S, T, C, D]             = andThen(other)
 
   /** alias to composeTraversal */
   @inline def ^|->>[C, D](other: PTraversal[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+
   /** alias to composeOptional */
   @inline def ^|-?[C, D](other: POptional[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+
   /** alias to composePrism */
   @inline def ^<-?[C, D](other: PPrism[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+
   /** alias to composeLens */
   @inline def ^|->[C, D](other: PLens[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
+
   /** alias to composeIso */
   @inline def ^<->[C, D](other: PIso[A, B, C, D]): ApplyTraversal[S, T, C, D] = andThen(other)
 }

--- a/docs/src/main/mdoc/examples/university_example.md
+++ b/docs/src/main/mdoc/examples/university_example.md
@@ -42,7 +42,7 @@ import monocle.function.At.at // to get at Lens
 ```
 
 ```scala mdoc
-(departments composeLens at("History")).set(None)(uni)
+departments.composeLens(at("History")).set(None)(uni)
 ```
 
 if instead we wanted to create a department, we would have used `set` with `Some`:
@@ -55,7 +55,7 @@ val physics = Department(36, List(
 ```
 
 ```scala mdoc
-(departments composeLens at("Physics")).set(Some(physics))(uni)
+departments.composeLens(at("Physics")).set(Some(physics))(uni)
 ```
 
 ## How to update a field in a nested case class
@@ -77,13 +77,13 @@ import monocle.function.all._ // to get each and other typeclass based optics su
 import monocle.Traversal
 import monocle.unsafe.MapTraversal._ // to get Each instance for Map (SortedMap does not require this import)
 
-val allLecturers: Traversal[University, Lecturer] = departments composeTraversal each composeLens lecturers composeTraversal each
+val allLecturers: Traversal[University, Lecturer] = departments.composeTraversal(each).andThen(lecturers).composeTraversal(each)
 ```
 
 Note that we used `each` twice, the first time on `Map` and the second time on `List`.
 
 ```scala mdoc
-(allLecturers composeLens salary).modify(_ + 2)(uni)
+allLecturers.andThen(salary).modify(_ + 2)(uni)
 ```
 
 ## How to create your own Traversal
@@ -103,8 +103,8 @@ Then, we can use `Cons` typeclass which provides both `headOption` and `tailOpti
 to use `headOption` to zoom into the first character of a `String`
 
 ```scala mdoc
-val upperCasedFirstName = (allLecturers composeLens firstName composeOptional headOption).modify(_.toUpper)(uni)
-(allLecturers composeLens lastName composeOptional headOption).modify(_.toUpper)(upperCasedFirstName)
+val upperCasedFirstName = allLecturers.andThen(firstName).composeOptional(headOption).modify(_.toUpper)(uni)
+allLecturers.andThen(lastName).composeOptional(headOption).modify(_.toUpper)(upperCasedFirstName)
 ```
 
 It is annoying that we have to call `modify` on first name and then repeat the same action on last name. Ideally, we
@@ -116,5 +116,5 @@ val firstAndLastNames = Traversal.apply2[Lecturer, String](_.firstName, _.lastNa
 ```
 
 ```scala mdoc
-(allLecturers composeTraversal firstAndLastNames composeOptional headOption).modify(_.toUpper)(uni)
+allLecturers.andThen(firstAndLastNames).composeOptional(headOption).modify(_.toUpper)(uni)
 ```

--- a/docs/src/main/mdoc/faq.md
+++ b/docs/src/main/mdoc/faq.md
@@ -37,7 +37,7 @@ val is = GenLens[Foo](_.is)
 ```
 
 ```scala mdoc
-(is composeOptional headOption).getOption(foo)
+is.composeOptional(headOption).getOption(foo)
 ```
 
 Note: if you use a version of monocle before 1.4.x, you need another import to get the typeclass instance
@@ -60,11 +60,11 @@ val root = Iso.id[Map[String, Int]]
 ```
 
 ```scala mdoc
-(root composeOptional index("two")).set(0)(m)   // update value at index "two"
-(root composeOptional index("three")).set(3)(m) // noop because m doesn't have a value at "three"
-(root composeLens at("three")).set(Some(3))(m)  // insert element at "three"
-(root composeLens at("two")).set(None)(m)       // delete element at "two"
-(root composeLens at("two")).set(Some(0))(m)    // upsert element at "two"
+root.composeOptional(index("two")).set(0)(m)   // update value at index "two"
+root.composeOptional(index("three")).set(3)(m) // noop because m doesn't have a value at "three"
+root.composeLens(at("three")).set(Some(3))(m)  // insert element at "three"
+root.composeLens(at("two")).set(None)(m)       // delete element at "two"
+root.composeLens(at("two")).set(Some(0))(m)    // upsert element at "two"
 ```
 
 In other words, `index` can update any existing values while `at` can also `insert` and `delete`.
@@ -87,5 +87,5 @@ Similarly, if the `Map` was in a case class, a `Lens` would provide the same kin
 case class Bar(kv: Map[String, Int])
 ```
 ```scala mdoc
-(GenLens[Bar](_.kv) composeOptional index("two")).set(0)(Bar(m))
+GenLens[Bar](_.kv).composeOptional(index("two")).set(0)(Bar(m))
 ```

--- a/docs/src/main/mdoc/optics/lens.md
+++ b/docs/src/main/mdoc/optics/lens.md
@@ -86,8 +86,8 @@ val address = GenLens[Person](_.address)
 ```
 
 ```scala mdoc
-(address composeLens streetNumber).get(john)
-(address composeLens streetNumber).set(2)(john)
+address.andThen(streetNumber).get(john)
+address.andThen(streetNumber).set(2)(john)
 ```
 
 ## Other Ways of Lens Composition
@@ -121,7 +121,7 @@ case class A(b: Option[B])
 val c = GenLens[B](_.c)
 val b = GenLens[A](_.b)
 
-(b composePrism some composeLens c).getOption(A(Some(B(1))))
+b.some.andThen(c).getOption(A(Some(B(1))))
 ```
 
 For more detailed view of the various optics composition see [Optics](../optics.html)

--- a/docs/src/main/mdoc/optics/lens.md
+++ b/docs/src/main/mdoc/optics/lens.md
@@ -112,7 +112,6 @@ Sometimes you need an easy way to update `Product` type inside
 `Sum` type - for that case you can compose `Prism` with `Lens` by using `some`:
 
 ```scala mdoc
-import monocle.std.option.some
 import monocle.macros.GenLens
 
 case class B(c: Int)

--- a/docs/src/main/mdoc/optics/prism.md
+++ b/docs/src/main/mdoc/optics/prism.md
@@ -83,7 +83,7 @@ import monocle.std.double.doubleToInt // Prism[Double, Int] defined in Monocle
 
 val jNum: Prism[Json, Double] = Prism.partial[Json, Double]{case JNum(v) => v}(JNum)
 
-val jInt: Prism[Json, Int] = jNum composePrism doubleToInt
+val jInt: Prism[Json, Int] = jNum.andThen(doubleToInt)
 ```
 
 ```scala mdoc
@@ -116,11 +116,11 @@ with `GenIso` (see `Iso` documentation):
 ```scala mdoc:nest:silent
 import monocle.macros.GenIso
 
-val jNum: Prism[Json, Double] = GenPrism[Json, JNum] composeIso GenIso[JNum, Double]
+val jNum: Prism[Json, Double] = GenPrism[Json, JNum].andThen(GenIso[JNum, Double])
 ```
 
 ```scala
-val jNull: Prism[Json, Unit] = GenPrism[Json, JNull.type] composeIso GenIso.unit[JNull.type]
+val jNull: Prism[Json, Unit] = GenPrism[Json, JNull.type].andThen(GenIso.unit[JNull.type])
 ```
 
 A [ticket](https://github.com/optics-dev/Monocle/issues/363) currently exists to add a macro to merge these two steps together.

--- a/docs/src/main/mdoc/unsafe_module.md
+++ b/docs/src/main/mdoc/unsafe_module.md
@@ -24,7 +24,7 @@ Using an `UnsafeSelect` we can select all `Person` with `age >= 18` and then use
 import monocle.unsafe.UnsafeSelect
 import monocle.macros.GenLens
 
-(UnsafeSelect.unsafeSelect[Person](_.age >= 18) composeLens GenLens[Person](_.name)).modify("Adult " + _)
+UnsafeSelect.unsafeSelect[Person](_.age >= 18).andThen(GenLens[Person](_.name)).modify("Adult " + _)
 ```
 
 This operator is considered unsafe because it allows for inconsistency if a `Lens` is then used to change one of the values used in the predicates. For example:
@@ -33,7 +33,7 @@ This operator is considered unsafe because it allows for inconsistency if a `Len
 import monocle.unsafe.UnsafeSelect
 import monocle.macros.GenLens
 
-(UnsafeSelect.unsafeSelect[Person](_.age >= 18) composeLens GenLens[Person](_.age)).set(0)
+UnsafeSelect.unsafeSelect[Person](_.age >= 18).andThen(GenLens[Person](_.age)).set(0)
 ```
 
 In this example the age is reset to `0` which invalidates the original predicate of `age >= 18`. More formally `UnsafeSelect` can invalidate the `roundTripOtherWayLaw` law.

--- a/example/src/test/scala/monocle/ComposeIssueExample.scala
+++ b/example/src/test/scala/monocle/ComposeIssueExample.scala
@@ -2,7 +2,7 @@ package monocle
 
 import shapeless.test.illTyped
 
-// we had to replace compose by non overloaded versions: composeLens, composePrism for the following reason
+// we had to replace compose by non overloaded versions: andThen, composePrism for the following reason
 class ComposeIssueExample extends MonocleSuite {
   class A[S, T] {
     def compose[U](a: A[T, U]): A[S, U] = new A[S, U]

--- a/example/src/test/scala/monocle/HttpRequestExample.scala
+++ b/example/src/test/scala/monocle/HttpRequestExample.scala
@@ -62,7 +62,8 @@ class HttpRequestExample extends MonocleSuite {
   test("headers with filterIndex") {
     val r = headers
       .composeTraversal(filterIndex { h: String => h.contains("timeout") })
-      .andThen(stringToInt).modify(_ * 2)(r1)
+      .andThen(stringToInt)
+      .modify(_ * 2)(r1)
 
     assertEquals(r.headers.get("socket_timeout"), Some("40"))
     assertEquals(r.headers.get("connection_timeout"), Some("20"))

--- a/example/src/test/scala/monocle/HttpRequestExample.scala
+++ b/example/src/test/scala/monocle/HttpRequestExample.scala
@@ -35,14 +35,11 @@ class HttpRequestExample extends MonocleSuite {
   }
 
   test("host") {
-    assertEquals((uri composeLens host).set("google.com")(r2), r2.copy(uri = r2.uri.copy(host = "google.com")))
+    assertEquals(uri.andThen(host).set("google.com")(r2), r2.copy(uri = r2.uri.copy(host = "google.com")))
   }
 
   test("query using index") {
-    val r = (uri
-      composeLens query
-      composeOptional index("hop")
-      composePrism stringToInt).modify(_ + 10)(r1)
+    val r = uri.andThen(query).composeOptional(index("hop")).andThen(stringToInt).modify(_ + 10)(r1)
 
     assertEquals(r.uri.query.get("hop"), Some("15"))
   }
@@ -52,24 +49,20 @@ class HttpRequestExample extends MonocleSuite {
     /**  `at` returns Lens[S, Option[A]] while `index` returns Optional[S, A]
       *  So that we need the `some: Prism[Option[A], A]` for further investigation
       */
-    val r = (uri
-      composeLens query
-      composeLens at("hop")
-      composePrism some
-      composePrism stringToInt).modify(_ + 10)(r1)
+    val r = uri.andThen(query).composeLens(at("hop")).some.andThen(stringToInt).modify(_ + 10)(r1)
 
     assertEquals(r.uri.query.get("hop"), Some("15"))
   }
 
   test("headers") {
-    val r = (headers composeLens at("Content-Type")).set(Some("text/plain; utf-8"))(r2)
+    val r = headers.composeLens(at("Content-Type")).set(Some("text/plain; utf-8"))(r2)
     assertEquals(r.headers.get("Content-Type"), Some("text/plain; utf-8"))
   }
 
   test("headers with filterIndex") {
-    val r = (headers
-      composeTraversal filterIndex { h: String => h.contains("timeout") }
-      composePrism stringToInt).modify(_ * 2)(r1)
+    val r = headers
+      .composeTraversal(filterIndex { h: String => h.contains("timeout") })
+      .andThen(stringToInt).modify(_ * 2)(r1)
 
     assertEquals(r.headers.get("socket_timeout"), Some("40"))
     assertEquals(r.headers.get("connection_timeout"), Some("20"))

--- a/example/src/test/scala/monocle/JsonExample.scala
+++ b/example/src/test/scala/monocle/JsonExample.scala
@@ -49,15 +49,15 @@ class JsonExample extends MonocleSuite {
   }
 
   test("Use index to go into an JsObject or JsArray") {
-    assertEquals((jsObject composeOptional index("age") composePrism jsNumber).getOption(json), Some(28))
+    assertEquals(jsObject.composeOptional(index("age")).andThen(jsNumber).getOption(json), Some(28))
 
     assertEquals(
-      (jsObject composeOptional index("siblings")
-        composePrism jsArray
-        composeOptional index(1)
-        composePrism jsObject
-        composeOptional index("first_name")
-        composePrism jsString).set("Robert Jr.")(json),
+      jsObject.composeOptional(index("siblings"))
+        .andThen(jsArray)
+        .composeOptional(index(1))
+        .andThen(jsObject)
+        .composeOptional(index("first_name"))
+        .andThen(jsString).set("Robert Jr.")(json),
       JsObject(
         Map(
           "first_name" -> JsString("John"),
@@ -86,7 +86,7 @@ class JsonExample extends MonocleSuite {
 
   test("Use at to add delete fields") {
     assertEquals(
-      (jsObject composeLens at("nick_name")).set(Some(JsString("Jojo")))(json),
+      jsObject.composeLens(at("nick_name")).set(Some(JsString("Jojo")))(json),
       JsObject(
         Map(
           "first_name" -> JsString("John"),
@@ -114,7 +114,7 @@ class JsonExample extends MonocleSuite {
     )
 
     assertEquals(
-      (jsObject composeLens at("age")).set(None)(json),
+      jsObject.composeLens(at("age")).set(None)(json),
       JsObject(
         Map(
           "first_name" -> JsString("John"),
@@ -142,9 +142,10 @@ class JsonExample extends MonocleSuite {
 
   test("Use each and filterIndex to modify several fields at a time") {
     assertEquals(
-      (jsObject composeTraversal filterIndex((_: String).contains("name"))
-        composePrism jsString
-        composeOptional headOption).modify(_.toLower)(json),
+      jsObject.composeTraversal(filterIndex((_: String).contains("name")))
+        .andThen(jsString)
+        .composeOptional(headOption)
+        .modify(_.toLower)(json),
       JsObject(
         Map(
           "first_name" -> JsString("john"), // starts with lower case
@@ -171,12 +172,13 @@ class JsonExample extends MonocleSuite {
     )
 
     assertEquals(
-      (jsObject composeOptional index("siblings")
-        composePrism jsArray
-        composeTraversal each
-        composePrism jsObject
-        composeOptional index("age")
-        composePrism jsNumber).modify(_ + 1)(json),
+      jsObject.composeOptional(index("siblings"))
+        .andThen(jsArray)
+        .composeTraversal(each)
+        .andThen(jsObject)
+        .composeOptional(index("age"))
+        .andThen(jsNumber)
+        .modify(_ + 1)(json),
       JsObject(
         Map(
           "first_name" -> JsString("John"),

--- a/example/src/test/scala/monocle/JsonExample.scala
+++ b/example/src/test/scala/monocle/JsonExample.scala
@@ -52,12 +52,14 @@ class JsonExample extends MonocleSuite {
     assertEquals(jsObject.composeOptional(index("age")).andThen(jsNumber).getOption(json), Some(28))
 
     assertEquals(
-      jsObject.composeOptional(index("siblings"))
+      jsObject
+        .composeOptional(index("siblings"))
         .andThen(jsArray)
         .composeOptional(index(1))
         .andThen(jsObject)
         .composeOptional(index("first_name"))
-        .andThen(jsString).set("Robert Jr.")(json),
+        .andThen(jsString)
+        .set("Robert Jr.")(json),
       JsObject(
         Map(
           "first_name" -> JsString("John"),
@@ -142,7 +144,8 @@ class JsonExample extends MonocleSuite {
 
   test("Use each and filterIndex to modify several fields at a time") {
     assertEquals(
-      jsObject.composeTraversal(filterIndex((_: String).contains("name")))
+      jsObject
+        .composeTraversal(filterIndex((_: String).contains("name")))
         .andThen(jsString)
         .composeOptional(headOption)
         .modify(_.toLower)(json),
@@ -172,7 +175,8 @@ class JsonExample extends MonocleSuite {
     )
 
     assertEquals(
-      jsObject.composeOptional(index("siblings"))
+      jsObject
+        .composeOptional(index("siblings"))
         .andThen(jsArray)
         .composeTraversal(each)
         .andThen(jsObject)

--- a/example/src/test/scala/monocle/LensExample.scala
+++ b/example/src/test/scala/monocle/LensExample.scala
@@ -42,9 +42,9 @@ class LensMonoExample extends MonocleSuite {
   }
 
   test("compose") {
-    assertEquals((Manual._address composeLens Manual._streetNumber).get(john), 126)
-    assertEquals((Semi.address composeLens Semi.streetNumber).get(john), 126)
-    assertEquals((Person.address composeLens Address.streetNumber).get(john), 126)
+    assertEquals((Manual._address andThen Manual._streetNumber).get(john), 126)
+    assertEquals((Semi.address andThen Semi.streetNumber).get(john), 126)
+    assertEquals((Person.address andThen Address.streetNumber).get(john), 126)
     assertEquals(john.lens(_.address.streetNumber).get, 126)
   }
 

--- a/example/src/test/scala/monocle/generic/CoproductExample.scala
+++ b/example/src/test/scala/monocle/generic/CoproductExample.scala
@@ -91,8 +91,8 @@ class CoproductExample extends MonocleSuite {
     case class C(otherName: String) extends S
 
     val lens: Lens[S, String] =
-      coProductToDisjunction[S].apply composeLens
-        (GenLens[A](_.name) choice (GenLens[B](_.name) choice GenLens[C](_.otherName)))
+      coProductToDisjunction[S].apply andThen
+        GenLens[A](_.name).choice(GenLens[B](_.name).choice(GenLens[C](_.otherName)))
 
     assertEquals(lens.get(A("a")), "a")
     assertEquals(lens.get(B("b")), "b")

--- a/macro/src/main/scala/monocle/macros/internal/Macro.scala
+++ b/macro/src/main/scala/monocle/macros/internal/Macro.scala
@@ -49,7 +49,7 @@ private[macros] class MacroImpl(val c: blackbox.Context) {
         c.Expr[Lens[S, A]](
           typesFields
             .map { case (t, f) => q"monocle.macros.GenLens[$t](_.$f)" }
-            .reduce((a, b) => q"$a composeLens $b")
+            .reduce((a, b) => q"$a.andThen($b)")
         )
 
       case _ =>

--- a/test/shared/src/test/scala/monocle/PrismSpec.scala
+++ b/test/shared/src/test/scala/monocle/PrismSpec.scala
@@ -96,7 +96,7 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
   case class I(i: Int)    extends IntOrString
   case class S(s: String) extends IntOrString
 
-  val i = GenPrism[IntOrString, I] composeIso GenIso[I, Int]
+  val i = GenPrism[IntOrString, I].andThen(GenIso[I, Int])
   val s = Prism[IntOrString, String] { case S(s) => Some(s); case _ => None }(S.apply)
 
   test("getOption") {
@@ -161,30 +161,21 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
 
   test("GenPrism nullary equality".ignore) {
     assertEquals(
-      GenPrism[Arities, Nullary] composeIso GenIso
-        .unit[Nullary],
+      GenPrism[Arities, Nullary].andThen(GenIso.unit[Nullary]),
       _nullary
     )
   }
 
   test("GenPrism unary equality".ignore) {
-    assertEquals(GenPrism[Arities, Unary] composeIso GenIso[Unary, Int], _unary)
+    assertEquals(GenPrism[Arities, Unary].andThen(GenIso[Unary, Int]), _unary)
   }
 
   test("GenPrism binary equality".ignore) {
-    assertEquals(
-      GenPrism[Arities, Binary] composeIso GenIso
-        .fields[Binary],
-      _binary
-    )
+    assertEquals(GenPrism[Arities, Binary].andThen(GenIso.fields[Binary]), _binary)
   }
 
   test("GenPrism quintary equality".ignore) {
-    assertEquals(
-      GenPrism[Arities, Quintary] composeIso GenIso
-        .fields[Quintary],
-      _quintary
-    )
+    assertEquals(GenPrism[Arities, Quintary].andThen(GenIso.fields[Quintary]), _quintary)
   }
 
   test("to") {

--- a/test/shared/src/test/scala/monocle/std/OptionSpec.scala
+++ b/test/shared/src/test/scala/monocle/std/OptionSpec.scala
@@ -32,7 +32,7 @@ class OptionSpec extends MonocleSuite {
       at(index)
 
     def mapDefaultTo0(index: String): Lens[Map[String, Int], Int] =
-      mapAt(index) composeIso withDefault(0)
+      mapAt(index).andThen(withDefault(0))
 
     assert(mapDefaultTo0("id").set(0)(Map("id" -> 0)) == Map.empty)
   }

--- a/test/shared/src/test/scala/monocle/unsafe/UnsafeSelectSpec.scala
+++ b/test/shared/src/test/scala/monocle/unsafe/UnsafeSelectSpec.scala
@@ -40,6 +40,6 @@ class UnsafeSelectSpec extends MonocleSuite {
 
   checkAll(
     "unsafe legal",
-    OptionalTests(UnsafeSelect.unsafeSelect[Person](_.age >= 18) composeLens GenLens[Person](_.name))
+    OptionalTests(UnsafeSelect.unsafeSelect[Person](_.age >= 18).andThen(GenLens[Person](_.name)))
   )
 }


### PR DESCRIPTION
see #964

I believe we can deprecate all `composeX` methods once we have a short cut for `at`, `index` and maybe a few other common optics.