### PR TITLE
deprecate all applyX methods and operators in favor of optics method

### DIFF
--- a/core/shared/src/main/scala/monocle/syntax/Apply.scala
+++ b/core/shared/src/main/scala/monocle/syntax/Apply.scala
@@ -5,6 +5,8 @@ import monocle._
 object apply extends ApplySyntax
 
 trait ApplySyntax {
+  implicit def toApplyOpticsOps[S](value: S): ApplyOpticsOps[S] = ApplyOpticsOps(value)
+
   implicit def toApplyFoldOps[S](value: S): ApplyFoldOps[S] =
     new ApplyFoldOps(value)
   implicit def toApplyGetterOps[S](value: S): ApplyGetterOps[S] =
@@ -23,62 +25,79 @@ trait ApplySyntax {
     new ApplyTraversalOps(value)
 }
 
+final case class ApplyOpticsOps[S](private val s: S) extends AnyVal {
+  def optics[T, A, B]: ApplyIso[S, S, S, S] = ApplyIso(s, Iso.id)
+}
+
 final case class ApplyFoldOps[S](private val s: S) extends AnyVal {
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def applyFold[A](fold: Fold[S, A]): ApplyFold[S, A] =
     new ApplyFold[S, A](s, fold)
 }
 
 final case class ApplyGetterOps[S](private val s: S) extends AnyVal {
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def applyGetter[A](getter: Getter[S, A]): ApplyGetter[S, A] =
     new ApplyGetter[S, A](s, getter)
 }
 
 final case class ApplyIsoOps[S](private val s: S) extends AnyVal {
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def applyIso[T, A, B](iso: PIso[S, T, A, B]): ApplyIso[S, T, A, B] =
     ApplyIso[S, T, A, B](s, iso)
 
   /** alias to applyIso */
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def &<->[T, A, B](iso: PIso[S, T, A, B]): ApplyIso[S, T, A, B] =
     applyIso(iso)
 }
 
 final case class ApplyLensOps[S](private val s: S) extends AnyVal {
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def applyLens[T, A, B](lens: PLens[S, T, A, B]): ApplyLens[S, T, A, B] =
     ApplyLens[S, T, A, B](s, lens)
 
   /** alias to applyLens */
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def &|->[T, A, B](lens: PLens[S, T, A, B]): ApplyLens[S, T, A, B] =
     applyLens(lens)
 }
 
 final case class ApplyOptionalOps[S](private val s: S) extends AnyVal {
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def applyOptional[T, A, B](optional: POptional[S, T, A, B]): ApplyOptional[S, T, A, B] =
     ApplyOptional[S, T, A, B](s, optional)
 
   /** alias to applyOptional */
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def &|-?[T, A, B](optional: POptional[S, T, A, B]): ApplyOptional[S, T, A, B] =
     applyOptional(optional)
 }
 
 final case class ApplyPrismOps[S](private val s: S) extends AnyVal {
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def applyPrism[T, A, B](prism: PPrism[S, T, A, B]): ApplyPrism[S, T, A, B] =
     ApplyPrism[S, T, A, B](s, prism)
 
   /** alias to applyPrism */
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def &<-?[T, A, B](prism: PPrism[S, T, A, B]): ApplyPrism[S, T, A, B] =
     applyPrism(prism)
 }
 
 final case class ApplySetterOps[S](private val s: S) extends AnyVal {
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def applySetter[T, A, B](setter: PSetter[S, T, A, B]): ApplySetter[S, T, A, B] =
     new ApplySetter[S, T, A, B](s, setter)
 }
 
 final case class ApplyTraversalOps[S](private val s: S) extends AnyVal {
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def applyTraversal[T, A, B](traversal: PTraversal[S, T, A, B]): ApplyTraversal[S, T, A, B] =
     ApplyTraversal[S, T, A, B](s, traversal)
 
   /** alias to applyTraversal */
+  @deprecated("use optics.andThen", since = "3.0.0-M1")
   def &|->>[T, A, B](traversal: PTraversal[S, T, A, B]): ApplyTraversal[S, T, A, B] =
     applyTraversal(traversal)
 }

--- a/example/src/test/scala/monocle/function/AtExample.scala
+++ b/example/src/test/scala/monocle/function/AtExample.scala
@@ -9,17 +9,17 @@ import scala.collection.immutable.SortedMap
 
 class AtExample extends MonocleSuite {
   test("at creates a Lens from a Map, SortedMap to an optional value") {
-    assertEquals((Map("One" -> 2, "Two" -> 2) applyLens at("Two") get), Some(2))
-    assertEquals((SortedMap("One" -> 2, "Two" -> 2) applyLens at("Two") get), Some(2))
+    assertEquals(Map("One" -> 2, "Two" -> 2).optics.at("Two").get, Some(2))
+    assertEquals(SortedMap("One" -> 2, "Two" -> 2).optics.at("Two").get, Some(2))
 
-    assertEquals((Map("One" -> 1, "Two" -> 2) applyLens at("One") replace Some(-1)), Map("One" -> -1, "Two" -> 2))
+    assertEquals(Map("One" -> 1, "Two" -> 2).optics.at("One").replace(Some(-1)), Map("One" -> -1, "Two" -> 2))
 
     // can delete a value
-    assertEquals((Map("One" -> 1, "Two" -> 2) applyLens at("Two") replace None), Map("One" -> 1))
+    assertEquals(Map("One" -> 1, "Two" -> 2).optics.at("Two").replace(None), Map("One" -> 1))
 
     // add a new value
     assertEquals(
-      (Map("One" -> 1, "Two" -> 2) applyLens at("Three") replace Some(3)),
+      Map("One" -> 1, "Two" -> 2).optics.at("Three").replace(Some(3)),
       Map(
         "One"   -> 1,
         "Two"   -> 2,
@@ -29,27 +29,27 @@ class AtExample extends MonocleSuite {
   }
 
   test("at creates a Lens from a Set to an optional element of the Set") {
-    assertEquals((Set(1, 2, 3) applyLens at(2) get), true)
-    assertEquals((Set(1, 2, 3) applyLens at(4) get), false)
+    assertEquals(Set(1, 2, 3).optics.at(2).get, true)
+    assertEquals(Set(1, 2, 3).optics.at(4).get, false)
 
-    assertEquals((Set(1, 2, 3) applyLens at(4) replace true), Set(1, 2, 3, 4))
-    assertEquals((Set(1, 2, 3) applyLens at(2) replace false), Set(1, 3))
+    assertEquals(Set(1, 2, 3).optics.at(4).replace(true), Set(1, 2, 3, 4))
+    assertEquals(Set(1, 2, 3).optics.at(2).replace(false), Set(1, 3))
   }
 
   test("at creates a Lens from Int to one of its bit") {
-    assertEquals((3 applyLens at(0: IntBits) get), true)  // true  means bit is 1
-    assertEquals((4 applyLens at(0: IntBits) get), false) // false means bit is 0
+    assertEquals(3.optics.at(0: IntBits).get, true)  // true  means bit is 1
+    assertEquals(4.optics.at(0: IntBits).get, false) // false means bit is 0
 
-    assertEquals((32 applyLens at(0: IntBits) replace true), 33)
-    assertEquals((3 applyLens at(1: IntBits) modify (!_)), 1) // toggle 2nd bit
+    assertEquals(32.optics.at(0: IntBits).replace(true), 33)
+    assertEquals(3.optics.at(1: IntBits).modify(!_), 1) // toggle 2nd bit
 
     illTyped("""0 applyLens at(79: IntBits) get""", "Right predicate.*fail.*")
     illTyped("""0 applyLens at(-1: IntBits) get""", "Left predicate.*fail.*")
   }
 
   test("at creates a Lens from Char to one of its bit") {
-    assertEquals(('x' applyLens at(0: CharBits) get), false)
-    assertEquals(('x' applyLens at(0: CharBits) replace true), 'y')
+    assertEquals('x'.optics.at(0: CharBits).get, false)
+    assertEquals('x'.optics.at(0: CharBits).replace(true), 'y')
   }
 
   test("remove deletes an element of a Map") {

--- a/example/src/test/scala/monocle/function/EachExample.scala
+++ b/example/src/test/scala/monocle/function/EachExample.scala
@@ -9,26 +9,26 @@ import scala.annotation.nowarn
 
 class EachExample extends MonocleSuite {
   test("Each can be used on Option") {
-    assertEquals((Option(3) applyTraversal each modify (_ + 1)), Some(4))
-    assertEquals(((None: Option[Int]) applyTraversal each modify (_ + 1)), None)
+    assertEquals(Option(3).optics.each.modify(_ + 1), Some(4))
+    assertEquals((None: Option[Int]).optics.each.modify(_ + 1), None)
   }
 
   test("Each can be used on List, IList, Vector, Stream and OneAnd") {
-    assertEquals((List(1, 2) applyTraversal each modify (_ + 1)), List(2, 3))
-    assertEquals((Vector(1, 2) applyTraversal each modify (_ + 1)), Vector(2, 3))
-    assertEquals((OneAnd(1, List(2, 3)) applyTraversal each modify (_ + 1)), OneAnd(2, List(3, 4)))
+    assertEquals(List(1, 2).optics.each.modify(_ + 1), List(2, 3))
+    assertEquals(Vector(1, 2).optics.each.modify(_ + 1), Vector(2, 3))
+    assertEquals(OneAnd(1, List(2, 3)).optics.each.modify(_ + 1), OneAnd(2, List(3, 4)))
   }
 
   test("Each can be used on Map, IMap to update all values") {
     assertEquals(
-      (SortedMap("One" -> 1, "Two" -> 2) applyTraversal each modify (_ + 1)),
+      SortedMap("One" -> 1, "Two" -> 2).optics.each.modify(_ + 1),
       SortedMap("One" -> 2, "Two" -> 3)
     )
   }
 
   test("Each can be used on tuple of same type") {
-    assertEquals(((1, 2) applyTraversal each modify (_ + 1)), ((2, 3))): @nowarn
-    assertEquals(((1, 2, 3) applyTraversal each modify (_ + 1)), ((2, 3, 4))): @nowarn
-    assertEquals(((1, 2, 3, 4, 5, 6) applyTraversal each modify (_ + 1)), ((2, 3, 4, 5, 6, 7))): @nowarn
+    assertEquals((1, 2).optics.each.modify(_ + 1), ((2, 3))): @nowarn
+    assertEquals((1, 2, 3).optics.each.modify(_ + 1), ((2, 3, 4))): @nowarn
+    assertEquals((1, 2, 3, 4, 5, 6).optics.each.modify(_ + 1), ((2, 3, 4, 5, 6, 7))): @nowarn
   }
 }

--- a/example/src/test/scala/monocle/function/FieldsExample.scala
+++ b/example/src/test/scala/monocle/function/FieldsExample.scala
@@ -4,24 +4,24 @@ import monocle.MonocleSuite
 
 class FieldsExample extends MonocleSuite {
   test("_1 creates a Lens from a 2-6 tuple to its first element") {
-    assertEquals((("Hello", 3) applyLens at(1) get), "Hello")
+    assertEquals(("Hello", 3).optics.at(1).get, "Hello")
 
-    assertEquals((("Hello", 3, true) applyLens at(1) replace "World"), (("World", 3, true)))
+    assertEquals(("Hello", 3, true).optics.at(1).replace("World"), (("World", 3, true)))
 
-    assertEquals((("Hello", 3, true, 5.6, 7L, 'c') applyLens at(1) get), "Hello")
+    assertEquals(("Hello", 3, true, 5.6, 7L, 'c').optics.at(1).get, "Hello")
   }
 
   test("_2 creates a Lens from a 2-6 tuple to its second element") {
-    assertEquals((("Hello", 3) applyLens at(2) get), 3)
+    assertEquals(("Hello", 3).optics.at(2).get, 3)
 
-    assertEquals((("Hello", 3, true, 5.6, 7L, 'c') applyLens at(2) replace 4), (("Hello", 4, true, 5.6, 7L, 'c')))
+    assertEquals(("Hello", 3, true, 5.6, 7L, 'c').optics.at(2).replace(4), (("Hello", 4, true, 5.6, 7L, 'c')))
   }
 
   // ...
 
   test("_6 creates a Lens from a 6-tuple to its sixth element") {
-    assertEquals((("Hello", 3, true, 5.6, 7L, 'c') applyLens at(6) get), 'c')
+    assertEquals(("Hello", 3, true, 5.6, 7L, 'c').optics.at(6).get, 'c')
 
-    assertEquals((("Hello", 3, true, 5.6, 7L, 'c') applyLens at(6) replace 'a'), (("Hello", 3, true, 5.6, 7L, 'a')))
+    assertEquals(("Hello", 3, true, 5.6, 7L, 'c').optics.at(6).replace('a'), (("Hello", 3, true, 5.6, 7L, 'a')))
   }
 }

--- a/example/src/test/scala/monocle/function/FilterIndexExample.scala
+++ b/example/src/test/scala/monocle/function/FilterIndexExample.scala
@@ -7,18 +7,20 @@ import scala.collection.immutable.SortedMap
 class FilterIndexExample extends MonocleSuite {
   test("filterIndexes creates Traversal from a SortedMap, IMap to all values where the index matches the predicate") {
     assertEquals(
-      (SortedMap("One" -> 1, "Two" -> 2) applyTraversal filterIndex { k: String =>
+      SortedMap("One" -> 1, "Two" -> 2).optics.filterIndex { k: String =>
         k.toLowerCase.contains("o")
-      } getAll),
+      }.getAll,
       List(
         1,
         2
       )
     )
     assertEquals(
-      (SortedMap("One" -> 1, "Two" -> 2) applyTraversal filterIndex { k: String =>
-        k.startsWith("T")
-      } replace 3),
+      SortedMap("One" -> 1, "Two" -> 2).optics
+        .filterIndex { k: String =>
+          k.startsWith("T")
+        }
+        .replace(3),
       SortedMap(
         "One" -> 1,
         "Two" -> 3
@@ -29,11 +31,11 @@ class FilterIndexExample extends MonocleSuite {
   test(
     "filterIndexes creates Traversal from a List, IList, Vector or Stream to all values where the index matches the predicate"
   ) {
-    assertEquals((List(1, 3, 5, 7) applyTraversal filterIndex { i: Int => i % 2 == 0 } getAll), List(1, 5))
+    assertEquals(List(1, 3, 5, 7).optics.filterIndex { i: Int => i % 2 == 0 }.getAll, List(1, 5))
 
-    assertEquals((List(1, 3, 5, 7) applyTraversal filterIndex { i: Int => i >= 2 } modify (_ + 2)), List(1, 3, 7, 9))
+    assertEquals(List(1, 3, 5, 7).optics.filterIndex { i: Int => i >= 2 }.modify(_ + 2), List(1, 3, 7, 9))
     assertEquals(
-      (Vector(1, 3, 5, 7) applyTraversal filterIndex { i: Int => i >= 2 } modify (_ + 2)),
+      Vector(1, 3, 5, 7).optics.filterIndex { i: Int => i >= 2 }.modify(_ + 2),
       Vector(1, 3, 7, 9)
     )
   }

--- a/example/src/test/scala/monocle/function/IndexExample.scala
+++ b/example/src/test/scala/monocle/function/IndexExample.scala
@@ -7,24 +7,24 @@ import cats.data.OneAnd
 
 class IndexExample extends MonocleSuite {
   test("index creates an Optional from a Map, IMap to a value at the index") {
-    assertEquals((Map("One" -> 1, "Two" -> 2) applyOptional index("One") getOption), Some(1))
+    assertEquals(Map("One" -> 1, "Two" -> 2).optics.index("One").getOption, Some(1))
 
-    assertEquals((Map("One" -> 1, "Two" -> 2) applyOptional index("One") replace 2), Map("One" -> 2, "Two" -> 2))
+    assertEquals(Map("One" -> 1, "Two" -> 2).optics.index("One").replace(2), Map("One" -> 2, "Two" -> 2))
   }
 
   test("index creates an Optional from a List, Vector or Stream to a value at the index") {
-    assertEquals((List(0, 1, 2, 3) applyOptional index(1) getOption), Some(1))
-    assertEquals((List(0, 1, 2, 3) applyOptional index(8) getOption), None)
+    assertEquals(List(0, 1, 2, 3).optics.index(1).getOption, Some(1))
+    assertEquals(List(0, 1, 2, 3).optics.index(8).getOption, None)
 
-    assertEquals((Vector(0, 1, 2, 3) applyOptional index(1) modify (_ + 1)), Vector(0, 2, 2, 3))
+    assertEquals(Vector(0, 1, 2, 3).optics.index(1).modify(_ + 1), Vector(0, 2, 2, 3))
   }
 
   test("index creates an Optional from a OneAnd to a value at the index") {
-    assertEquals((OneAnd(1, List(2, 3)) applyOptional index(0) getOption), Some(1))
-    assertEquals((OneAnd(1, List(2, 3)) applyOptional index(1) getOption), Some(2))
+    assertEquals(OneAnd(1, List(2, 3)).optics.index(0).getOption, Some(1))
+    assertEquals(OneAnd(1, List(2, 3)).optics.index(1).getOption, Some(2))
   }
 
   test("index creates an Optional from a String to a Char") {
-    assertEquals(("Hello World" applyOptional index(2) getOption), Some('l'))
+    assertEquals("Hello World".optics.index(2).getOption, Some('l'))
   }
 }

--- a/test/shared/src/test/scala/monocle/FoldSpec.scala
+++ b/test/shared/src/test/scala/monocle/FoldSpec.scala
@@ -107,7 +107,7 @@ class FoldSpec extends MonocleSuite {
     val fold    = Fold.fromFoldable[List, Option[Int]]
 
     assertEquals(fold.some.getAll(numbers), List(1, 2))
-    assertEquals(numbers.applyFold(fold).some.getAll, List(1, 2))
+    assertEquals(numbers.optics.andThen(fold).some.getAll, List(1, 2))
   }
 
   test("withDefault") {
@@ -115,7 +115,7 @@ class FoldSpec extends MonocleSuite {
     val fold    = Fold.fromFoldable[List, Option[Int]]
 
     assertEquals(fold.withDefault(0).getAll(numbers), List(1, 0, 2, 0))
-    assertEquals(numbers.applyFold(fold).withDefault(0).getAll, List(1, 0, 2, 0))
+    assertEquals(numbers.optics.andThen(fold).withDefault(0).getAll, List(1, 0, 2, 0))
   }
 
   test("each") {
@@ -123,7 +123,7 @@ class FoldSpec extends MonocleSuite {
     val fold    = Fold.fromFoldable[List, List[Int]]
 
     assertEquals(fold.each.getAll(numbers), List(1, 2, 3, 4))
-    assertEquals(numbers.applyFold(fold).each.getAll, List(1, 2, 3, 4))
+    assertEquals(numbers.optics.andThen(fold).each.getAll, List(1, 2, 3, 4))
   }
 
   test("filter") {
@@ -131,7 +131,7 @@ class FoldSpec extends MonocleSuite {
     val fold    = Fold.fromFoldable[List, Int]
 
     assertEquals(fold.filter(_ > 1).getAll(numbers), List(2, 3))
-    assertEquals(numbers.applyFold(fold).filter(_ > 1).getAll, List(2, 3))
+    assertEquals(numbers.optics.andThen(fold).filter(_ > 1).getAll, List(2, 3))
   }
 
   test("filterIndex") {
@@ -139,7 +139,7 @@ class FoldSpec extends MonocleSuite {
     val fold  = Fold.fromFoldable[List, List[String]]
 
     assertEquals(fold.filterIndex((_: Int) > 0).getAll(words), List("world", "hi"))
-    assertEquals(words.applyFold(fold).filterIndex((_: Int) > 0).getAll, List("world", "hi"))
+    assertEquals(words.optics.andThen(fold).filterIndex((_: Int) > 0).getAll, List("world", "hi"))
   }
 
   test("at") {
@@ -147,17 +147,17 @@ class FoldSpec extends MonocleSuite {
     val tuple2Fold = Fold.id[(Int, Int)]
     assertEquals(tuple2Fold.at(1).getAll(tuple2), List(1))
     assertEquals(tuple2Fold.at(2).getAll(tuple2), List(2))
-    assertEquals(tuple2.applyFold(tuple2Fold).at(1).getAll, List(1))
-    assertEquals(tuple2.applyFold(tuple2Fold).at(2).getAll, List(2))
+    assertEquals(tuple2.optics.andThen(tuple2Fold).at(1).getAll, List(1))
+    assertEquals(tuple2.optics.andThen(tuple2Fold).at(2).getAll, List(2))
 
     val tuple3     = (1, 2, 3)
     val tuple3Fold = Fold.id[(Int, Int, Int)]
     assertEquals(tuple3Fold.at(1).getAll(tuple3), List(1))
     assertEquals(tuple3Fold.at(2).getAll(tuple3), List(2))
     assertEquals(tuple3Fold.at(3).getAll(tuple3), List(3))
-    assertEquals(tuple3.applyFold(tuple3Fold).at(1).getAll, List(1))
-    assertEquals(tuple3.applyFold(tuple3Fold).at(2).getAll, List(2))
-    assertEquals(tuple3.applyFold(tuple3Fold).at(3).getAll, List(3))
+    assertEquals(tuple3.optics.andThen(tuple3Fold).at(1).getAll, List(1))
+    assertEquals(tuple3.optics.andThen(tuple3Fold).at(2).getAll, List(2))
+    assertEquals(tuple3.optics.andThen(tuple3Fold).at(3).getAll, List(3))
 
     val tuple4     = (1, 2, 3, 4)
     val tuple4Fold = Fold.id[(Int, Int, Int, Int)]
@@ -165,10 +165,10 @@ class FoldSpec extends MonocleSuite {
     assertEquals(tuple4Fold.at(2).getAll(tuple4), List(2))
     assertEquals(tuple4Fold.at(3).getAll(tuple4), List(3))
     assertEquals(tuple4Fold.at(4).getAll(tuple4), List(4))
-    assertEquals(tuple4.applyFold(tuple4Fold).at(1).getAll, List(1))
-    assertEquals(tuple4.applyFold(tuple4Fold).at(2).getAll, List(2))
-    assertEquals(tuple4.applyFold(tuple4Fold).at(3).getAll, List(3))
-    assertEquals(tuple4.applyFold(tuple4Fold).at(4).getAll, List(4))
+    assertEquals(tuple4.optics.andThen(tuple4Fold).at(1).getAll, List(1))
+    assertEquals(tuple4.optics.andThen(tuple4Fold).at(2).getAll, List(2))
+    assertEquals(tuple4.optics.andThen(tuple4Fold).at(3).getAll, List(3))
+    assertEquals(tuple4.optics.andThen(tuple4Fold).at(4).getAll, List(4))
 
     val tuple5     = (1, 2, 3, 4, 5)
     val tuple5Fold = Fold.id[(Int, Int, Int, Int, Int)]
@@ -177,11 +177,11 @@ class FoldSpec extends MonocleSuite {
     assertEquals(tuple5Fold.at(3).getAll(tuple5), List(3))
     assertEquals(tuple5Fold.at(4).getAll(tuple5), List(4))
     assertEquals(tuple5Fold.at(5).getAll(tuple5), List(5))
-    assertEquals(tuple5.applyFold(tuple5Fold).at(1).getAll, List(1))
-    assertEquals(tuple5.applyFold(tuple5Fold).at(2).getAll, List(2))
-    assertEquals(tuple5.applyFold(tuple5Fold).at(3).getAll, List(3))
-    assertEquals(tuple5.applyFold(tuple5Fold).at(4).getAll, List(4))
-    assertEquals(tuple5.applyFold(tuple5Fold).at(5).getAll, List(5))
+    assertEquals(tuple5.optics.andThen(tuple5Fold).at(1).getAll, List(1))
+    assertEquals(tuple5.optics.andThen(tuple5Fold).at(2).getAll, List(2))
+    assertEquals(tuple5.optics.andThen(tuple5Fold).at(3).getAll, List(3))
+    assertEquals(tuple5.optics.andThen(tuple5Fold).at(4).getAll, List(4))
+    assertEquals(tuple5.optics.andThen(tuple5Fold).at(5).getAll, List(5))
 
     val tuple6     = (1, 2, 3, 4, 5, 6)
     val tuple6Fold = Fold.id[(Int, Int, Int, Int, Int, Int)]
@@ -191,40 +191,40 @@ class FoldSpec extends MonocleSuite {
     assertEquals(tuple6Fold.at(4).getAll(tuple6), List(4))
     assertEquals(tuple6Fold.at(5).getAll(tuple6), List(5))
     assertEquals(tuple6Fold.at(6).getAll(tuple6), List(6))
-    assertEquals(tuple6.applyFold(tuple6Fold).at(1).getAll, List(1))
-    assertEquals(tuple6.applyFold(tuple6Fold).at(2).getAll, List(2))
-    assertEquals(tuple6.applyFold(tuple6Fold).at(3).getAll, List(3))
-    assertEquals(tuple6.applyFold(tuple6Fold).at(4).getAll, List(4))
-    assertEquals(tuple6.applyFold(tuple6Fold).at(5).getAll, List(5))
-    assertEquals(tuple6.applyFold(tuple6Fold).at(6).getAll, List(6))
+    assertEquals(tuple6.optics.andThen(tuple6Fold).at(1).getAll, List(1))
+    assertEquals(tuple6.optics.andThen(tuple6Fold).at(2).getAll, List(2))
+    assertEquals(tuple6.optics.andThen(tuple6Fold).at(3).getAll, List(3))
+    assertEquals(tuple6.optics.andThen(tuple6Fold).at(4).getAll, List(4))
+    assertEquals(tuple6.optics.andThen(tuple6Fold).at(5).getAll, List(5))
+    assertEquals(tuple6.optics.andThen(tuple6Fold).at(6).getAll, List(6))
 
     val sortedMap     = immutable.SortedMap(1 -> "one")
     val sortedMapFold = Fold.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapFold.at(1).getAll(sortedMap), List(Some("one")))
     assertEquals(sortedMapFold.at(0).getAll(sortedMap), List(None))
-    assertEquals(sortedMap.applyFold(sortedMapFold).at(1).getAll, List(Some("one")))
-    assertEquals(sortedMap.applyFold(sortedMapFold).at(0).getAll, List(None))
+    assertEquals(sortedMap.optics.andThen(sortedMapFold).at(1).getAll, List(Some("one")))
+    assertEquals(sortedMap.optics.andThen(sortedMapFold).at(0).getAll, List(None))
 
     val listMap     = immutable.ListMap(1 -> "one")
     val listMapFold = Fold.id[immutable.ListMap[Int, String]]
     assertEquals(listMapFold.at(1).getAll(listMap), List(Some("one")))
     assertEquals(listMapFold.at(0).getAll(listMap), List(None))
-    assertEquals(listMap.applyFold(listMapFold).at(1).getAll, List(Some("one")))
-    assertEquals(listMap.applyFold(listMapFold).at(0).getAll, List(None))
+    assertEquals(listMap.optics.andThen(listMapFold).at(1).getAll, List(Some("one")))
+    assertEquals(listMap.optics.andThen(listMapFold).at(0).getAll, List(None))
 
     val map     = immutable.Map(1 -> "one")
     val mapFold = Fold.id[Map[Int, String]]
     assertEquals(mapFold.at(1).getAll(map), List(Some("one")))
     assertEquals(mapFold.at(0).getAll(map), List(None))
-    assertEquals(map.applyFold(mapFold).at(1).getAll, List(Some("one")))
-    assertEquals(map.applyFold(mapFold).at(0).getAll, List(None))
+    assertEquals(map.optics.andThen(mapFold).at(1).getAll, List(Some("one")))
+    assertEquals(map.optics.andThen(mapFold).at(0).getAll, List(None))
 
     val set     = Set(1)
     val setFold = Fold.id[Set[Int]]
     assertEquals(setFold.at(1).getAll(set), List(true))
     assertEquals(setFold.at(0).getAll(set), List(false))
-    assertEquals(set.applyFold(setFold).at(1).getAll, List(true))
-    assertEquals(set.applyFold(setFold).at(0).getAll, List(false))
+    assertEquals(set.optics.andThen(setFold).at(1).getAll, List(true))
+    assertEquals(set.optics.andThen(setFold).at(0).getAll, List(false))
   }
 
   test("index") {
@@ -232,70 +232,70 @@ class FoldSpec extends MonocleSuite {
     val listFold = Fold.id[List[Int]]
     assertEquals(listFold.index(0).getAll(list), List(1))
     assertEquals(listFold.index(1).getAll(list), Nil)
-    assertEquals(list.applyFold(listFold).index(0).getAll, List(1))
-    assertEquals(list.applyFold(listFold).index(1).getAll, Nil)
+    assertEquals(list.optics.andThen(listFold).index(0).getAll, List(1))
+    assertEquals(list.optics.andThen(listFold).index(1).getAll, Nil)
 
     val lazyList     = LazyList(1)
     val lazyListFold = Fold.id[LazyList[Int]]
     assertEquals(lazyListFold.index(0).getAll(lazyList), List(1))
     assertEquals(lazyListFold.index(1).getAll(lazyList), Nil)
-    assertEquals(lazyList.applyFold(lazyListFold).index(0).getAll, List(1))
-    assertEquals(lazyList.applyFold(lazyListFold).index(1).getAll, Nil)
+    assertEquals(lazyList.optics.andThen(lazyListFold).index(0).getAll, List(1))
+    assertEquals(lazyList.optics.andThen(lazyListFold).index(1).getAll, Nil)
 
     val listMap     = immutable.ListMap(1 -> "one")
     val listMapFold = Fold.id[immutable.ListMap[Int, String]]
     assertEquals(listMapFold.index(0).getAll(listMap), Nil)
     assertEquals(listMapFold.index(1).getAll(listMap), List("one"))
-    assertEquals(listMap.applyFold(listMapFold).index(0).getAll, Nil)
-    assertEquals(listMap.applyFold(listMapFold).index(1).getAll, List("one"))
+    assertEquals(listMap.optics.andThen(listMapFold).index(0).getAll, Nil)
+    assertEquals(listMap.optics.andThen(listMapFold).index(1).getAll, List("one"))
 
     val map     = Map(1 -> "one")
     val mapFold = Fold.id[Map[Int, String]]
     assertEquals(mapFold.index(0).getAll(map), Nil)
     assertEquals(mapFold.index(1).getAll(map), List("one"))
-    assertEquals(map.applyFold(mapFold).index(0).getAll, Nil)
-    assertEquals(map.applyFold(mapFold).index(1).getAll, List("one"))
+    assertEquals(map.optics.andThen(mapFold).index(0).getAll, Nil)
+    assertEquals(map.optics.andThen(mapFold).index(1).getAll, List("one"))
 
     val sortedMap     = immutable.SortedMap(1 -> "one")
     val sortedMapFold = Fold.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapFold.index(0).getAll(sortedMap), Nil)
     assertEquals(sortedMapFold.index(1).getAll(sortedMap), List("one"))
-    assertEquals(sortedMap.applyFold(sortedMapFold).index(0).getAll, Nil)
-    assertEquals(sortedMap.applyFold(sortedMapFold).index(1).getAll, List("one"))
+    assertEquals(sortedMap.optics.andThen(sortedMapFold).index(0).getAll, Nil)
+    assertEquals(sortedMap.optics.andThen(sortedMapFold).index(1).getAll, List("one"))
 
     val vector     = Vector(1)
     val vectorFold = Fold.id[Vector[Int]]
     assertEquals(vectorFold.index(0).getAll(vector), List(1))
     assertEquals(vectorFold.index(1).getAll(vector), Nil)
-    assertEquals(vector.applyFold(vectorFold).index(0).getAll, List(1))
-    assertEquals(vector.applyFold(vectorFold).index(1).getAll, Nil)
+    assertEquals(vector.optics.andThen(vectorFold).index(0).getAll, List(1))
+    assertEquals(vector.optics.andThen(vectorFold).index(1).getAll, Nil)
 
     val chain     = Chain.one(1)
     val chainFold = Fold.id[Chain[Int]]
     assertEquals(chainFold.index(0).getAll(chain), List(1))
     assertEquals(chainFold.index(1).getAll(chain), Nil)
-    assertEquals(chain.applyFold(chainFold).index(0).getAll, List(1))
-    assertEquals(chain.applyFold(chainFold).index(1).getAll, Nil)
+    assertEquals(chain.optics.andThen(chainFold).index(0).getAll, List(1))
+    assertEquals(chain.optics.andThen(chainFold).index(1).getAll, Nil)
 
     val nec     = NonEmptyChain.one(1)
     val necFold = Fold.id[NonEmptyChain[Int]]
     assertEquals(necFold.index(0).getAll(nec), List(1))
     assertEquals(necFold.index(1).getAll(nec), Nil)
-    assertEquals(nec.applyFold(necFold).index(0).getAll, List(1))
-    assertEquals(nec.applyFold(necFold).index(1).getAll, Nil)
+    assertEquals(nec.optics.andThen(necFold).index(0).getAll, List(1))
+    assertEquals(nec.optics.andThen(necFold).index(1).getAll, Nil)
 
     val nev     = NonEmptyVector.one(1)
     val nevFold = Fold.id[NonEmptyVector[Int]]
     assertEquals(nevFold.index(0).getAll(nev), List(1))
     assertEquals(nevFold.index(1).getAll(nev), Nil)
-    assertEquals(nev.applyFold(nevFold).index(0).getAll, List(1))
-    assertEquals(nev.applyFold(nevFold).index(1).getAll, Nil)
+    assertEquals(nev.optics.andThen(nevFold).index(0).getAll, List(1))
+    assertEquals(nev.optics.andThen(nevFold).index(1).getAll, Nil)
 
     val nel     = NonEmptyList.one(1)
     val nelFold = Fold.id[NonEmptyList[Int]]
     assertEquals(nelFold.index(0).getAll(nel), List(1))
     assertEquals(nelFold.index(1).getAll(nel), Nil)
-    assertEquals(nel.applyFold(nelFold).index(0).getAll, List(1))
-    assertEquals(nel.applyFold(nelFold).index(1).getAll, Nil)
+    assertEquals(nel.optics.andThen(nelFold).index(0).getAll, List(1))
+    assertEquals(nel.optics.andThen(nelFold).index(1).getAll, Nil)
   }
 }

--- a/test/shared/src/test/scala/monocle/GetterSpec.scala
+++ b/test/shared/src/test/scala/monocle/GetterSpec.scala
@@ -82,7 +82,7 @@ class GetterSpec extends MonocleSuite {
     val getter = Getter((_: SomeTest).y)
 
     assertEquals(getter.some.getAll(obj), List(2))
-    assertEquals(obj.applyGetter(getter).some.getAll, List(2))
+    assertEquals(obj.optics.andThen(getter).some.getAll, List(2))
   }
 
   test("withDefault") {
@@ -95,8 +95,8 @@ class GetterSpec extends MonocleSuite {
     assertEquals(getter.withDefault(0).get(objSome), 2)
     assertEquals(getter.withDefault(0).get(objNone), 0)
 
-    assertEquals(objSome.applyGetter(getter).withDefault(0).get, 2)
-    assertEquals(objNone.applyGetter(getter).withDefault(0).get, 0)
+    assertEquals(objSome.optics.andThen(getter).withDefault(0).get, 2)
+    assertEquals(objNone.optics.andThen(getter).withDefault(0).get, 0)
   }
 
   test("each") {
@@ -106,7 +106,7 @@ class GetterSpec extends MonocleSuite {
     val getter = Getter((_: SomeTest).y)
 
     assertEquals(getter.each.getAll(obj), List(1, 2, 3))
-    assertEquals(obj.applyGetter(getter).each.getAll, List(1, 2, 3))
+    assertEquals(obj.optics.andThen(getter).each.getAll, List(1, 2, 3))
   }
 
   test("filter") {
@@ -116,7 +116,7 @@ class GetterSpec extends MonocleSuite {
     val getter = Getter[SomeTest, Int](_.y)
 
     assertEquals(getter.filter(_ > 0).getAll(obj), List(2))
-    assertEquals(obj.applyGetter(getter).filter(_ > 0).getAll, List(2))
+    assertEquals(obj.optics.andThen(getter).filter(_ > 0).getAll, List(2))
   }
 
   test("filterIndex") {
@@ -126,7 +126,7 @@ class GetterSpec extends MonocleSuite {
     val getter = Getter[SomeTest, List[String]](_.y)
 
     assertEquals(getter.filterIndex((_: Int) > 0).getAll(obj), List("world"))
-    assertEquals(obj.applyGetter(getter).filterIndex((_: Int) > 0).getAll, List("world"))
+    assertEquals(obj.optics.andThen(getter).filterIndex((_: Int) > 0).getAll, List("world"))
   }
 
   test("at") {
@@ -134,17 +134,17 @@ class GetterSpec extends MonocleSuite {
     val tuple2Getter = Getter.id[(Int, Int)]
     assertEquals(tuple2Getter.at(1).get(tuple2), 1)
     assertEquals(tuple2Getter.at(2).get(tuple2), 2)
-    assertEquals(tuple2.applyGetter(tuple2Getter).at(1).get, 1)
-    assertEquals(tuple2.applyGetter(tuple2Getter).at(2).get, 2)
+    assertEquals(tuple2.optics.andThen(tuple2Getter).at(1).get, 1)
+    assertEquals(tuple2.optics.andThen(tuple2Getter).at(2).get, 2)
 
     val tuple3       = (1, 2, 3)
     val tuple3Getter = Getter.id[(Int, Int, Int)]
     assertEquals(tuple3Getter.at(1).get(tuple3), 1)
     assertEquals(tuple3Getter.at(2).get(tuple3), 2)
     assertEquals(tuple3Getter.at(3).get(tuple3), 3)
-    assertEquals(tuple3.applyGetter(tuple3Getter).at(1).get, 1)
-    assertEquals(tuple3.applyGetter(tuple3Getter).at(2).get, 2)
-    assertEquals(tuple3.applyGetter(tuple3Getter).at(3).get, 3)
+    assertEquals(tuple3.optics.andThen(tuple3Getter).at(1).get, 1)
+    assertEquals(tuple3.optics.andThen(tuple3Getter).at(2).get, 2)
+    assertEquals(tuple3.optics.andThen(tuple3Getter).at(3).get, 3)
 
     val tuple4       = (1, 2, 3, 4)
     val tuple4Getter = Getter.id[(Int, Int, Int, Int)]
@@ -152,10 +152,10 @@ class GetterSpec extends MonocleSuite {
     assertEquals(tuple4Getter.at(2).get(tuple4), 2)
     assertEquals(tuple4Getter.at(3).get(tuple4), 3)
     assertEquals(tuple4Getter.at(4).get(tuple4), 4)
-    assertEquals(tuple4.applyGetter(tuple4Getter).at(1).get, 1)
-    assertEquals(tuple4.applyGetter(tuple4Getter).at(2).get, 2)
-    assertEquals(tuple4.applyGetter(tuple4Getter).at(3).get, 3)
-    assertEquals(tuple4.applyGetter(tuple4Getter).at(4).get, 4)
+    assertEquals(tuple4.optics.andThen(tuple4Getter).at(1).get, 1)
+    assertEquals(tuple4.optics.andThen(tuple4Getter).at(2).get, 2)
+    assertEquals(tuple4.optics.andThen(tuple4Getter).at(3).get, 3)
+    assertEquals(tuple4.optics.andThen(tuple4Getter).at(4).get, 4)
 
     val tuple5       = (1, 2, 3, 4, 5)
     val tuple5Getter = Getter.id[(Int, Int, Int, Int, Int)]
@@ -164,11 +164,11 @@ class GetterSpec extends MonocleSuite {
     assertEquals(tuple5Getter.at(3).get(tuple5), 3)
     assertEquals(tuple5Getter.at(4).get(tuple5), 4)
     assertEquals(tuple5Getter.at(5).get(tuple5), 5)
-    assertEquals(tuple5.applyGetter(tuple5Getter).at(1).get, 1)
-    assertEquals(tuple5.applyGetter(tuple5Getter).at(2).get, 2)
-    assertEquals(tuple5.applyGetter(tuple5Getter).at(3).get, 3)
-    assertEquals(tuple5.applyGetter(tuple5Getter).at(4).get, 4)
-    assertEquals(tuple5.applyGetter(tuple5Getter).at(5).get, 5)
+    assertEquals(tuple5.optics.andThen(tuple5Getter).at(1).get, 1)
+    assertEquals(tuple5.optics.andThen(tuple5Getter).at(2).get, 2)
+    assertEquals(tuple5.optics.andThen(tuple5Getter).at(3).get, 3)
+    assertEquals(tuple5.optics.andThen(tuple5Getter).at(4).get, 4)
+    assertEquals(tuple5.optics.andThen(tuple5Getter).at(5).get, 5)
 
     val tuple6       = (1, 2, 3, 4, 5, 6)
     val tuple6Getter = Getter.id[(Int, Int, Int, Int, Int, Int)]
@@ -178,40 +178,40 @@ class GetterSpec extends MonocleSuite {
     assertEquals(tuple6Getter.at(4).get(tuple6), 4)
     assertEquals(tuple6Getter.at(5).get(tuple6), 5)
     assertEquals(tuple6Getter.at(6).get(tuple6), 6)
-    assertEquals(tuple6.applyGetter(tuple6Getter).at(1).get, 1)
-    assertEquals(tuple6.applyGetter(tuple6Getter).at(2).get, 2)
-    assertEquals(tuple6.applyGetter(tuple6Getter).at(3).get, 3)
-    assertEquals(tuple6.applyGetter(tuple6Getter).at(4).get, 4)
-    assertEquals(tuple6.applyGetter(tuple6Getter).at(5).get, 5)
-    assertEquals(tuple6.applyGetter(tuple6Getter).at(6).get, 6)
+    assertEquals(tuple6.optics.andThen(tuple6Getter).at(1).get, 1)
+    assertEquals(tuple6.optics.andThen(tuple6Getter).at(2).get, 2)
+    assertEquals(tuple6.optics.andThen(tuple6Getter).at(3).get, 3)
+    assertEquals(tuple6.optics.andThen(tuple6Getter).at(4).get, 4)
+    assertEquals(tuple6.optics.andThen(tuple6Getter).at(5).get, 5)
+    assertEquals(tuple6.optics.andThen(tuple6Getter).at(6).get, 6)
 
     val sortedMap       = immutable.SortedMap(1 -> "one")
     val sortedMapGetter = Getter.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapGetter.at(1).get(sortedMap), Some("one"))
     assertEquals(sortedMapGetter.at(0).get(sortedMap), None)
-    assertEquals(sortedMap.applyGetter(sortedMapGetter).at(1).get, Some("one"))
-    assertEquals(sortedMap.applyGetter(sortedMapGetter).at(0).get, None)
+    assertEquals(sortedMap.optics.andThen(sortedMapGetter).at(1).get, Some("one"))
+    assertEquals(sortedMap.optics.andThen(sortedMapGetter).at(0).get, None)
 
     val listMap       = immutable.ListMap(1 -> "one")
     val listMapGetter = Getter.id[immutable.ListMap[Int, String]]
     assertEquals(listMapGetter.at(1).get(listMap), Some("one"))
     assertEquals(listMapGetter.at(0).get(listMap), None)
-    assertEquals(listMap.applyGetter(listMapGetter).at(1).get, Some("one"))
-    assertEquals(listMap.applyGetter(listMapGetter).at(0).get, None)
+    assertEquals(listMap.optics.andThen(listMapGetter).at(1).get, Some("one"))
+    assertEquals(listMap.optics.andThen(listMapGetter).at(0).get, None)
 
     val map       = immutable.Map(1 -> "one")
     val mapGetter = Getter.id[Map[Int, String]]
     assertEquals(mapGetter.at(1).get(map), Some("one"))
     assertEquals(mapGetter.at(0).get(map), None)
-    assertEquals(map.applyGetter(mapGetter).at(1).get, Some("one"))
-    assertEquals(map.applyGetter(mapGetter).at(0).get, None)
+    assertEquals(map.optics.andThen(mapGetter).at(1).get, Some("one"))
+    assertEquals(map.optics.andThen(mapGetter).at(0).get, None)
 
     val set       = Set(1)
     val setGetter = Getter.id[Set[Int]]
     assertEquals(setGetter.at(1).get(set), true)
     assertEquals(setGetter.at(0).get(set), false)
-    assertEquals(set.applyGetter(setGetter).at(1).get, true)
-    assertEquals(set.applyGetter(setGetter).at(0).get, false)
+    assertEquals(set.optics.andThen(setGetter).at(1).get, true)
+    assertEquals(set.optics.andThen(setGetter).at(0).get, false)
   }
 
   test("index") {
@@ -219,70 +219,70 @@ class GetterSpec extends MonocleSuite {
     val listGetter = Getter.id[List[Int]]
     assertEquals(listGetter.index(0).getAll(list), List(1))
     assertEquals(listGetter.index(1).getAll(list), Nil)
-    assertEquals(list.applyGetter(listGetter).index(0).getAll, List(1))
-    assertEquals(list.applyGetter(listGetter).index(1).getAll, Nil)
+    assertEquals(list.optics.andThen(listGetter).index(0).getAll, List(1))
+    assertEquals(list.optics.andThen(listGetter).index(1).getAll, Nil)
 
     val lazyList       = LazyList(1)
     val lazyListGetter = Getter.id[LazyList[Int]]
     assertEquals(lazyListGetter.index(0).getAll(lazyList), List(1))
     assertEquals(lazyListGetter.index(1).getAll(lazyList), Nil)
-    assertEquals(lazyList.applyGetter(lazyListGetter).index(0).getAll, List(1))
-    assertEquals(lazyList.applyGetter(lazyListGetter).index(1).getAll, Nil)
+    assertEquals(lazyList.optics.andThen(lazyListGetter).index(0).getAll, List(1))
+    assertEquals(lazyList.optics.andThen(lazyListGetter).index(1).getAll, Nil)
 
     val listMap       = immutable.ListMap(1 -> "one")
     val listMapGetter = Getter.id[immutable.ListMap[Int, String]]
     assertEquals(listMapGetter.index(0).getAll(listMap), Nil)
     assertEquals(listMapGetter.index(1).getAll(listMap), List("one"))
-    assertEquals(listMap.applyGetter(listMapGetter).index(0).getAll, Nil)
-    assertEquals(listMap.applyGetter(listMapGetter).index(1).getAll, List("one"))
+    assertEquals(listMap.optics.andThen(listMapGetter).index(0).getAll, Nil)
+    assertEquals(listMap.optics.andThen(listMapGetter).index(1).getAll, List("one"))
 
     val map       = Map(1 -> "one")
     val mapGetter = Getter.id[Map[Int, String]]
     assertEquals(mapGetter.index(0).getAll(map), Nil)
     assertEquals(mapGetter.index(1).getAll(map), List("one"))
-    assertEquals(map.applyGetter(mapGetter).index(0).getAll, Nil)
-    assertEquals(map.applyGetter(mapGetter).index(1).getAll, List("one"))
+    assertEquals(map.optics.andThen(mapGetter).index(0).getAll, Nil)
+    assertEquals(map.optics.andThen(mapGetter).index(1).getAll, List("one"))
 
     val sortedMap       = immutable.SortedMap(1 -> "one")
     val sortedMapGetter = Getter.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapGetter.index(0).getAll(sortedMap), Nil)
     assertEquals(sortedMapGetter.index(1).getAll(sortedMap), List("one"))
-    assertEquals(sortedMap.applyGetter(sortedMapGetter).index(0).getAll, Nil)
-    assertEquals(sortedMap.applyGetter(sortedMapGetter).index(1).getAll, List("one"))
+    assertEquals(sortedMap.optics.andThen(sortedMapGetter).index(0).getAll, Nil)
+    assertEquals(sortedMap.optics.andThen(sortedMapGetter).index(1).getAll, List("one"))
 
     val vector       = Vector(1)
     val vectorGetter = Getter.id[Vector[Int]]
     assertEquals(vectorGetter.index(0).getAll(vector), List(1))
     assertEquals(vectorGetter.index(1).getAll(vector), Nil)
-    assertEquals(vector.applyGetter(vectorGetter).index(0).getAll, List(1))
-    assertEquals(vector.applyGetter(vectorGetter).index(1).getAll, Nil)
+    assertEquals(vector.optics.andThen(vectorGetter).index(0).getAll, List(1))
+    assertEquals(vector.optics.andThen(vectorGetter).index(1).getAll, Nil)
 
     val chain       = Chain.one(1)
     val chainGetter = Getter.id[Chain[Int]]
     assertEquals(chainGetter.index(0).getAll(chain), List(1))
     assertEquals(chainGetter.index(1).getAll(chain), Nil)
-    assertEquals(chain.applyGetter(chainGetter).index(0).getAll, List(1))
-    assertEquals(chain.applyGetter(chainGetter).index(1).getAll, Nil)
+    assertEquals(chain.optics.andThen(chainGetter).index(0).getAll, List(1))
+    assertEquals(chain.optics.andThen(chainGetter).index(1).getAll, Nil)
 
     val nec       = NonEmptyChain.one(1)
     val necGetter = Getter.id[NonEmptyChain[Int]]
     assertEquals(necGetter.index(0).getAll(nec), List(1))
     assertEquals(necGetter.index(1).getAll(nec), Nil)
-    assertEquals(nec.applyGetter(necGetter).index(0).getAll, List(1))
-    assertEquals(nec.applyGetter(necGetter).index(1).getAll, Nil)
+    assertEquals(nec.optics.andThen(necGetter).index(0).getAll, List(1))
+    assertEquals(nec.optics.andThen(necGetter).index(1).getAll, Nil)
 
     val nev       = NonEmptyVector.one(1)
     val nevGetter = Getter.id[NonEmptyVector[Int]]
     assertEquals(nevGetter.index(0).getAll(nev), List(1))
     assertEquals(nevGetter.index(1).getAll(nev), Nil)
-    assertEquals(nev.applyGetter(nevGetter).index(0).getAll, List(1))
-    assertEquals(nev.applyGetter(nevGetter).index(1).getAll, Nil)
+    assertEquals(nev.optics.andThen(nevGetter).index(0).getAll, List(1))
+    assertEquals(nev.optics.andThen(nevGetter).index(1).getAll, Nil)
 
     val nel       = NonEmptyList.one(1)
     val nelGetter = Getter.id[NonEmptyList[Int]]
     assertEquals(nelGetter.index(0).getAll(nel), List(1))
     assertEquals(nelGetter.index(1).getAll(nel), Nil)
-    assertEquals(nel.applyGetter(nelGetter).index(0).getAll, List(1))
-    assertEquals(nel.applyGetter(nelGetter).index(1).getAll, Nil)
+    assertEquals(nel.optics.andThen(nelGetter).index(0).getAll, List(1))
+    assertEquals(nel.optics.andThen(nelGetter).index(1).getAll, Nil)
   }
 }

--- a/test/shared/src/test/scala/monocle/IsoSpec.scala
+++ b/test/shared/src/test/scala/monocle/IsoSpec.scala
@@ -175,7 +175,7 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     val iso = Iso[SomeTest, Option[Int]](_.y)(SomeTest)
 
     assertEquals(iso.some.getOption(obj), Some(2))
-    assertEquals(obj.applyIso(iso).some.getOption, Some(2))
+    assertEquals(obj.optics.andThen(iso).some.getOption, Some(2))
   }
 
   test("withDefault") {
@@ -188,7 +188,7 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     assertEquals(iso.withDefault(0).get(objSome), 2)
     assertEquals(iso.withDefault(0).get(objNone), 0)
 
-    assertEquals(objNone.applyIso(iso).withDefault(0).get, 0)
+    assertEquals(objNone.optics.andThen(iso).withDefault(0).get, 0)
   }
 
   test("each") {
@@ -198,7 +198,7 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     val iso = Iso[SomeTest, List[Int]](_.y)(SomeTest)
 
     assertEquals(iso.each.getAll(obj), List(1, 2, 3))
-    assertEquals(obj.applyIso(iso).each.getAll, List(1, 2, 3))
+    assertEquals(obj.optics.andThen(iso).each.getAll, List(1, 2, 3))
   }
 
   test("filter") {
@@ -208,7 +208,7 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     val iso = Iso[SomeTest, Int](_.y)(SomeTest)
 
     assertEquals(iso.filter(_ > 0).getOption(obj), Some(2))
-    assertEquals(obj.applyIso(iso).filter(_ > 0).getOption, Some(2))
+    assertEquals(obj.optics.andThen(iso).filter(_ > 0).getOption, Some(2))
   }
 
   test("filterIndex") {
@@ -218,7 +218,7 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     val iso = Iso[SomeTest, List[String]](_.y)(SomeTest)
 
     assertEquals(iso.filterIndex((_: Int) > 0).getAll(obj), List("world"))
-    assertEquals(obj.applyIso(iso).filterIndex((_: Int) > 0).getAll, List("world"))
+    assertEquals(obj.optics.andThen(iso).filterIndex((_: Int) > 0).getAll, List("world"))
   }
 
   test("at") {
@@ -226,17 +226,17 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     val tuple2Lens = Iso.id[(Int, Int)]
     assertEquals(tuple2Lens.at(1).get(tuple2), 1)
     assertEquals(tuple2Lens.at(2).get(tuple2), 2)
-    assertEquals(tuple2.applyIso(tuple2Lens).at(1).get, 1)
-    assertEquals(tuple2.applyIso(tuple2Lens).at(2).get, 2)
+    assertEquals(tuple2.optics.andThen(tuple2Lens).at(1).get, 1)
+    assertEquals(tuple2.optics.andThen(tuple2Lens).at(2).get, 2)
 
     val tuple3     = (1, 2, 3)
     val tuple3Lens = Iso.id[(Int, Int, Int)]
     assertEquals(tuple3Lens.at(1).get(tuple3), 1)
     assertEquals(tuple3Lens.at(2).get(tuple3), 2)
     assertEquals(tuple3Lens.at(3).get(tuple3), 3)
-    assertEquals(tuple3.applyIso(tuple3Lens).at(1).get, 1)
-    assertEquals(tuple3.applyIso(tuple3Lens).at(2).get, 2)
-    assertEquals(tuple3.applyIso(tuple3Lens).at(3).get, 3)
+    assertEquals(tuple3.optics.andThen(tuple3Lens).at(1).get, 1)
+    assertEquals(tuple3.optics.andThen(tuple3Lens).at(2).get, 2)
+    assertEquals(tuple3.optics.andThen(tuple3Lens).at(3).get, 3)
 
     val tuple4     = (1, 2, 3, 4)
     val tuple4Lens = Iso.id[(Int, Int, Int, Int)]
@@ -244,10 +244,10 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     assertEquals(tuple4Lens.at(2).get(tuple4), 2)
     assertEquals(tuple4Lens.at(3).get(tuple4), 3)
     assertEquals(tuple4Lens.at(4).get(tuple4), 4)
-    assertEquals(tuple4.applyIso(tuple4Lens).at(1).get, 1)
-    assertEquals(tuple4.applyIso(tuple4Lens).at(2).get, 2)
-    assertEquals(tuple4.applyIso(tuple4Lens).at(3).get, 3)
-    assertEquals(tuple4.applyIso(tuple4Lens).at(4).get, 4)
+    assertEquals(tuple4.optics.andThen(tuple4Lens).at(1).get, 1)
+    assertEquals(tuple4.optics.andThen(tuple4Lens).at(2).get, 2)
+    assertEquals(tuple4.optics.andThen(tuple4Lens).at(3).get, 3)
+    assertEquals(tuple4.optics.andThen(tuple4Lens).at(4).get, 4)
 
     val tuple5     = (1, 2, 3, 4, 5)
     val tuple5Lens = Iso.id[(Int, Int, Int, Int, Int)]
@@ -256,11 +256,11 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     assertEquals(tuple5Lens.at(3).get(tuple5), 3)
     assertEquals(tuple5Lens.at(4).get(tuple5), 4)
     assertEquals(tuple5Lens.at(5).get(tuple5), 5)
-    assertEquals(tuple5.applyIso(tuple5Lens).at(1).get, 1)
-    assertEquals(tuple5.applyIso(tuple5Lens).at(2).get, 2)
-    assertEquals(tuple5.applyIso(tuple5Lens).at(3).get, 3)
-    assertEquals(tuple5.applyIso(tuple5Lens).at(4).get, 4)
-    assertEquals(tuple5.applyIso(tuple5Lens).at(5).get, 5)
+    assertEquals(tuple5.optics.andThen(tuple5Lens).at(1).get, 1)
+    assertEquals(tuple5.optics.andThen(tuple5Lens).at(2).get, 2)
+    assertEquals(tuple5.optics.andThen(tuple5Lens).at(3).get, 3)
+    assertEquals(tuple5.optics.andThen(tuple5Lens).at(4).get, 4)
+    assertEquals(tuple5.optics.andThen(tuple5Lens).at(5).get, 5)
 
     val tuple6     = (1, 2, 3, 4, 5, 6)
     val tuple6Lens = Iso.id[(Int, Int, Int, Int, Int, Int)]
@@ -270,40 +270,40 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     assertEquals(tuple6Lens.at(4).get(tuple6), 4)
     assertEquals(tuple6Lens.at(5).get(tuple6), 5)
     assertEquals(tuple6Lens.at(6).get(tuple6), 6)
-    assertEquals(tuple6.applyIso(tuple6Lens).at(1).get, 1)
-    assertEquals(tuple6.applyIso(tuple6Lens).at(2).get, 2)
-    assertEquals(tuple6.applyIso(tuple6Lens).at(3).get, 3)
-    assertEquals(tuple6.applyIso(tuple6Lens).at(4).get, 4)
-    assertEquals(tuple6.applyIso(tuple6Lens).at(5).get, 5)
-    assertEquals(tuple6.applyIso(tuple6Lens).at(6).get, 6)
+    assertEquals(tuple6.optics.andThen(tuple6Lens).at(1).get, 1)
+    assertEquals(tuple6.optics.andThen(tuple6Lens).at(2).get, 2)
+    assertEquals(tuple6.optics.andThen(tuple6Lens).at(3).get, 3)
+    assertEquals(tuple6.optics.andThen(tuple6Lens).at(4).get, 4)
+    assertEquals(tuple6.optics.andThen(tuple6Lens).at(5).get, 5)
+    assertEquals(tuple6.optics.andThen(tuple6Lens).at(6).get, 6)
 
     val sortedMap     = immutable.SortedMap(1 -> "one")
     val sortedMapLens = Iso.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapLens.at(1).get(sortedMap), Some("one"))
     assertEquals(sortedMapLens.at(2).get(sortedMap), None)
-    assertEquals(sortedMap.applyIso(sortedMapLens).at(1).get, Some("one"))
-    assertEquals(sortedMap.applyIso(sortedMapLens).at(2).get, None)
+    assertEquals(sortedMap.optics.andThen(sortedMapLens).at(1).get, Some("one"))
+    assertEquals(sortedMap.optics.andThen(sortedMapLens).at(2).get, None)
 
     val listMap     = immutable.ListMap(1 -> "one")
     val listMapLens = Iso.id[immutable.ListMap[Int, String]]
     assertEquals(listMapLens.at(1).get(listMap), Some("one"))
     assertEquals(listMapLens.at(2).get(listMap), None)
-    assertEquals(listMap.applyIso(listMapLens).at(1).get, Some("one"))
-    assertEquals(listMap.applyIso(listMapLens).at(2).get, None)
+    assertEquals(listMap.optics.andThen(listMapLens).at(1).get, Some("one"))
+    assertEquals(listMap.optics.andThen(listMapLens).at(2).get, None)
 
     val map     = immutable.Map(1 -> "one")
     val mapLens = Iso.id[Map[Int, String]]
     assertEquals(mapLens.at(1).get(map), Some("one"))
     assertEquals(mapLens.at(2).get(map), None)
-    assertEquals(map.applyIso(mapLens).at(1).get, Some("one"))
-    assertEquals(map.applyIso(mapLens).at(2).get, None)
+    assertEquals(map.optics.andThen(mapLens).at(1).get, Some("one"))
+    assertEquals(map.optics.andThen(mapLens).at(2).get, None)
 
     val set     = Set(1)
     val setLens = Iso.id[Set[Int]]
     assertEquals(setLens.at(1).get(set), true)
     assertEquals(setLens.at(2).get(set), false)
-    assertEquals(set.applyIso(setLens).at(1).get, true)
-    assertEquals(set.applyIso(setLens).at(2).get, false)
+    assertEquals(set.optics.andThen(setLens).at(1).get, true)
+    assertEquals(set.optics.andThen(setLens).at(2).get, false)
   }
 
   test("index") {
@@ -311,70 +311,70 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     val listLens = Iso.id[List[Int]]
     assertEquals(listLens.index(0).getOption(list), Some(1))
     assertEquals(listLens.index(1).getOption(list), None)
-    assertEquals(list.applyIso(listLens).index(0).getOption, Some(1))
-    assertEquals(list.applyIso(listLens).index(1).getOption, None)
+    assertEquals(list.optics.andThen(listLens).index(0).getOption, Some(1))
+    assertEquals(list.optics.andThen(listLens).index(1).getOption, None)
 
     val lazyList     = LazyList(1)
     val lazyListLens = Iso.id[LazyList[Int]]
     assertEquals(lazyListLens.index(0).getOption(lazyList), Some(1))
     assertEquals(lazyListLens.index(1).getOption(lazyList), None)
-    assertEquals(lazyList.applyIso(lazyListLens).index(0).getOption, Some(1))
-    assertEquals(lazyList.applyIso(lazyListLens).index(1).getOption, None)
+    assertEquals(lazyList.optics.andThen(lazyListLens).index(0).getOption, Some(1))
+    assertEquals(lazyList.optics.andThen(lazyListLens).index(1).getOption, None)
 
     val listMap     = immutable.ListMap(1 -> "one")
     val listMapLens = Iso.id[immutable.ListMap[Int, String]]
     assertEquals(listMapLens.index(0).getOption(listMap), None)
     assertEquals(listMapLens.index(1).getOption(listMap), Some("one"))
-    assertEquals(listMap.applyIso(listMapLens).index(0).getOption, None)
-    assertEquals(listMap.applyIso(listMapLens).index(1).getOption, Some("one"))
+    assertEquals(listMap.optics.andThen(listMapLens).index(0).getOption, None)
+    assertEquals(listMap.optics.andThen(listMapLens).index(1).getOption, Some("one"))
 
     val map     = Map(1 -> "one")
     val mapLens = Iso.id[Map[Int, String]]
     assertEquals(mapLens.index(1).getOption(map), Some("one"))
     assertEquals(mapLens.index(0).getOption(map), None)
-    assertEquals(map.applyIso(mapLens).index(1).getOption, Some("one"))
-    assertEquals(map.applyIso(mapLens).index(0).getOption, None)
+    assertEquals(map.optics.andThen(mapLens).index(1).getOption, Some("one"))
+    assertEquals(map.optics.andThen(mapLens).index(0).getOption, None)
 
     val sortedMap     = immutable.SortedMap(1 -> "one")
     val sortedMapLens = Iso.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapLens.index(1).getOption(sortedMap), Some("one"))
     assertEquals(sortedMapLens.index(0).getOption(sortedMap), None)
-    assertEquals(sortedMap.applyIso(sortedMapLens).index(1).getOption, Some("one"))
-    assertEquals(sortedMap.applyIso(sortedMapLens).index(0).getOption, None)
+    assertEquals(sortedMap.optics.andThen(sortedMapLens).index(1).getOption, Some("one"))
+    assertEquals(sortedMap.optics.andThen(sortedMapLens).index(0).getOption, None)
 
     val vector     = Vector(1)
     val vectorLens = Iso.id[Vector[Int]]
     assertEquals(vectorLens.index(0).getOption(vector), Some(1))
     assertEquals(vectorLens.index(1).getOption(vector), None)
-    assertEquals(vector.applyIso(vectorLens).index(0).getOption, Some(1))
-    assertEquals(vector.applyIso(vectorLens).index(1).getOption, None)
+    assertEquals(vector.optics.andThen(vectorLens).index(0).getOption, Some(1))
+    assertEquals(vector.optics.andThen(vectorLens).index(1).getOption, None)
 
     val chain     = Chain.one(1)
     val chainLens = Iso.id[Chain[Int]]
     assertEquals(chainLens.index(0).getOption(chain), Some(1))
     assertEquals(chainLens.index(1).getOption(chain), None)
-    assertEquals(chain.applyIso(chainLens).index(0).getOption, Some(1))
-    assertEquals(chain.applyIso(chainLens).index(1).getOption, None)
+    assertEquals(chain.optics.andThen(chainLens).index(0).getOption, Some(1))
+    assertEquals(chain.optics.andThen(chainLens).index(1).getOption, None)
 
     val nec     = NonEmptyChain.one(1)
     val necLens = Iso.id[NonEmptyChain[Int]]
     assertEquals(necLens.index(0).getOption(nec), Some(1))
     assertEquals(necLens.index(1).getOption(nec), None)
-    assertEquals(nec.applyIso(necLens).index(0).getOption, Some(1))
-    assertEquals(nec.applyIso(necLens).index(1).getOption, None)
+    assertEquals(nec.optics.andThen(necLens).index(0).getOption, Some(1))
+    assertEquals(nec.optics.andThen(necLens).index(1).getOption, None)
 
     val nev     = NonEmptyVector.one(1)
     val nevLens = Iso.id[NonEmptyVector[Int]]
     assertEquals(nevLens.index(0).getOption(nev), Some(1))
     assertEquals(nevLens.index(1).getOption(nev), None)
-    assertEquals(nev.applyIso(nevLens).index(0).getOption, Some(1))
-    assertEquals(nev.applyIso(nevLens).index(1).getOption, None)
+    assertEquals(nev.optics.andThen(nevLens).index(0).getOption, Some(1))
+    assertEquals(nev.optics.andThen(nevLens).index(1).getOption, None)
 
     val nel     = NonEmptyList.one(1)
     val nelLens = Iso.id[NonEmptyList[Int]]
     assertEquals(nelLens.index(0).getOption(nel), Some(1))
     assertEquals(nelLens.index(1).getOption(nel), None)
-    assertEquals(nel.applyIso(nelLens).index(0).getOption, Some(1))
-    assertEquals(nel.applyIso(nelLens).index(1).getOption, None)
+    assertEquals(nel.optics.andThen(nelLens).index(0).getOption, Some(1))
+    assertEquals(nel.optics.andThen(nelLens).index(1).getOption, None)
   }
 }

--- a/test/shared/src/test/scala/monocle/LensSpec.scala
+++ b/test/shared/src/test/scala/monocle/LensSpec.scala
@@ -104,7 +104,7 @@ class LensSpec extends MonocleSuite {
     val lens = GenLens[SomeTest](_.y)
 
     assertEquals(lens.some.getOption(obj), Some(2))
-    assertEquals(obj.applyLens(lens).some.getOption, Some(2))
+    assertEquals(obj.optics.andThen(lens).some.getOption, Some(2))
   }
 
   test("withDefault") {
@@ -117,7 +117,7 @@ class LensSpec extends MonocleSuite {
     assertEquals(lens.withDefault(0).get(objSome), 2)
     assertEquals(lens.withDefault(0).get(objNone), 0)
 
-    assertEquals(objNone.applyLens(lens).withDefault(0).get, 0)
+    assertEquals(objNone.optics.andThen(lens).withDefault(0).get, 0)
   }
 
   test("each") {
@@ -127,7 +127,7 @@ class LensSpec extends MonocleSuite {
     val lens = GenLens[SomeTest](_.y)
 
     assertEquals(lens.each.getAll(obj), List(1, 2, 3))
-    assertEquals(obj.applyLens(lens).each.getAll, List(1, 2, 3))
+    assertEquals(obj.optics.andThen(lens).each.getAll, List(1, 2, 3))
   }
 
   test("filter") {
@@ -137,7 +137,7 @@ class LensSpec extends MonocleSuite {
     val lens = GenLens[SomeTest](_.y)
 
     assertEquals(lens.filter(_ > 0).getOption(obj), Some(2))
-    assertEquals(obj.applyLens(lens).filter(_ > 0).getOption, Some(2))
+    assertEquals(obj.optics.andThen(lens).filter(_ > 0).getOption, Some(2))
   }
 
   test("filterIndex") {
@@ -147,7 +147,7 @@ class LensSpec extends MonocleSuite {
     val lens = GenLens[SomeTest](_.y)
 
     assertEquals(lens.filterIndex((_: Int) > 0).getAll(obj), List("world"))
-    assertEquals(obj.applyLens(lens).filterIndex((_: Int) > 0).getAll, List("world"))
+    assertEquals(obj.optics.andThen(lens).filterIndex((_: Int) > 0).getAll, List("world"))
   }
 
   test("at") {
@@ -155,17 +155,17 @@ class LensSpec extends MonocleSuite {
     val tuple2Lens = Lens.id[(Int, Int)]
     assertEquals(tuple2Lens.at(1).get(tuple2), 1)
     assertEquals(tuple2Lens.at(2).get(tuple2), 2)
-    assertEquals(tuple2.applyLens(tuple2Lens).at(1).get, 1)
-    assertEquals(tuple2.applyLens(tuple2Lens).at(2).get, 2)
+    assertEquals(tuple2.optics.andThen(tuple2Lens).at(1).get, 1)
+    assertEquals(tuple2.optics.andThen(tuple2Lens).at(2).get, 2)
 
     val tuple3     = (1, 2, 3)
     val tuple3Lens = Lens.id[(Int, Int, Int)]
     assertEquals(tuple3Lens.at(1).get(tuple3), 1)
     assertEquals(tuple3Lens.at(2).get(tuple3), 2)
     assertEquals(tuple3Lens.at(3).get(tuple3), 3)
-    assertEquals(tuple3.applyLens(tuple3Lens).at(1).get, 1)
-    assertEquals(tuple3.applyLens(tuple3Lens).at(2).get, 2)
-    assertEquals(tuple3.applyLens(tuple3Lens).at(3).get, 3)
+    assertEquals(tuple3.optics.andThen(tuple3Lens).at(1).get, 1)
+    assertEquals(tuple3.optics.andThen(tuple3Lens).at(2).get, 2)
+    assertEquals(tuple3.optics.andThen(tuple3Lens).at(3).get, 3)
 
     val tuple4     = (1, 2, 3, 4)
     val tuple4Lens = Lens.id[(Int, Int, Int, Int)]
@@ -173,10 +173,10 @@ class LensSpec extends MonocleSuite {
     assertEquals(tuple4Lens.at(2).get(tuple4), 2)
     assertEquals(tuple4Lens.at(3).get(tuple4), 3)
     assertEquals(tuple4Lens.at(4).get(tuple4), 4)
-    assertEquals(tuple4.applyLens(tuple4Lens).at(1).get, 1)
-    assertEquals(tuple4.applyLens(tuple4Lens).at(2).get, 2)
-    assertEquals(tuple4.applyLens(tuple4Lens).at(3).get, 3)
-    assertEquals(tuple4.applyLens(tuple4Lens).at(4).get, 4)
+    assertEquals(tuple4.optics.andThen(tuple4Lens).at(1).get, 1)
+    assertEquals(tuple4.optics.andThen(tuple4Lens).at(2).get, 2)
+    assertEquals(tuple4.optics.andThen(tuple4Lens).at(3).get, 3)
+    assertEquals(tuple4.optics.andThen(tuple4Lens).at(4).get, 4)
 
     val tuple5     = (1, 2, 3, 4, 5)
     val tuple5Lens = Lens.id[(Int, Int, Int, Int, Int)]
@@ -185,11 +185,11 @@ class LensSpec extends MonocleSuite {
     assertEquals(tuple5Lens.at(3).get(tuple5), 3)
     assertEquals(tuple5Lens.at(4).get(tuple5), 4)
     assertEquals(tuple5Lens.at(5).get(tuple5), 5)
-    assertEquals(tuple5.applyLens(tuple5Lens).at(1).get, 1)
-    assertEquals(tuple5.applyLens(tuple5Lens).at(2).get, 2)
-    assertEquals(tuple5.applyLens(tuple5Lens).at(3).get, 3)
-    assertEquals(tuple5.applyLens(tuple5Lens).at(4).get, 4)
-    assertEquals(tuple5.applyLens(tuple5Lens).at(5).get, 5)
+    assertEquals(tuple5.optics.andThen(tuple5Lens).at(1).get, 1)
+    assertEquals(tuple5.optics.andThen(tuple5Lens).at(2).get, 2)
+    assertEquals(tuple5.optics.andThen(tuple5Lens).at(3).get, 3)
+    assertEquals(tuple5.optics.andThen(tuple5Lens).at(4).get, 4)
+    assertEquals(tuple5.optics.andThen(tuple5Lens).at(5).get, 5)
 
     val tuple6     = (1, 2, 3, 4, 5, 6)
     val tuple6Lens = Lens.id[(Int, Int, Int, Int, Int, Int)]
@@ -199,40 +199,40 @@ class LensSpec extends MonocleSuite {
     assertEquals(tuple6Lens.at(4).get(tuple6), 4)
     assertEquals(tuple6Lens.at(5).get(tuple6), 5)
     assertEquals(tuple6Lens.at(6).get(tuple6), 6)
-    assertEquals(tuple6.applyLens(tuple6Lens).at(1).get, 1)
-    assertEquals(tuple6.applyLens(tuple6Lens).at(2).get, 2)
-    assertEquals(tuple6.applyLens(tuple6Lens).at(3).get, 3)
-    assertEquals(tuple6.applyLens(tuple6Lens).at(4).get, 4)
-    assertEquals(tuple6.applyLens(tuple6Lens).at(5).get, 5)
-    assertEquals(tuple6.applyLens(tuple6Lens).at(6).get, 6)
+    assertEquals(tuple6.optics.andThen(tuple6Lens).at(1).get, 1)
+    assertEquals(tuple6.optics.andThen(tuple6Lens).at(2).get, 2)
+    assertEquals(tuple6.optics.andThen(tuple6Lens).at(3).get, 3)
+    assertEquals(tuple6.optics.andThen(tuple6Lens).at(4).get, 4)
+    assertEquals(tuple6.optics.andThen(tuple6Lens).at(5).get, 5)
+    assertEquals(tuple6.optics.andThen(tuple6Lens).at(6).get, 6)
 
     val sortedMap     = immutable.SortedMap(1 -> "one")
     val sortedMapLens = Lens.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapLens.at(1).get(sortedMap), Some("one"))
     assertEquals(sortedMapLens.at(2).get(sortedMap), None)
-    assertEquals(sortedMap.applyLens(sortedMapLens).at(1).get, Some("one"))
-    assertEquals(sortedMap.applyLens(sortedMapLens).at(2).get, None)
+    assertEquals(sortedMap.optics.andThen(sortedMapLens).at(1).get, Some("one"))
+    assertEquals(sortedMap.optics.andThen(sortedMapLens).at(2).get, None)
 
     val listMap     = immutable.ListMap(1 -> "one")
     val listMapLens = Lens.id[immutable.ListMap[Int, String]]
     assertEquals(listMapLens.at(1).get(listMap), Some("one"))
     assertEquals(listMapLens.at(2).get(listMap), None)
-    assertEquals(listMap.applyLens(listMapLens).at(1).get, Some("one"))
-    assertEquals(listMap.applyLens(listMapLens).at(2).get, None)
+    assertEquals(listMap.optics.andThen(listMapLens).at(1).get, Some("one"))
+    assertEquals(listMap.optics.andThen(listMapLens).at(2).get, None)
 
     val map     = immutable.Map(1 -> "one")
     val mapLens = Lens.id[Map[Int, String]]
     assertEquals(mapLens.at(1).get(map), Some("one"))
     assertEquals(mapLens.at(2).get(map), None)
-    assertEquals(map.applyLens(mapLens).at(1).get, Some("one"))
-    assertEquals(map.applyLens(mapLens).at(2).get, None)
+    assertEquals(map.optics.andThen(mapLens).at(1).get, Some("one"))
+    assertEquals(map.optics.andThen(mapLens).at(2).get, None)
 
     val set     = Set(1)
     val setLens = Lens.id[Set[Int]]
     assertEquals(setLens.at(1).get(set), true)
     assertEquals(setLens.at(2).get(set), false)
-    assertEquals(set.applyLens(setLens).at(1).get, true)
-    assertEquals(set.applyLens(setLens).at(2).get, false)
+    assertEquals(set.optics.andThen(setLens).at(1).get, true)
+    assertEquals(set.optics.andThen(setLens).at(2).get, false)
   }
 
   test("index") {
@@ -240,70 +240,70 @@ class LensSpec extends MonocleSuite {
     val listLens = Lens.id[List[Int]]
     assertEquals(listLens.index(0).getOption(list), Some(1))
     assertEquals(listLens.index(1).getOption(list), None)
-    assertEquals(list.applyLens(listLens).index(0).getOption, Some(1))
-    assertEquals(list.applyLens(listLens).index(1).getOption, None)
+    assertEquals(list.optics.andThen(listLens).index(0).getOption, Some(1))
+    assertEquals(list.optics.andThen(listLens).index(1).getOption, None)
 
     val lazyList     = LazyList(1)
     val lazyListLens = Lens.id[LazyList[Int]]
     assertEquals(lazyListLens.index(0).getOption(lazyList), Some(1))
     assertEquals(lazyListLens.index(1).getOption(lazyList), None)
-    assertEquals(lazyList.applyLens(lazyListLens).index(0).getOption, Some(1))
-    assertEquals(lazyList.applyLens(lazyListLens).index(1).getOption, None)
+    assertEquals(lazyList.optics.andThen(lazyListLens).index(0).getOption, Some(1))
+    assertEquals(lazyList.optics.andThen(lazyListLens).index(1).getOption, None)
 
     val listMap     = immutable.ListMap(1 -> "one")
     val listMapLens = Lens.id[immutable.ListMap[Int, String]]
     assertEquals(listMapLens.index(0).getOption(listMap), None)
     assertEquals(listMapLens.index(1).getOption(listMap), Some("one"))
-    assertEquals(listMap.applyLens(listMapLens).index(0).getOption, None)
-    assertEquals(listMap.applyLens(listMapLens).index(1).getOption, Some("one"))
+    assertEquals(listMap.optics.andThen(listMapLens).index(0).getOption, None)
+    assertEquals(listMap.optics.andThen(listMapLens).index(1).getOption, Some("one"))
 
     val map     = Map(1 -> "one")
     val mapLens = Lens.id[Map[Int, String]]
     assertEquals(mapLens.index(1).getOption(map), Some("one"))
     assertEquals(mapLens.index(0).getOption(map), None)
-    assertEquals(map.applyLens(mapLens).index(1).getOption, Some("one"))
-    assertEquals(map.applyLens(mapLens).index(0).getOption, None)
+    assertEquals(map.optics.andThen(mapLens).index(1).getOption, Some("one"))
+    assertEquals(map.optics.andThen(mapLens).index(0).getOption, None)
 
     val sortedMap     = immutable.SortedMap(1 -> "one")
     val sortedMapLens = Lens.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapLens.index(1).getOption(sortedMap), Some("one"))
     assertEquals(sortedMapLens.index(0).getOption(sortedMap), None)
-    assertEquals(sortedMap.applyLens(sortedMapLens).index(1).getOption, Some("one"))
-    assertEquals(sortedMap.applyLens(sortedMapLens).index(0).getOption, None)
+    assertEquals(sortedMap.optics.andThen(sortedMapLens).index(1).getOption, Some("one"))
+    assertEquals(sortedMap.optics.andThen(sortedMapLens).index(0).getOption, None)
 
     val vector     = Vector(1)
     val vectorLens = Lens.id[Vector[Int]]
     assertEquals(vectorLens.index(0).getOption(vector), Some(1))
     assertEquals(vectorLens.index(1).getOption(vector), None)
-    assertEquals(vector.applyLens(vectorLens).index(0).getOption, Some(1))
-    assertEquals(vector.applyLens(vectorLens).index(1).getOption, None)
+    assertEquals(vector.optics.andThen(vectorLens).index(0).getOption, Some(1))
+    assertEquals(vector.optics.andThen(vectorLens).index(1).getOption, None)
 
     val chain     = Chain.one(1)
     val chainLens = Lens.id[Chain[Int]]
     assertEquals(chainLens.index(0).getOption(chain), Some(1))
     assertEquals(chainLens.index(1).getOption(chain), None)
-    assertEquals(chain.applyLens(chainLens).index(0).getOption, Some(1))
-    assertEquals(chain.applyLens(chainLens).index(1).getOption, None)
+    assertEquals(chain.optics.andThen(chainLens).index(0).getOption, Some(1))
+    assertEquals(chain.optics.andThen(chainLens).index(1).getOption, None)
 
     val nec     = NonEmptyChain.one(1)
     val necLens = Lens.id[NonEmptyChain[Int]]
     assertEquals(necLens.index(0).getOption(nec), Some(1))
     assertEquals(necLens.index(1).getOption(nec), None)
-    assertEquals(nec.applyLens(necLens).index(0).getOption, Some(1))
-    assertEquals(nec.applyLens(necLens).index(1).getOption, None)
+    assertEquals(nec.optics.andThen(necLens).index(0).getOption, Some(1))
+    assertEquals(nec.optics.andThen(necLens).index(1).getOption, None)
 
     val nev     = NonEmptyVector.one(1)
     val nevLens = Lens.id[NonEmptyVector[Int]]
     assertEquals(nevLens.index(0).getOption(nev), Some(1))
     assertEquals(nevLens.index(1).getOption(nev), None)
-    assertEquals(nev.applyLens(nevLens).index(0).getOption, Some(1))
-    assertEquals(nev.applyLens(nevLens).index(1).getOption, None)
+    assertEquals(nev.optics.andThen(nevLens).index(0).getOption, Some(1))
+    assertEquals(nev.optics.andThen(nevLens).index(1).getOption, None)
 
     val nel     = NonEmptyList.one(1)
     val nelLens = Lens.id[NonEmptyList[Int]]
     assertEquals(nelLens.index(0).getOption(nel), Some(1))
     assertEquals(nelLens.index(1).getOption(nel), None)
-    assertEquals(nel.applyLens(nelLens).index(0).getOption, Some(1))
-    assertEquals(nel.applyLens(nelLens).index(1).getOption, None)
+    assertEquals(nel.optics.andThen(nelLens).index(0).getOption, Some(1))
+    assertEquals(nel.optics.andThen(nelLens).index(1).getOption, None)
   }
 }

--- a/test/shared/src/test/scala/monocle/OptionalSpec.scala
+++ b/test/shared/src/test/scala/monocle/OptionalSpec.scala
@@ -119,7 +119,7 @@ class OptionalSpec extends MonocleSuite {
     val optional = GenLens[SomeTest](_.y).asOptional
 
     assertEquals(optional.some.getOption(obj), Some(2))
-    assertEquals(obj.applyOptional(optional).some.getOption, Some(2))
+    assertEquals(obj.optics.andThen(optional).some.getOption, Some(2))
   }
 
   test("withDefault") {
@@ -132,7 +132,7 @@ class OptionalSpec extends MonocleSuite {
     assertEquals(optional.withDefault(0).getOption(objSome), Some(2))
     assertEquals(optional.withDefault(0).getOption(objNone), Some(0))
 
-    assertEquals(objNone.applyOptional(optional).withDefault(0).getOption, Some(0))
+    assertEquals(objNone.optics.andThen(optional).withDefault(0).getOption, Some(0))
   }
 
   test("each") {
@@ -142,7 +142,7 @@ class OptionalSpec extends MonocleSuite {
     val optional = GenLens[SomeTest](_.y).asOptional
 
     assertEquals(optional.each.getAll(obj), List(1, 2, 3))
-    assertEquals(obj.applyOptional(optional).each.getAll, List(1, 2, 3))
+    assertEquals(obj.optics.andThen(optional).each.getAll, List(1, 2, 3))
   }
 
   test("at") {
@@ -150,17 +150,17 @@ class OptionalSpec extends MonocleSuite {
     val tuple2Optional = Optional.id[(Int, Int)]
     assertEquals(tuple2Optional.at(1).getOption(tuple2), Some(1))
     assertEquals(tuple2Optional.at(2).getOption(tuple2), Some(2))
-    assertEquals(tuple2.applyOptional(tuple2Optional).at(1).getOption, Some(1))
-    assertEquals(tuple2.applyOptional(tuple2Optional).at(2).getOption, Some(2))
+    assertEquals(tuple2.optics.andThen(tuple2Optional).at(1).getOption, Some(1))
+    assertEquals(tuple2.optics.andThen(tuple2Optional).at(2).getOption, Some(2))
 
     val tuple3         = (1, 2, 3)
     val tuple3Optional = Optional.id[(Int, Int, Int)]
     assertEquals(tuple3Optional.at(1).getOption(tuple3), Some(1))
     assertEquals(tuple3Optional.at(2).getOption(tuple3), Some(2))
     assertEquals(tuple3Optional.at(3).getOption(tuple3), Some(3))
-    assertEquals(tuple3.applyOptional(tuple3Optional).at(1).getOption, Some(1))
-    assertEquals(tuple3.applyOptional(tuple3Optional).at(2).getOption, Some(2))
-    assertEquals(tuple3.applyOptional(tuple3Optional).at(3).getOption, Some(3))
+    assertEquals(tuple3.optics.andThen(tuple3Optional).at(1).getOption, Some(1))
+    assertEquals(tuple3.optics.andThen(tuple3Optional).at(2).getOption, Some(2))
+    assertEquals(tuple3.optics.andThen(tuple3Optional).at(3).getOption, Some(3))
 
     val tuple4         = (1, 2, 3, 4)
     val tuple4Optional = Optional.id[(Int, Int, Int, Int)]
@@ -168,10 +168,10 @@ class OptionalSpec extends MonocleSuite {
     assertEquals(tuple4Optional.at(2).getOption(tuple4), Some(2))
     assertEquals(tuple4Optional.at(3).getOption(tuple4), Some(3))
     assertEquals(tuple4Optional.at(4).getOption(tuple4), Some(4))
-    assertEquals(tuple4.applyOptional(tuple4Optional).at(1).getOption, Some(1))
-    assertEquals(tuple4.applyOptional(tuple4Optional).at(2).getOption, Some(2))
-    assertEquals(tuple4.applyOptional(tuple4Optional).at(3).getOption, Some(3))
-    assertEquals(tuple4.applyOptional(tuple4Optional).at(4).getOption, Some(4))
+    assertEquals(tuple4.optics.andThen(tuple4Optional).at(1).getOption, Some(1))
+    assertEquals(tuple4.optics.andThen(tuple4Optional).at(2).getOption, Some(2))
+    assertEquals(tuple4.optics.andThen(tuple4Optional).at(3).getOption, Some(3))
+    assertEquals(tuple4.optics.andThen(tuple4Optional).at(4).getOption, Some(4))
 
     val tuple5         = (1, 2, 3, 4, 5)
     val tuple5Optional = Optional.id[(Int, Int, Int, Int, Int)]
@@ -180,11 +180,11 @@ class OptionalSpec extends MonocleSuite {
     assertEquals(tuple5Optional.at(3).getOption(tuple5), Some(3))
     assertEquals(tuple5Optional.at(4).getOption(tuple5), Some(4))
     assertEquals(tuple5Optional.at(5).getOption(tuple5), Some(5))
-    assertEquals(tuple5.applyOptional(tuple5Optional).at(1).getOption, Some(1))
-    assertEquals(tuple5.applyOptional(tuple5Optional).at(2).getOption, Some(2))
-    assertEquals(tuple5.applyOptional(tuple5Optional).at(3).getOption, Some(3))
-    assertEquals(tuple5.applyOptional(tuple5Optional).at(4).getOption, Some(4))
-    assertEquals(tuple5.applyOptional(tuple5Optional).at(5).getOption, Some(5))
+    assertEquals(tuple5.optics.andThen(tuple5Optional).at(1).getOption, Some(1))
+    assertEquals(tuple5.optics.andThen(tuple5Optional).at(2).getOption, Some(2))
+    assertEquals(tuple5.optics.andThen(tuple5Optional).at(3).getOption, Some(3))
+    assertEquals(tuple5.optics.andThen(tuple5Optional).at(4).getOption, Some(4))
+    assertEquals(tuple5.optics.andThen(tuple5Optional).at(5).getOption, Some(5))
 
     val tuple6         = (1, 2, 3, 4, 5, 6)
     val tuple6Optional = Optional.id[(Int, Int, Int, Int, Int, Int)]
@@ -194,40 +194,40 @@ class OptionalSpec extends MonocleSuite {
     assertEquals(tuple6Optional.at(4).getOption(tuple6), Some(4))
     assertEquals(tuple6Optional.at(5).getOption(tuple6), Some(5))
     assertEquals(tuple6Optional.at(6).getOption(tuple6), Some(6))
-    assertEquals(tuple6.applyOptional(tuple6Optional).at(1).getOption, Some(1))
-    assertEquals(tuple6.applyOptional(tuple6Optional).at(2).getOption, Some(2))
-    assertEquals(tuple6.applyOptional(tuple6Optional).at(3).getOption, Some(3))
-    assertEquals(tuple6.applyOptional(tuple6Optional).at(4).getOption, Some(4))
-    assertEquals(tuple6.applyOptional(tuple6Optional).at(5).getOption, Some(5))
-    assertEquals(tuple6.applyOptional(tuple6Optional).at(6).getOption, Some(6))
+    assertEquals(tuple6.optics.andThen(tuple6Optional).at(1).getOption, Some(1))
+    assertEquals(tuple6.optics.andThen(tuple6Optional).at(2).getOption, Some(2))
+    assertEquals(tuple6.optics.andThen(tuple6Optional).at(3).getOption, Some(3))
+    assertEquals(tuple6.optics.andThen(tuple6Optional).at(4).getOption, Some(4))
+    assertEquals(tuple6.optics.andThen(tuple6Optional).at(5).getOption, Some(5))
+    assertEquals(tuple6.optics.andThen(tuple6Optional).at(6).getOption, Some(6))
 
     val sortedMap         = immutable.SortedMap(1 -> "one")
     val sortedMapOptional = Optional.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapOptional.at(1).getOption(sortedMap), Some(Some("one")))
     assertEquals(sortedMapOptional.at(0).getOption(sortedMap), Some(None))
-    assertEquals(sortedMap.applyOptional(sortedMapOptional).at(1).getOption, Some(Some("one")))
-    assertEquals(sortedMap.applyOptional(sortedMapOptional).at(0).getOption, Some(None))
+    assertEquals(sortedMap.optics.andThen(sortedMapOptional).at(1).getOption, Some(Some("one")))
+    assertEquals(sortedMap.optics.andThen(sortedMapOptional).at(0).getOption, Some(None))
 
     val listMap         = immutable.ListMap(1 -> "one")
     val listMapOptional = Optional.id[immutable.ListMap[Int, String]]
     assertEquals(listMapOptional.at(1).getOption(listMap), Some(Some("one")))
     assertEquals(listMapOptional.at(0).getOption(listMap), Some(None))
-    assertEquals(listMap.applyOptional(listMapOptional).at(1).getOption, Some(Some("one")))
-    assertEquals(listMap.applyOptional(listMapOptional).at(0).getOption, Some(None))
+    assertEquals(listMap.optics.andThen(listMapOptional).at(1).getOption, Some(Some("one")))
+    assertEquals(listMap.optics.andThen(listMapOptional).at(0).getOption, Some(None))
 
     val map         = immutable.Map(1 -> "one")
     val mapOptional = Optional.id[Map[Int, String]]
     assertEquals(mapOptional.at(1).getOption(map), Some(Some("one")))
     assertEquals(mapOptional.at(0).getOption(map), Some(None))
-    assertEquals(map.applyOptional(mapOptional).at(1).getOption, Some(Some("one")))
-    assertEquals(map.applyOptional(mapOptional).at(0).getOption, Some(None))
+    assertEquals(map.optics.andThen(mapOptional).at(1).getOption, Some(Some("one")))
+    assertEquals(map.optics.andThen(mapOptional).at(0).getOption, Some(None))
 
     val set         = Set(1)
     val setOptional = Optional.id[Set[Int]]
     assertEquals(setOptional.at(1).getOption(set), Some(true))
     assertEquals(setOptional.at(0).getOption(set), Some(false))
-    assertEquals(set.applyOptional(setOptional).at(1).getOption, Some(true))
-    assertEquals(set.applyOptional(setOptional).at(0).getOption, Some(false))
+    assertEquals(set.optics.andThen(setOptional).at(1).getOption, Some(true))
+    assertEquals(set.optics.andThen(setOptional).at(0).getOption, Some(false))
   }
 
   test("index") {
@@ -235,71 +235,71 @@ class OptionalSpec extends MonocleSuite {
     val listOptional = Optional.id[List[Int]]
     assertEquals(listOptional.index(0).getOption(list), Some(1))
     assertEquals(listOptional.index(1).getOption(list), None)
-    assertEquals(list.applyOptional(listOptional).index(0).getOption, Some(1))
-    assertEquals(list.applyOptional(listOptional).index(1).getOption, None)
+    assertEquals(list.optics.andThen(listOptional).index(0).getOption, Some(1))
+    assertEquals(list.optics.andThen(listOptional).index(1).getOption, None)
 
     val lazyList         = LazyList(1)
     val lazyListOptional = Optional.id[LazyList[Int]]
     assertEquals(lazyListOptional.index(0).getOption(lazyList), Some(1))
     assertEquals(lazyListOptional.index(1).getOption(lazyList), None)
-    assertEquals(lazyList.applyOptional(lazyListOptional).index(0).getOption, Some(1))
-    assertEquals(lazyList.applyOptional(lazyListOptional).index(1).getOption, None)
+    assertEquals(lazyList.optics.andThen(lazyListOptional).index(0).getOption, Some(1))
+    assertEquals(lazyList.optics.andThen(lazyListOptional).index(1).getOption, None)
 
     val listMap         = immutable.ListMap(1 -> "one")
     val listMapOptional = Optional.id[immutable.ListMap[Int, String]]
     assertEquals(listMapOptional.index(0).getOption(listMap), None)
     assertEquals(listMapOptional.index(1).getOption(listMap), Some("one"))
-    assertEquals(listMap.applyOptional(listMapOptional).index(0).getOption, None)
-    assertEquals(listMap.applyOptional(listMapOptional).index(1).getOption, Some("one"))
+    assertEquals(listMap.optics.andThen(listMapOptional).index(0).getOption, None)
+    assertEquals(listMap.optics.andThen(listMapOptional).index(1).getOption, Some("one"))
 
     val map         = Map(1 -> "one")
     val mapOptional = Optional.id[Map[Int, String]]
     assertEquals(mapOptional.index(0).getOption(map), None)
     assertEquals(mapOptional.index(1).getOption(map), Some("one"))
-    assertEquals(map.applyOptional(mapOptional).index(0).getOption, None)
-    assertEquals(map.applyOptional(mapOptional).index(1).getOption, Some("one"))
+    assertEquals(map.optics.andThen(mapOptional).index(0).getOption, None)
+    assertEquals(map.optics.andThen(mapOptional).index(1).getOption, Some("one"))
 
     val sortedMap         = immutable.SortedMap(1 -> "one")
     val sortedMapOptional = Optional.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapOptional.index(0).getOption(sortedMap), None)
     assertEquals(sortedMapOptional.index(1).getOption(sortedMap), Some("one"))
-    assertEquals(sortedMap.applyOptional(sortedMapOptional).index(0).getOption, None)
-    assertEquals(sortedMap.applyOptional(sortedMapOptional).index(1).getOption, Some("one"))
+    assertEquals(sortedMap.optics.andThen(sortedMapOptional).index(0).getOption, None)
+    assertEquals(sortedMap.optics.andThen(sortedMapOptional).index(1).getOption, Some("one"))
 
     val vector         = Vector(1)
     val vectorOptional = Optional.id[Vector[Int]]
     assertEquals(vectorOptional.index(0).getOption(vector), Some(1))
     assertEquals(vectorOptional.index(1).getOption(vector), None)
-    assertEquals(vector.applyOptional(vectorOptional).index(0).getOption, Some(1))
-    assertEquals(vector.applyOptional(vectorOptional).index(1).getOption, None)
+    assertEquals(vector.optics.andThen(vectorOptional).index(0).getOption, Some(1))
+    assertEquals(vector.optics.andThen(vectorOptional).index(1).getOption, None)
 
     val chain         = Chain.one(1)
     val chainOptional = Optional.id[Chain[Int]]
     assertEquals(chainOptional.index(0).getOption(chain), Some(1))
     assertEquals(chainOptional.index(1).getOption(chain), None)
-    assertEquals(chain.applyOptional(chainOptional).index(0).getOption, Some(1))
-    assertEquals(chain.applyOptional(chainOptional).index(1).getOption, None)
+    assertEquals(chain.optics.andThen(chainOptional).index(0).getOption, Some(1))
+    assertEquals(chain.optics.andThen(chainOptional).index(1).getOption, None)
 
     val nec         = NonEmptyChain.one(1)
     val necOptional = Optional.id[NonEmptyChain[Int]]
     assertEquals(necOptional.index(0).getOption(nec), Some(1))
     assertEquals(necOptional.index(1).getOption(nec), None)
-    assertEquals(nec.applyOptional(necOptional).index(0).getOption, Some(1))
-    assertEquals(nec.applyOptional(necOptional).index(1).getOption, None)
+    assertEquals(nec.optics.andThen(necOptional).index(0).getOption, Some(1))
+    assertEquals(nec.optics.andThen(necOptional).index(1).getOption, None)
 
     val nev         = NonEmptyVector.one(1)
     val nevOptional = Optional.id[NonEmptyVector[Int]]
     assertEquals(nevOptional.index(0).getOption(nev), Some(1))
     assertEquals(nevOptional.index(1).getOption(nev), None)
-    assertEquals(nev.applyOptional(nevOptional).index(0).getOption, Some(1))
-    assertEquals(nev.applyOptional(nevOptional).index(1).getOption, None)
+    assertEquals(nev.optics.andThen(nevOptional).index(0).getOption, Some(1))
+    assertEquals(nev.optics.andThen(nevOptional).index(1).getOption, None)
 
     val nel         = NonEmptyList.one(1)
     val nelOptional = Optional.id[NonEmptyList[Int]]
     assertEquals(nelOptional.index(0).getOption(nel), Some(1))
     assertEquals(nelOptional.index(1).getOption(nel), None)
-    assertEquals(nel.applyOptional(nelOptional).index(0).getOption, Some(1))
-    assertEquals(nel.applyOptional(nelOptional).index(1).getOption, None)
+    assertEquals(nel.optics.andThen(nelOptional).index(0).getOption, Some(1))
+    assertEquals(nel.optics.andThen(nelOptional).index(1).getOption, None)
   }
 
   test("filter") {
@@ -316,7 +316,7 @@ class OptionalSpec extends MonocleSuite {
     val optional = GenLens[SomeTest](_.y).asOptional
 
     assertEquals(optional.filterIndex((_: Int) > 0).getAll(obj), List("world"))
-    assertEquals(obj.applyOptional(optional).filterIndex((_: Int) > 0).getAll, List("world"))
+    assertEquals(obj.optics.andThen(optional).filterIndex((_: Int) > 0).getAll, List("world"))
   }
 
   test("filter can break the fusion property") {

--- a/test/shared/src/test/scala/monocle/PrismSpec.scala
+++ b/test/shared/src/test/scala/monocle/PrismSpec.scala
@@ -192,7 +192,7 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     val prism = Iso[SomeTest, Option[Int]](_.y)(SomeTest).asPrism
 
     assertEquals(prism.some.getOption(obj), Some(2))
-    assertEquals(obj.applyPrism(prism).some.getOption, Some(2))
+    assertEquals(obj.optics.andThen(prism).some.getOption, Some(2))
   }
 
   test("withDefault") {
@@ -205,7 +205,7 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     assertEquals(prism.withDefault(0).getOption(objSome), Some(2))
     assertEquals(prism.withDefault(0).getOption(objNone), Some(0))
 
-    assertEquals(objNone.applyPrism(prism).withDefault(0).getOption, Some(0))
+    assertEquals(objNone.optics.andThen(prism).withDefault(0).getOption, Some(0))
   }
 
   test("each") {
@@ -215,7 +215,7 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     val prism = Iso[SomeTest, List[Int]](_.y)(SomeTest).asPrism
 
     assertEquals(prism.each.getAll(obj), List(1, 2, 3))
-    assertEquals(obj.applyPrism(prism).each.getAll, List(1, 2, 3))
+    assertEquals(obj.optics.andThen(prism).each.getAll, List(1, 2, 3))
   }
 
   test("filter") {
@@ -225,7 +225,7 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     val prism = Iso[SomeTest, Int](_.y)(SomeTest).asPrism
 
     assertEquals(prism.filter(_ > 0).getOption(obj), Some(2))
-    assertEquals(obj.applyPrism(prism).filter(_ > 0).getOption, Some(2))
+    assertEquals(obj.optics.andThen(prism).filter(_ > 0).getOption, Some(2))
   }
 
   test("filterIndex") {
@@ -235,7 +235,7 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     val prism = Iso[SomeTest, List[String]](_.y)(SomeTest).asPrism
 
     assertEquals(prism.filterIndex((_: Int) > 0).getAll(obj), List("world"))
-    assertEquals(obj.applyPrism(prism).filterIndex((_: Int) > 0).getAll, List("world"))
+    assertEquals(obj.optics.andThen(prism).filterIndex((_: Int) > 0).getAll, List("world"))
   }
 
   test("at") {
@@ -243,17 +243,17 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     val tuple2Prism = Prism.id[(Int, Int)]
     assertEquals(tuple2Prism.at(1).getOption(tuple2), Some(1))
     assertEquals(tuple2Prism.at(2).getOption(tuple2), Some(2))
-    assertEquals(tuple2.applyPrism(tuple2Prism).at(1).getOption, Some(1))
-    assertEquals(tuple2.applyPrism(tuple2Prism).at(2).getOption, Some(2))
+    assertEquals(tuple2.optics.andThen(tuple2Prism).at(1).getOption, Some(1))
+    assertEquals(tuple2.optics.andThen(tuple2Prism).at(2).getOption, Some(2))
 
     val tuple3      = (1, 2, 3)
     val tuple3Prism = Prism.id[(Int, Int, Int)]
     assertEquals(tuple3Prism.at(1).getOption(tuple3), Some(1))
     assertEquals(tuple3Prism.at(2).getOption(tuple3), Some(2))
     assertEquals(tuple3Prism.at(3).getOption(tuple3), Some(3))
-    assertEquals(tuple3.applyPrism(tuple3Prism).at(1).getOption, Some(1))
-    assertEquals(tuple3.applyPrism(tuple3Prism).at(2).getOption, Some(2))
-    assertEquals(tuple3.applyPrism(tuple3Prism).at(3).getOption, Some(3))
+    assertEquals(tuple3.optics.andThen(tuple3Prism).at(1).getOption, Some(1))
+    assertEquals(tuple3.optics.andThen(tuple3Prism).at(2).getOption, Some(2))
+    assertEquals(tuple3.optics.andThen(tuple3Prism).at(3).getOption, Some(3))
 
     val tuple4      = (1, 2, 3, 4)
     val tuple4Prism = Prism.id[(Int, Int, Int, Int)]
@@ -261,10 +261,10 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     assertEquals(tuple4Prism.at(2).getOption(tuple4), Some(2))
     assertEquals(tuple4Prism.at(3).getOption(tuple4), Some(3))
     assertEquals(tuple4Prism.at(4).getOption(tuple4), Some(4))
-    assertEquals(tuple4.applyPrism(tuple4Prism).at(1).getOption, Some(1))
-    assertEquals(tuple4.applyPrism(tuple4Prism).at(2).getOption, Some(2))
-    assertEquals(tuple4.applyPrism(tuple4Prism).at(3).getOption, Some(3))
-    assertEquals(tuple4.applyPrism(tuple4Prism).at(4).getOption, Some(4))
+    assertEquals(tuple4.optics.andThen(tuple4Prism).at(1).getOption, Some(1))
+    assertEquals(tuple4.optics.andThen(tuple4Prism).at(2).getOption, Some(2))
+    assertEquals(tuple4.optics.andThen(tuple4Prism).at(3).getOption, Some(3))
+    assertEquals(tuple4.optics.andThen(tuple4Prism).at(4).getOption, Some(4))
 
     val tuple5      = (1, 2, 3, 4, 5)
     val tuple5Prism = Prism.id[(Int, Int, Int, Int, Int)]
@@ -273,11 +273,11 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     assertEquals(tuple5Prism.at(3).getOption(tuple5), Some(3))
     assertEquals(tuple5Prism.at(4).getOption(tuple5), Some(4))
     assertEquals(tuple5Prism.at(5).getOption(tuple5), Some(5))
-    assertEquals(tuple5.applyPrism(tuple5Prism).at(1).getOption, Some(1))
-    assertEquals(tuple5.applyPrism(tuple5Prism).at(2).getOption, Some(2))
-    assertEquals(tuple5.applyPrism(tuple5Prism).at(3).getOption, Some(3))
-    assertEquals(tuple5.applyPrism(tuple5Prism).at(4).getOption, Some(4))
-    assertEquals(tuple5.applyPrism(tuple5Prism).at(5).getOption, Some(5))
+    assertEquals(tuple5.optics.andThen(tuple5Prism).at(1).getOption, Some(1))
+    assertEquals(tuple5.optics.andThen(tuple5Prism).at(2).getOption, Some(2))
+    assertEquals(tuple5.optics.andThen(tuple5Prism).at(3).getOption, Some(3))
+    assertEquals(tuple5.optics.andThen(tuple5Prism).at(4).getOption, Some(4))
+    assertEquals(tuple5.optics.andThen(tuple5Prism).at(5).getOption, Some(5))
 
     val tuple6      = (1, 2, 3, 4, 5, 6)
     val tuple6Prism = Prism.id[(Int, Int, Int, Int, Int, Int)]
@@ -287,40 +287,40 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     assertEquals(tuple6Prism.at(4).getOption(tuple6), Some(4))
     assertEquals(tuple6Prism.at(5).getOption(tuple6), Some(5))
     assertEquals(tuple6Prism.at(6).getOption(tuple6), Some(6))
-    assertEquals(tuple6.applyPrism(tuple6Prism).at(1).getOption, Some(1))
-    assertEquals(tuple6.applyPrism(tuple6Prism).at(2).getOption, Some(2))
-    assertEquals(tuple6.applyPrism(tuple6Prism).at(3).getOption, Some(3))
-    assertEquals(tuple6.applyPrism(tuple6Prism).at(4).getOption, Some(4))
-    assertEquals(tuple6.applyPrism(tuple6Prism).at(5).getOption, Some(5))
-    assertEquals(tuple6.applyPrism(tuple6Prism).at(6).getOption, Some(6))
+    assertEquals(tuple6.optics.andThen(tuple6Prism).at(1).getOption, Some(1))
+    assertEquals(tuple6.optics.andThen(tuple6Prism).at(2).getOption, Some(2))
+    assertEquals(tuple6.optics.andThen(tuple6Prism).at(3).getOption, Some(3))
+    assertEquals(tuple6.optics.andThen(tuple6Prism).at(4).getOption, Some(4))
+    assertEquals(tuple6.optics.andThen(tuple6Prism).at(5).getOption, Some(5))
+    assertEquals(tuple6.optics.andThen(tuple6Prism).at(6).getOption, Some(6))
 
     val sortedMap      = immutable.SortedMap(1 -> "one")
     val sortedMapPrism = Prism.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapPrism.at(1).getOption(sortedMap), Some(Some("one")))
     assertEquals(sortedMapPrism.at(0).getOption(sortedMap), Some(None))
-    assertEquals(sortedMap.applyPrism(sortedMapPrism).at(1).getOption, Some(Some("one")))
-    assertEquals(sortedMap.applyPrism(sortedMapPrism).at(0).getOption, Some(None))
+    assertEquals(sortedMap.optics.andThen(sortedMapPrism).at(1).getOption, Some(Some("one")))
+    assertEquals(sortedMap.optics.andThen(sortedMapPrism).at(0).getOption, Some(None))
 
     val listMap      = immutable.ListMap(1 -> "one")
     val listMapPrism = Prism.id[immutable.ListMap[Int, String]]
     assertEquals(listMapPrism.at(1).getOption(listMap), Some(Some("one")))
     assertEquals(listMapPrism.at(0).getOption(listMap), Some(None))
-    assertEquals(listMap.applyPrism(listMapPrism).at(1).getOption, Some(Some("one")))
-    assertEquals(listMap.applyPrism(listMapPrism).at(0).getOption, Some(None))
+    assertEquals(listMap.optics.andThen(listMapPrism).at(1).getOption, Some(Some("one")))
+    assertEquals(listMap.optics.andThen(listMapPrism).at(0).getOption, Some(None))
 
     val map      = immutable.Map(1 -> "one")
     val mapPrism = Prism.id[Map[Int, String]]
     assertEquals(mapPrism.at(1).getOption(map), Some(Some("one")))
     assertEquals(mapPrism.at(0).getOption(map), Some(None))
-    assertEquals(map.applyPrism(mapPrism).at(1).getOption, Some(Some("one")))
-    assertEquals(map.applyPrism(mapPrism).at(0).getOption, Some(None))
+    assertEquals(map.optics.andThen(mapPrism).at(1).getOption, Some(Some("one")))
+    assertEquals(map.optics.andThen(mapPrism).at(0).getOption, Some(None))
 
     val set      = Set(1)
     val setPrism = Prism.id[Set[Int]]
     assertEquals(setPrism.at(1).getOption(set), Some(true))
     assertEquals(setPrism.at(0).getOption(set), Some(false))
-    assertEquals(set.applyPrism(setPrism).at(1).getOption, Some(true))
-    assertEquals(set.applyPrism(setPrism).at(0).getOption, Some(false))
+    assertEquals(set.optics.andThen(setPrism).at(1).getOption, Some(true))
+    assertEquals(set.optics.andThen(setPrism).at(0).getOption, Some(false))
   }
 
   test("index") {
@@ -328,70 +328,70 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     val listPrism = Prism.id[List[Int]]
     assertEquals(listPrism.index(0).getOption(list), Some(1))
     assertEquals(listPrism.index(1).getOption(list), None)
-    assertEquals(list.applyPrism(listPrism).index(0).getOption, Some(1))
-    assertEquals(list.applyPrism(listPrism).index(1).getOption, None)
+    assertEquals(list.optics.andThen(listPrism).index(0).getOption, Some(1))
+    assertEquals(list.optics.andThen(listPrism).index(1).getOption, None)
 
     val lazyList      = LazyList(1)
     val lazyListPrism = Prism.id[LazyList[Int]]
     assertEquals(lazyListPrism.index(0).getOption(lazyList), Some(1))
     assertEquals(lazyListPrism.index(1).getOption(lazyList), None)
-    assertEquals(lazyList.applyPrism(lazyListPrism).index(0).getOption, Some(1))
-    assertEquals(lazyList.applyPrism(lazyListPrism).index(1).getOption, None)
+    assertEquals(lazyList.optics.andThen(lazyListPrism).index(0).getOption, Some(1))
+    assertEquals(lazyList.optics.andThen(lazyListPrism).index(1).getOption, None)
 
     val listMap      = immutable.ListMap(1 -> "one")
     val listMapPrism = Prism.id[immutable.ListMap[Int, String]]
     assertEquals(listMapPrism.index(0).getOption(listMap), None)
     assertEquals(listMapPrism.index(1).getOption(listMap), Some("one"))
-    assertEquals(listMap.applyPrism(listMapPrism).index(0).getOption, None)
-    assertEquals(listMap.applyPrism(listMapPrism).index(1).getOption, Some("one"))
+    assertEquals(listMap.optics.andThen(listMapPrism).index(0).getOption, None)
+    assertEquals(listMap.optics.andThen(listMapPrism).index(1).getOption, Some("one"))
 
     val map      = Map(1 -> "one")
     val mapPrism = Prism.id[Map[Int, String]]
     assertEquals(mapPrism.index(0).getOption(map), None)
     assertEquals(mapPrism.index(1).getOption(map), Some("one"))
-    assertEquals(map.applyPrism(mapPrism).index(0).getOption, None)
-    assertEquals(map.applyPrism(mapPrism).index(1).getOption, Some("one"))
+    assertEquals(map.optics.andThen(mapPrism).index(0).getOption, None)
+    assertEquals(map.optics.andThen(mapPrism).index(1).getOption, Some("one"))
 
     val sortedMap      = immutable.SortedMap(1 -> "one")
     val sortedMapPrism = Prism.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapPrism.index(0).getOption(sortedMap), None)
     assertEquals(sortedMapPrism.index(1).getOption(sortedMap), Some("one"))
-    assertEquals(sortedMap.applyPrism(sortedMapPrism).index(0).getOption, None)
-    assertEquals(sortedMap.applyPrism(sortedMapPrism).index(1).getOption, Some("one"))
+    assertEquals(sortedMap.optics.andThen(sortedMapPrism).index(0).getOption, None)
+    assertEquals(sortedMap.optics.andThen(sortedMapPrism).index(1).getOption, Some("one"))
 
     val vector      = Vector(1)
     val vectorPrism = Prism.id[Vector[Int]]
     assertEquals(vectorPrism.index(0).getOption(vector), Some(1))
     assertEquals(vectorPrism.index(1).getOption(vector), None)
-    assertEquals(vector.applyPrism(vectorPrism).index(0).getOption, Some(1))
-    assertEquals(vector.applyPrism(vectorPrism).index(1).getOption, None)
+    assertEquals(vector.optics.andThen(vectorPrism).index(0).getOption, Some(1))
+    assertEquals(vector.optics.andThen(vectorPrism).index(1).getOption, None)
 
     val chain      = Chain.one(1)
     val chainPrism = Prism.id[Chain[Int]]
     assertEquals(chainPrism.index(0).getOption(chain), Some(1))
     assertEquals(chainPrism.index(1).getOption(chain), None)
-    assertEquals(chain.applyPrism(chainPrism).index(0).getOption, Some(1))
-    assertEquals(chain.applyPrism(chainPrism).index(1).getOption, None)
+    assertEquals(chain.optics.andThen(chainPrism).index(0).getOption, Some(1))
+    assertEquals(chain.optics.andThen(chainPrism).index(1).getOption, None)
 
     val nec      = NonEmptyChain.one(1)
     val necPrism = Prism.id[NonEmptyChain[Int]]
     assertEquals(necPrism.index(0).getOption(nec), Some(1))
     assertEquals(necPrism.index(1).getOption(nec), None)
-    assertEquals(nec.applyPrism(necPrism).index(0).getOption, Some(1))
-    assertEquals(nec.applyPrism(necPrism).index(1).getOption, None)
+    assertEquals(nec.optics.andThen(necPrism).index(0).getOption, Some(1))
+    assertEquals(nec.optics.andThen(necPrism).index(1).getOption, None)
 
     val nev      = NonEmptyVector.one(1)
     val nevPrism = Prism.id[NonEmptyVector[Int]]
     assertEquals(nevPrism.index(0).getOption(nev), Some(1))
     assertEquals(nevPrism.index(1).getOption(nev), None)
-    assertEquals(nev.applyPrism(nevPrism).index(0).getOption, Some(1))
-    assertEquals(nev.applyPrism(nevPrism).index(1).getOption, None)
+    assertEquals(nev.optics.andThen(nevPrism).index(0).getOption, Some(1))
+    assertEquals(nev.optics.andThen(nevPrism).index(1).getOption, None)
 
     val nel      = NonEmptyList.one(1)
     val nelPrism = Prism.id[NonEmptyList[Int]]
     assertEquals(nelPrism.index(0).getOption(nel), Some(1))
     assertEquals(nelPrism.index(1).getOption(nel), None)
-    assertEquals(nel.applyPrism(nelPrism).index(0).getOption, Some(1))
-    assertEquals(nel.applyPrism(nelPrism).index(1).getOption, None)
+    assertEquals(nel.optics.andThen(nelPrism).index(0).getOption, Some(1))
+    assertEquals(nel.optics.andThen(nelPrism).index(1).getOption, None)
   }
 }

--- a/test/shared/src/test/scala/monocle/SetterSpec.scala
+++ b/test/shared/src/test/scala/monocle/SetterSpec.scala
@@ -53,7 +53,7 @@ class SetterSpec extends MonocleSuite {
     val setter = GenLens[SomeTest](_.y).asSetter
 
     assertEquals(setter.some.replace(3)(obj), SomeTest(1, Some(3)))
-    assertEquals(obj.applySetter(setter).some.replace(3), SomeTest(1, Some(3)))
+    assertEquals(obj.optics.andThen(setter).some.replace(3), SomeTest(1, Some(3)))
   }
 
   test("withDefault") {
@@ -66,7 +66,7 @@ class SetterSpec extends MonocleSuite {
     assertEquals(setter.withDefault(0).modify(_ + 1)(objSome), SomeTest(1, Some(3)))
     assertEquals(setter.withDefault(0).modify(_ + 1)(objNone), SomeTest(1, Some(1)))
 
-    assertEquals(objNone.applySetter(setter).withDefault(0).modify(_ + 1), SomeTest(1, Some(1)))
+    assertEquals(objNone.optics.andThen(setter).withDefault(0).modify(_ + 1), SomeTest(1, Some(1)))
   }
 
   test("each") {
@@ -76,7 +76,7 @@ class SetterSpec extends MonocleSuite {
     val setter = GenLens[SomeTest](_.y).asSetter
 
     assertEquals(setter.each.replace(3)(obj), SomeTest(1, List(3, 3, 3)))
-    assertEquals(obj.applySetter(setter).each.replace(3), SomeTest(1, List(3, 3, 3)))
+    assertEquals(obj.optics.andThen(setter).each.replace(3), SomeTest(1, List(3, 3, 3)))
   }
 
   test("filter") {
@@ -86,7 +86,7 @@ class SetterSpec extends MonocleSuite {
     val setter = GenLens[SomeTest](_.y).asSetter
 
     assertEquals(setter.filter(_ > 0).replace(3)(obj), SomeTest(1, 3))
-    assertEquals(obj.applySetter(setter).filter(_ > 0).replace(3), SomeTest(1, 3))
+    assertEquals(obj.optics.andThen(setter).filter(_ > 0).replace(3), SomeTest(1, 3))
   }
 
   test("filterIndex") {
@@ -96,7 +96,7 @@ class SetterSpec extends MonocleSuite {
     val setter = GenLens[SomeTest](_.y).asSetter
 
     assertEquals(setter.filterIndex((_: Int) > 0).replace("!")(obj), SomeTest(1, List("hello", "!")))
-    assertEquals(obj.applySetter(setter).filterIndex((_: Int) > 0).replace("!"), SomeTest(1, List("hello", "!")))
+    assertEquals(obj.optics.andThen(setter).filterIndex((_: Int) > 0).replace("!"), SomeTest(1, List("hello", "!")))
   }
 
   test("at") {
@@ -104,17 +104,17 @@ class SetterSpec extends MonocleSuite {
     val tuple2Setter = Setter.id[(Int, Int)]
     assertEquals(tuple2Setter.at(1).replace(2)(tuple2), (2, 2))
     assertEquals(tuple2Setter.at(2).replace(3)(tuple2), (1, 3))
-    assertEquals(tuple2.applySetter(tuple2Setter).at(1).replace(2), (2, 2))
-    assertEquals(tuple2.applySetter(tuple2Setter).at(2).replace(3), (1, 3))
+    assertEquals(tuple2.optics.andThen(tuple2Setter).at(1).replace(2), (2, 2))
+    assertEquals(tuple2.optics.andThen(tuple2Setter).at(2).replace(3), (1, 3))
 
     val tuple3       = (1, 2, 3)
     val tuple3Setter = Setter.id[(Int, Int, Int)]
     assertEquals(tuple3Setter.at(1).replace(2)(tuple3), (2, 2, 3))
     assertEquals(tuple3Setter.at(2).replace(3)(tuple3), (1, 3, 3))
     assertEquals(tuple3Setter.at(3).replace(4)(tuple3), (1, 2, 4))
-    assertEquals(tuple3.applySetter(tuple3Setter).at(1).replace(2), (2, 2, 3))
-    assertEquals(tuple3.applySetter(tuple3Setter).at(2).replace(3), (1, 3, 3))
-    assertEquals(tuple3.applySetter(tuple3Setter).at(3).replace(4), (1, 2, 4))
+    assertEquals(tuple3.optics.andThen(tuple3Setter).at(1).replace(2), (2, 2, 3))
+    assertEquals(tuple3.optics.andThen(tuple3Setter).at(2).replace(3), (1, 3, 3))
+    assertEquals(tuple3.optics.andThen(tuple3Setter).at(3).replace(4), (1, 2, 4))
 
     val tuple4       = (1, 2, 3, 4)
     val tuple4Setter = Setter.id[(Int, Int, Int, Int)]
@@ -122,10 +122,10 @@ class SetterSpec extends MonocleSuite {
     assertEquals(tuple4Setter.at(2).replace(3)(tuple4), (1, 3, 3, 4))
     assertEquals(tuple4Setter.at(3).replace(4)(tuple4), (1, 2, 4, 4))
     assertEquals(tuple4Setter.at(4).replace(1)(tuple4), (1, 2, 3, 1))
-    assertEquals(tuple4.applySetter(tuple4Setter).at(1).replace(2), (2, 2, 3, 4))
-    assertEquals(tuple4.applySetter(tuple4Setter).at(2).replace(3), (1, 3, 3, 4))
-    assertEquals(tuple4.applySetter(tuple4Setter).at(3).replace(4), (1, 2, 4, 4))
-    assertEquals(tuple4.applySetter(tuple4Setter).at(4).replace(1), (1, 2, 3, 1))
+    assertEquals(tuple4.optics.andThen(tuple4Setter).at(1).replace(2), (2, 2, 3, 4))
+    assertEquals(tuple4.optics.andThen(tuple4Setter).at(2).replace(3), (1, 3, 3, 4))
+    assertEquals(tuple4.optics.andThen(tuple4Setter).at(3).replace(4), (1, 2, 4, 4))
+    assertEquals(tuple4.optics.andThen(tuple4Setter).at(4).replace(1), (1, 2, 3, 1))
 
     val tuple5       = (1, 2, 3, 4, 5)
     val tuple5Setter = Setter.id[(Int, Int, Int, Int, Int)]
@@ -134,11 +134,11 @@ class SetterSpec extends MonocleSuite {
     assertEquals(tuple5Setter.at(3).replace(4)(tuple5), (1, 2, 4, 4, 5))
     assertEquals(tuple5Setter.at(4).replace(5)(tuple5), (1, 2, 3, 5, 5))
     assertEquals(tuple5Setter.at(5).replace(1)(tuple5), (1, 2, 3, 4, 1))
-    assertEquals(tuple5.applySetter(tuple5Setter).at(1).replace(2), (2, 2, 3, 4, 5))
-    assertEquals(tuple5.applySetter(tuple5Setter).at(2).replace(3), (1, 3, 3, 4, 5))
-    assertEquals(tuple5.applySetter(tuple5Setter).at(3).replace(4), (1, 2, 4, 4, 5))
-    assertEquals(tuple5.applySetter(tuple5Setter).at(4).replace(5), (1, 2, 3, 5, 5))
-    assertEquals(tuple5.applySetter(tuple5Setter).at(5).replace(1), (1, 2, 3, 4, 1))
+    assertEquals(tuple5.optics.andThen(tuple5Setter).at(1).replace(2), (2, 2, 3, 4, 5))
+    assertEquals(tuple5.optics.andThen(tuple5Setter).at(2).replace(3), (1, 3, 3, 4, 5))
+    assertEquals(tuple5.optics.andThen(tuple5Setter).at(3).replace(4), (1, 2, 4, 4, 5))
+    assertEquals(tuple5.optics.andThen(tuple5Setter).at(4).replace(5), (1, 2, 3, 5, 5))
+    assertEquals(tuple5.optics.andThen(tuple5Setter).at(5).replace(1), (1, 2, 3, 4, 1))
 
     val tuple6       = (1, 2, 3, 4, 5, 6)
     val tuple6Setter = Setter.id[(Int, Int, Int, Int, Int, Int)]
@@ -148,20 +148,20 @@ class SetterSpec extends MonocleSuite {
     assertEquals(tuple6Setter.at(4).replace(5)(tuple6), (1, 2, 3, 5, 5, 6))
     assertEquals(tuple6Setter.at(5).replace(6)(tuple6), (1, 2, 3, 4, 6, 6))
     assertEquals(tuple6Setter.at(6).replace(1)(tuple6), (1, 2, 3, 4, 5, 1))
-    assertEquals(tuple6.applySetter(tuple6Setter).at(1).replace(2), (2, 2, 3, 4, 5, 6))
-    assertEquals(tuple6.applySetter(tuple6Setter).at(2).replace(3), (1, 3, 3, 4, 5, 6))
-    assertEquals(tuple6.applySetter(tuple6Setter).at(3).replace(4), (1, 2, 4, 4, 5, 6))
-    assertEquals(tuple6.applySetter(tuple6Setter).at(4).replace(5), (1, 2, 3, 5, 5, 6))
-    assertEquals(tuple6.applySetter(tuple6Setter).at(5).replace(6), (1, 2, 3, 4, 6, 6))
-    assertEquals(tuple6.applySetter(tuple6Setter).at(6).replace(1), (1, 2, 3, 4, 5, 1))
+    assertEquals(tuple6.optics.andThen(tuple6Setter).at(1).replace(2), (2, 2, 3, 4, 5, 6))
+    assertEquals(tuple6.optics.andThen(tuple6Setter).at(2).replace(3), (1, 3, 3, 4, 5, 6))
+    assertEquals(tuple6.optics.andThen(tuple6Setter).at(3).replace(4), (1, 2, 4, 4, 5, 6))
+    assertEquals(tuple6.optics.andThen(tuple6Setter).at(4).replace(5), (1, 2, 3, 5, 5, 6))
+    assertEquals(tuple6.optics.andThen(tuple6Setter).at(5).replace(6), (1, 2, 3, 4, 6, 6))
+    assertEquals(tuple6.optics.andThen(tuple6Setter).at(6).replace(1), (1, 2, 3, 4, 5, 1))
 
     val sortedMap       = immutable.SortedMap(1 -> "one")
     val sortedMapSetter = Setter.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapSetter.at(1).replace(Some("two"))(sortedMap), immutable.SortedMap(1 -> "two"))
     assertEquals(sortedMapSetter.at(0).replace(Some("two"))(sortedMap), immutable.SortedMap(0 -> "two", 1 -> "one"))
-    assertEquals(sortedMap.applySetter(sortedMapSetter).at(1).replace(Some("two")), immutable.SortedMap(1 -> "two"))
+    assertEquals(sortedMap.optics.andThen(sortedMapSetter).at(1).replace(Some("two")), immutable.SortedMap(1 -> "two"))
     assertEquals(
-      sortedMap.applySetter(sortedMapSetter).at(0).replace(Some("two")),
+      sortedMap.optics.andThen(sortedMapSetter).at(0).replace(Some("two")),
       immutable.SortedMap(0 -> "two", 1 -> "one")
     )
 
@@ -169,9 +169,9 @@ class SetterSpec extends MonocleSuite {
     val listMapSetter = Setter.id[immutable.ListMap[Int, String]]
     assertEquals(listMapSetter.at(1).replace(Some("two"))(listMap), immutable.ListMap(1 -> "two"))
     assertEquals(listMapSetter.at(0).replace(Some("two"))(listMap), immutable.ListMap(1 -> "one", 0 -> "two"))
-    assertEquals(listMap.applySetter(listMapSetter).at(1).replace(Some("two")), immutable.ListMap(1 -> "two"))
+    assertEquals(listMap.optics.andThen(listMapSetter).at(1).replace(Some("two")), immutable.ListMap(1 -> "two"))
     assertEquals(
-      listMap.applySetter(listMapSetter).at(0).replace(Some("two")),
+      listMap.optics.andThen(listMapSetter).at(0).replace(Some("two")),
       immutable.ListMap(1 -> "one", 0 -> "two")
     )
 
@@ -179,15 +179,15 @@ class SetterSpec extends MonocleSuite {
     val mapSetter = Setter.id[Map[Int, String]]
     assertEquals(mapSetter.at(1).replace(Some("two"))(map), Map(1 -> "two"))
     assertEquals(mapSetter.at(0).replace(Some("two"))(map), Map(1 -> "one", 0 -> "two"))
-    assertEquals(map.applySetter(mapSetter).at(1).replace(Some("two")), Map(1 -> "two"))
-    assertEquals(map.applySetter(mapSetter).at(0).replace(Some("two")), Map(1 -> "one", 0 -> "two"))
+    assertEquals(map.optics.andThen(mapSetter).at(1).replace(Some("two")), Map(1 -> "two"))
+    assertEquals(map.optics.andThen(mapSetter).at(0).replace(Some("two")), Map(1 -> "one", 0 -> "two"))
 
     val set       = Set(1)
     val setSetter = Setter.id[Set[Int]]
     assertEquals(setSetter.at(1).replace(true)(set), Set(1))
     assertEquals(setSetter.at(2).replace(false)(set), Set(1))
-    assertEquals(set.applySetter(setSetter).at(1).replace(true), Set(1))
-    assertEquals(set.applySetter(setSetter).at(2).replace(false), Set(1))
+    assertEquals(set.optics.andThen(setSetter).at(1).replace(true), Set(1))
+    assertEquals(set.optics.andThen(setSetter).at(2).replace(false), Set(1))
   }
 
   test("index") {
@@ -195,70 +195,70 @@ class SetterSpec extends MonocleSuite {
     val listSetter = Setter.id[List[Int]]
     assertEquals(listSetter.index(0).replace(2)(list), List(2))
     assertEquals(listSetter.index(1).replace(2)(list), list)
-    assertEquals(list.applySetter(listSetter).index(0).replace(2), List(2))
-    assertEquals(list.applySetter(listSetter).index(1).replace(2), list)
+    assertEquals(list.optics.andThen(listSetter).index(0).replace(2), List(2))
+    assertEquals(list.optics.andThen(listSetter).index(1).replace(2), list)
 
     val lazyList       = LazyList(1)
     val lazyListSetter = Setter.id[LazyList[Int]]
     assertEquals(lazyListSetter.index(0).replace(2)(lazyList), LazyList(2))
     assertEquals(lazyListSetter.index(1).replace(2)(lazyList), lazyList)
-    assertEquals(lazyList.applySetter(lazyListSetter).index(0).replace(2), LazyList(2))
-    assertEquals(lazyList.applySetter(lazyListSetter).index(1).replace(2), lazyList)
+    assertEquals(lazyList.optics.andThen(lazyListSetter).index(0).replace(2), LazyList(2))
+    assertEquals(lazyList.optics.andThen(lazyListSetter).index(1).replace(2), lazyList)
 
     val listMap       = immutable.ListMap(1 -> "one")
     val listMapSetter = Setter.id[immutable.ListMap[Int, String]]
     assertEquals(listMapSetter.index(0).replace("two")(listMap), listMap)
     assertEquals(listMapSetter.index(1).replace("two")(listMap), immutable.ListMap(1 -> "two"))
-    assertEquals(listMap.applySetter(listMapSetter).index(0).replace("two"), listMap)
-    assertEquals(listMap.applySetter(listMapSetter).index(1).replace("two"), immutable.ListMap(1 -> "two"))
+    assertEquals(listMap.optics.andThen(listMapSetter).index(0).replace("two"), listMap)
+    assertEquals(listMap.optics.andThen(listMapSetter).index(1).replace("two"), immutable.ListMap(1 -> "two"))
 
     val map       = Map(1 -> "one")
     val mapSetter = Setter.id[Map[Int, String]]
     assertEquals(mapSetter.index(0).replace("two")(map), map)
     assertEquals(mapSetter.index(1).replace("two")(map), Map(1 -> "two"))
-    assertEquals(map.applySetter(mapSetter).index(0).replace("two"), map)
-    assertEquals(map.applySetter(mapSetter).index(1).replace("two"), Map(1 -> "two"))
+    assertEquals(map.optics.andThen(mapSetter).index(0).replace("two"), map)
+    assertEquals(map.optics.andThen(mapSetter).index(1).replace("two"), Map(1 -> "two"))
 
     val sortedMap       = immutable.SortedMap(1 -> "one")
     val sortedMapSetter = Setter.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapSetter.index(0).replace("two")(sortedMap), sortedMap)
     assertEquals(sortedMapSetter.index(1).replace("two")(sortedMap), immutable.SortedMap(1 -> "two"))
-    assertEquals(sortedMap.applySetter(sortedMapSetter).index(0).replace("two"), sortedMap)
-    assertEquals(sortedMap.applySetter(sortedMapSetter).index(1).replace("two"), immutable.SortedMap(1 -> "two"))
+    assertEquals(sortedMap.optics.andThen(sortedMapSetter).index(0).replace("two"), sortedMap)
+    assertEquals(sortedMap.optics.andThen(sortedMapSetter).index(1).replace("two"), immutable.SortedMap(1 -> "two"))
 
     val vector       = Vector(1)
     val vectorSetter = Setter.id[Vector[Int]]
     assertEquals(vectorSetter.index(0).replace(2)(vector), Vector(2))
     assertEquals(vectorSetter.index(1).replace(2)(vector), vector)
-    assertEquals(vector.applySetter(vectorSetter).index(0).replace(2), Vector(2))
-    assertEquals(vector.applySetter(vectorSetter).index(1).replace(2), vector)
+    assertEquals(vector.optics.andThen(vectorSetter).index(0).replace(2), Vector(2))
+    assertEquals(vector.optics.andThen(vectorSetter).index(1).replace(2), vector)
 
     val chain       = Chain.one(1)
     val chainSetter = Setter.id[Chain[Int]]
     assertEquals(chainSetter.index(0).replace(2)(chain), Chain(2))
     assertEquals(chainSetter.index(1).replace(2)(chain), chain)
-    assertEquals(chain.applySetter(chainSetter).index(0).replace(2), Chain(2))
-    assertEquals(chain.applySetter(chainSetter).index(1).replace(2), chain)
+    assertEquals(chain.optics.andThen(chainSetter).index(0).replace(2), Chain(2))
+    assertEquals(chain.optics.andThen(chainSetter).index(1).replace(2), chain)
 
     val nec       = NonEmptyChain.one(1)
     val necSetter = Setter.id[NonEmptyChain[Int]]
     assertEquals(necSetter.index(0).replace(2)(nec), NonEmptyChain(2))
     assertEquals(necSetter.index(1).replace(2)(nec), nec)
-    assertEquals(nec.applySetter(necSetter).index(0).replace(2), NonEmptyChain(2))
-    assertEquals(nec.applySetter(necSetter).index(1).replace(2), nec)
+    assertEquals(nec.optics.andThen(necSetter).index(0).replace(2), NonEmptyChain(2))
+    assertEquals(nec.optics.andThen(necSetter).index(1).replace(2), nec)
 
     val nev       = NonEmptyVector.one(1)
     val nevSetter = Setter.id[NonEmptyVector[Int]]
     assertEquals(nevSetter.index(0).replace(2)(nev), NonEmptyVector.one(2))
     assertEquals(nevSetter.index(1).replace(2)(nev), nev)
-    assertEquals(nev.applySetter(nevSetter).index(0).replace(2), NonEmptyVector.one(2))
-    assertEquals(nev.applySetter(nevSetter).index(1).replace(2), nev)
+    assertEquals(nev.optics.andThen(nevSetter).index(0).replace(2), NonEmptyVector.one(2))
+    assertEquals(nev.optics.andThen(nevSetter).index(1).replace(2), nev)
 
     val nel       = NonEmptyList.one(1)
     val nelSetter = Setter.id[NonEmptyList[Int]]
     assertEquals(nelSetter.index(0).replace(2)(nel), NonEmptyList.one(2))
     assertEquals(nelSetter.index(1).replace(2)(nel), nel)
-    assertEquals(nel.applySetter(nelSetter).index(0).replace(2), NonEmptyList.one(2))
-    assertEquals(nel.applySetter(nelSetter).index(1).replace(2), nel)
+    assertEquals(nel.optics.andThen(nelSetter).index(0).replace(2), NonEmptyList.one(2))
+    assertEquals(nel.optics.andThen(nelSetter).index(1).replace(2), nel)
   }
 }

--- a/test/shared/src/test/scala/monocle/TraversalSpec.scala
+++ b/test/shared/src/test/scala/monocle/TraversalSpec.scala
@@ -167,7 +167,7 @@ class TraversalSpec extends MonocleSuite {
     val traversal = Traversal.fromTraverse[List, Option[Int]]
 
     assertEquals(traversal.some.replace(5)(numbers), List(Some(5), None, Some(5), None))
-    assertEquals(numbers.applyTraversal(traversal).some.replace(5), List(Some(5), None, Some(5), None))
+    assertEquals(numbers.optics.andThen(traversal).some.replace(5), List(Some(5), None, Some(5), None))
   }
 
   test("withDefault") {
@@ -176,7 +176,7 @@ class TraversalSpec extends MonocleSuite {
 
     assertEquals(traversal.withDefault(0).modify(_ + 1)(numbers), List(Some(2), Some(1), Some(3), Some(1)))
     assertEquals(
-      numbers.applyTraversal(traversal).withDefault(0).modify(_ + 1),
+      numbers.optics.andThen(traversal).withDefault(0).modify(_ + 1),
       List(Some(2), Some(1), Some(3), Some(1))
     )
   }
@@ -186,7 +186,7 @@ class TraversalSpec extends MonocleSuite {
     val traversal = Traversal.fromTraverse[List, List[Int]]
 
     assertEquals(traversal.each.getAll(numbers), List(1, 2, 3, 4))
-    assertEquals(numbers.applyTraversal(traversal).each.getAll, List(1, 2, 3, 4))
+    assertEquals(numbers.optics.andThen(traversal).each.getAll, List(1, 2, 3, 4))
   }
 
   test("filter") {
@@ -194,7 +194,7 @@ class TraversalSpec extends MonocleSuite {
     val traversal = Traversal.fromTraverse[List, Int]
 
     assertEquals(traversal.filter(_ > 1).getAll(numbers), List(2, 3))
-    assertEquals(numbers.applyTraversal(traversal).filter(_ > 1).getAll, List(2, 3))
+    assertEquals(numbers.optics.andThen(traversal).filter(_ > 1).getAll, List(2, 3))
   }
 
   test("filterIndex") {
@@ -202,7 +202,7 @@ class TraversalSpec extends MonocleSuite {
     val traversal = Traversal.fromTraverse[List, List[String]]
 
     assertEquals(traversal.filterIndex((_: Int) > 0).getAll(words), List("world", "hi"))
-    assertEquals(words.applyTraversal(traversal).filterIndex((_: Int) > 0).getAll, List("world", "hi"))
+    assertEquals(words.optics.andThen(traversal).filterIndex((_: Int) > 0).getAll, List("world", "hi"))
   }
 
   test("at") {
@@ -210,17 +210,17 @@ class TraversalSpec extends MonocleSuite {
     val tuple2Traversal = Traversal.id[(Int, Int)]
     assertEquals(tuple2Traversal.at(1).getAll(tuple2), List(1))
     assertEquals(tuple2Traversal.at(2).getAll(tuple2), List(2))
-    assertEquals(tuple2.applyTraversal(tuple2Traversal).at(1).getAll, List(1))
-    assertEquals(tuple2.applyTraversal(tuple2Traversal).at(2).getAll, List(2))
+    assertEquals(tuple2.optics.andThen(tuple2Traversal).at(1).getAll, List(1))
+    assertEquals(tuple2.optics.andThen(tuple2Traversal).at(2).getAll, List(2))
 
     val tuple3          = (1, 2, 3)
     val tuple3Traversal = Traversal.id[(Int, Int, Int)]
     assertEquals(tuple3Traversal.at(1).getAll(tuple3), List(1))
     assertEquals(tuple3Traversal.at(2).getAll(tuple3), List(2))
     assertEquals(tuple3Traversal.at(3).getAll(tuple3), List(3))
-    assertEquals(tuple3.applyTraversal(tuple3Traversal).at(1).getAll, List(1))
-    assertEquals(tuple3.applyTraversal(tuple3Traversal).at(2).getAll, List(2))
-    assertEquals(tuple3.applyTraversal(tuple3Traversal).at(3).getAll, List(3))
+    assertEquals(tuple3.optics.andThen(tuple3Traversal).at(1).getAll, List(1))
+    assertEquals(tuple3.optics.andThen(tuple3Traversal).at(2).getAll, List(2))
+    assertEquals(tuple3.optics.andThen(tuple3Traversal).at(3).getAll, List(3))
 
     val tuple4          = (1, 2, 3, 4)
     val tuple4Traversal = Traversal.id[(Int, Int, Int, Int)]
@@ -228,10 +228,10 @@ class TraversalSpec extends MonocleSuite {
     assertEquals(tuple4Traversal.at(2).getAll(tuple4), List(2))
     assertEquals(tuple4Traversal.at(3).getAll(tuple4), List(3))
     assertEquals(tuple4Traversal.at(4).getAll(tuple4), List(4))
-    assertEquals(tuple4.applyTraversal(tuple4Traversal).at(1).getAll, List(1))
-    assertEquals(tuple4.applyTraversal(tuple4Traversal).at(2).getAll, List(2))
-    assertEquals(tuple4.applyTraversal(tuple4Traversal).at(3).getAll, List(3))
-    assertEquals(tuple4.applyTraversal(tuple4Traversal).at(4).getAll, List(4))
+    assertEquals(tuple4.optics.andThen(tuple4Traversal).at(1).getAll, List(1))
+    assertEquals(tuple4.optics.andThen(tuple4Traversal).at(2).getAll, List(2))
+    assertEquals(tuple4.optics.andThen(tuple4Traversal).at(3).getAll, List(3))
+    assertEquals(tuple4.optics.andThen(tuple4Traversal).at(4).getAll, List(4))
 
     val tuple5          = (1, 2, 3, 4, 5)
     val tuple5Traversal = Traversal.id[(Int, Int, Int, Int, Int)]
@@ -240,11 +240,11 @@ class TraversalSpec extends MonocleSuite {
     assertEquals(tuple5Traversal.at(3).getAll(tuple5), List(3))
     assertEquals(tuple5Traversal.at(4).getAll(tuple5), List(4))
     assertEquals(tuple5Traversal.at(5).getAll(tuple5), List(5))
-    assertEquals(tuple5.applyTraversal(tuple5Traversal).at(1).getAll, List(1))
-    assertEquals(tuple5.applyTraversal(tuple5Traversal).at(2).getAll, List(2))
-    assertEquals(tuple5.applyTraversal(tuple5Traversal).at(3).getAll, List(3))
-    assertEquals(tuple5.applyTraversal(tuple5Traversal).at(4).getAll, List(4))
-    assertEquals(tuple5.applyTraversal(tuple5Traversal).at(5).getAll, List(5))
+    assertEquals(tuple5.optics.andThen(tuple5Traversal).at(1).getAll, List(1))
+    assertEquals(tuple5.optics.andThen(tuple5Traversal).at(2).getAll, List(2))
+    assertEquals(tuple5.optics.andThen(tuple5Traversal).at(3).getAll, List(3))
+    assertEquals(tuple5.optics.andThen(tuple5Traversal).at(4).getAll, List(4))
+    assertEquals(tuple5.optics.andThen(tuple5Traversal).at(5).getAll, List(5))
 
     val tuple6          = (1, 2, 3, 4, 5, 6)
     val tuple6Traversal = Traversal.id[(Int, Int, Int, Int, Int, Int)]
@@ -254,40 +254,40 @@ class TraversalSpec extends MonocleSuite {
     assertEquals(tuple6Traversal.at(4).getAll(tuple6), List(4))
     assertEquals(tuple6Traversal.at(5).getAll(tuple6), List(5))
     assertEquals(tuple6Traversal.at(6).getAll(tuple6), List(6))
-    assertEquals(tuple6.applyTraversal(tuple6Traversal).at(1).getAll, List(1))
-    assertEquals(tuple6.applyTraversal(tuple6Traversal).at(2).getAll, List(2))
-    assertEquals(tuple6.applyTraversal(tuple6Traversal).at(3).getAll, List(3))
-    assertEquals(tuple6.applyTraversal(tuple6Traversal).at(4).getAll, List(4))
-    assertEquals(tuple6.applyTraversal(tuple6Traversal).at(5).getAll, List(5))
-    assertEquals(tuple6.applyTraversal(tuple6Traversal).at(6).getAll, List(6))
+    assertEquals(tuple6.optics.andThen(tuple6Traversal).at(1).getAll, List(1))
+    assertEquals(tuple6.optics.andThen(tuple6Traversal).at(2).getAll, List(2))
+    assertEquals(tuple6.optics.andThen(tuple6Traversal).at(3).getAll, List(3))
+    assertEquals(tuple6.optics.andThen(tuple6Traversal).at(4).getAll, List(4))
+    assertEquals(tuple6.optics.andThen(tuple6Traversal).at(5).getAll, List(5))
+    assertEquals(tuple6.optics.andThen(tuple6Traversal).at(6).getAll, List(6))
 
     val sortedMap          = immutable.SortedMap(1 -> "one")
     val sortedMapTraversal = Traversal.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapTraversal.at(1).getAll(sortedMap), List(Some("one")))
     assertEquals(sortedMapTraversal.at(0).getAll(sortedMap), List(None))
-    assertEquals(sortedMap.applyTraversal(sortedMapTraversal).at(1).getAll, List(Some("one")))
-    assertEquals(sortedMap.applyTraversal(sortedMapTraversal).at(0).getAll, List(None))
+    assertEquals(sortedMap.optics.andThen(sortedMapTraversal).at(1).getAll, List(Some("one")))
+    assertEquals(sortedMap.optics.andThen(sortedMapTraversal).at(0).getAll, List(None))
 
     val listMap          = immutable.ListMap(1 -> "one")
     val listMapTraversal = Traversal.id[immutable.ListMap[Int, String]]
     assertEquals(listMapTraversal.at(1).getAll(listMap), List(Some("one")))
     assertEquals(listMapTraversal.at(0).getAll(listMap), List(None))
-    assertEquals(listMap.applyTraversal(listMapTraversal).at(1).getAll, List(Some("one")))
-    assertEquals(listMap.applyTraversal(listMapTraversal).at(0).getAll, List(None))
+    assertEquals(listMap.optics.andThen(listMapTraversal).at(1).getAll, List(Some("one")))
+    assertEquals(listMap.optics.andThen(listMapTraversal).at(0).getAll, List(None))
 
     val map          = immutable.Map(1 -> "one")
     val mapTraversal = Traversal.id[Map[Int, String]]
     assertEquals(mapTraversal.at(1).getAll(map), List(Some("one")))
     assertEquals(mapTraversal.at(0).getAll(map), List(None))
-    assertEquals(map.applyTraversal(mapTraversal).at(1).getAll, List(Some("one")))
-    assertEquals(map.applyTraversal(mapTraversal).at(0).getAll, List(None))
+    assertEquals(map.optics.andThen(mapTraversal).at(1).getAll, List(Some("one")))
+    assertEquals(map.optics.andThen(mapTraversal).at(0).getAll, List(None))
 
     val set          = Set(1)
     val setTraversal = Traversal.id[Set[Int]]
     assertEquals(setTraversal.at(1).getAll(set), List(true))
     assertEquals(setTraversal.at(0).getAll(set), List(false))
-    assertEquals(set.applyTraversal(setTraversal).at(1).getAll, List(true))
-    assertEquals(set.applyTraversal(setTraversal).at(0).getAll, List(false))
+    assertEquals(set.optics.andThen(setTraversal).at(1).getAll, List(true))
+    assertEquals(set.optics.andThen(setTraversal).at(0).getAll, List(false))
   }
 
   test("index") {
@@ -295,70 +295,70 @@ class TraversalSpec extends MonocleSuite {
     val listTraversal = Traversal.id[List[Int]]
     assertEquals(listTraversal.index(0).getAll(list), List(1))
     assertEquals(listTraversal.index(1).getAll(list), Nil)
-    assertEquals(list.applyTraversal(listTraversal).index(0).getAll, List(1))
-    assertEquals(list.applyTraversal(listTraversal).index(1).getAll, Nil)
+    assertEquals(list.optics.andThen(listTraversal).index(0).getAll, List(1))
+    assertEquals(list.optics.andThen(listTraversal).index(1).getAll, Nil)
 
     val lazyList          = LazyList(1)
     val lazyListTraversal = Traversal.id[LazyList[Int]]
     assertEquals(lazyListTraversal.index(0).getAll(lazyList), List(1))
     assertEquals(lazyListTraversal.index(1).getAll(lazyList), Nil)
-    assertEquals(lazyList.applyTraversal(lazyListTraversal).index(0).getAll, List(1))
-    assertEquals(lazyList.applyTraversal(lazyListTraversal).index(1).getAll, Nil)
+    assertEquals(lazyList.optics.andThen(lazyListTraversal).index(0).getAll, List(1))
+    assertEquals(lazyList.optics.andThen(lazyListTraversal).index(1).getAll, Nil)
 
     val listMap          = immutable.ListMap(1 -> "one")
     val listMapTraversal = Traversal.id[immutable.ListMap[Int, String]]
     assertEquals(listMapTraversal.index(0).getAll(listMap), Nil)
     assertEquals(listMapTraversal.index(1).getAll(listMap), List("one"))
-    assertEquals(listMap.applyTraversal(listMapTraversal).index(0).getAll, Nil)
-    assertEquals(listMap.applyTraversal(listMapTraversal).index(1).getAll, List("one"))
+    assertEquals(listMap.optics.andThen(listMapTraversal).index(0).getAll, Nil)
+    assertEquals(listMap.optics.andThen(listMapTraversal).index(1).getAll, List("one"))
 
     val map          = Map(1 -> "one")
     val mapTraversal = Traversal.id[Map[Int, String]]
     assertEquals(mapTraversal.index(0).getAll(map), Nil)
     assertEquals(mapTraversal.index(1).getAll(map), List("one"))
-    assertEquals(map.applyTraversal(mapTraversal).index(0).getAll, Nil)
-    assertEquals(map.applyTraversal(mapTraversal).index(1).getAll, List("one"))
+    assertEquals(map.optics.andThen(mapTraversal).index(0).getAll, Nil)
+    assertEquals(map.optics.andThen(mapTraversal).index(1).getAll, List("one"))
 
     val sortedMap          = immutable.SortedMap(1 -> "one")
     val sortedMapTraversal = Traversal.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapTraversal.index(0).getAll(sortedMap), Nil)
     assertEquals(sortedMapTraversal.index(1).getAll(sortedMap), List("one"))
-    assertEquals(sortedMap.applyTraversal(sortedMapTraversal).index(0).getAll, Nil)
-    assertEquals(sortedMap.applyTraversal(sortedMapTraversal).index(1).getAll, List("one"))
+    assertEquals(sortedMap.optics.andThen(sortedMapTraversal).index(0).getAll, Nil)
+    assertEquals(sortedMap.optics.andThen(sortedMapTraversal).index(1).getAll, List("one"))
 
     val vector          = Vector(1)
     val vectorTraversal = Traversal.id[Vector[Int]]
     assertEquals(vectorTraversal.index(0).getAll(vector), List(1))
     assertEquals(vectorTraversal.index(1).getAll(vector), Nil)
-    assertEquals(vector.applyTraversal(vectorTraversal).index(0).getAll, List(1))
-    assertEquals(vector.applyTraversal(vectorTraversal).index(1).getAll, Nil)
+    assertEquals(vector.optics.andThen(vectorTraversal).index(0).getAll, List(1))
+    assertEquals(vector.optics.andThen(vectorTraversal).index(1).getAll, Nil)
 
     val chain          = Chain.one(1)
     val chainTraversal = Traversal.id[Chain[Int]]
     assertEquals(chainTraversal.index(0).getAll(chain), List(1))
     assertEquals(chainTraversal.index(1).getAll(chain), Nil)
-    assertEquals(chain.applyTraversal(chainTraversal).index(0).getAll, List(1))
-    assertEquals(chain.applyTraversal(chainTraversal).index(1).getAll, Nil)
+    assertEquals(chain.optics.andThen(chainTraversal).index(0).getAll, List(1))
+    assertEquals(chain.optics.andThen(chainTraversal).index(1).getAll, Nil)
 
     val nec          = NonEmptyChain.one(1)
     val necTraversal = Traversal.id[NonEmptyChain[Int]]
     assertEquals(necTraversal.index(0).getAll(nec), List(1))
     assertEquals(necTraversal.index(1).getAll(nec), Nil)
-    assertEquals(nec.applyTraversal(necTraversal).index(0).getAll, List(1))
-    assertEquals(nec.applyTraversal(necTraversal).index(1).getAll, Nil)
+    assertEquals(nec.optics.andThen(necTraversal).index(0).getAll, List(1))
+    assertEquals(nec.optics.andThen(necTraversal).index(1).getAll, Nil)
 
     val nev          = NonEmptyVector.one(1)
     val nevTraversal = Traversal.id[NonEmptyVector[Int]]
     assertEquals(nevTraversal.index(0).getAll(nev), List(1))
     assertEquals(nevTraversal.index(1).getAll(nev), Nil)
-    assertEquals(nev.applyTraversal(nevTraversal).index(0).getAll, List(1))
-    assertEquals(nev.applyTraversal(nevTraversal).index(1).getAll, Nil)
+    assertEquals(nev.optics.andThen(nevTraversal).index(0).getAll, List(1))
+    assertEquals(nev.optics.andThen(nevTraversal).index(1).getAll, Nil)
 
     val nel          = NonEmptyList.one(1)
     val nelTraversal = Traversal.id[NonEmptyList[Int]]
     assertEquals(nelTraversal.index(0).getAll(nel), List(1))
     assertEquals(nelTraversal.index(1).getAll(nel), Nil)
-    assertEquals(nel.applyTraversal(nelTraversal).index(0).getAll, List(1))
-    assertEquals(nel.applyTraversal(nelTraversal).index(1).getAll, Nil)
+    assertEquals(nel.optics.andThen(nelTraversal).index(0).getAll, List(1))
+    assertEquals(nel.optics.andThen(nelTraversal).index(1).getAll, Nil)
   }
 }

--- a/test/shared/src/test/scala/monocle/function/AtSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/AtSpec.scala
@@ -18,19 +18,19 @@ class AtSpec extends MonocleSuite {
 
   test("at creates a Lens from a Map, SortedMap to an optional value") {
     val map = Map("One" -> 1, "Two" -> 2)
-    assertEquals((map applyLens at("One")).replace(Some(-1)), Map("One" -> -1, "Two" -> 2))
-    assertEquals((map applyLens at("Two")).get, Some(2))
+    assertEquals(map.optics.at("One").replace(Some(-1)), Map("One" -> -1, "Two" -> 2))
+    assertEquals(map.optics.at("Two").get, Some(2))
   }
 
   test("at for tuples") {
     val tuple2 = (true, "hello")
     val tuple3 = (true, "hello", 5)
 
-    assertEquals((tuple2 applyLens at(1)).get, true)
-    assertEquals((tuple2 applyLens at(2)).get, "hello")
+    assertEquals(tuple2.optics.at(1).get, true)
+    assertEquals(tuple2.optics.at(2).get, "hello")
 
-    assertEquals((tuple3 applyLens at(1)).get, true)
-    assertEquals((tuple3 applyLens at(2)).get, "hello")
-    assertEquals((tuple3 applyLens at(3)).get, 5)
+    assertEquals(tuple3.optics.at(1).get, true)
+    assertEquals(tuple3.optics.at(2).get, "hello")
+    assertEquals(tuple3.optics.at(3).get, 5)
   }
 }


### PR DESCRIPTION
1. deprecate `applyX`, e.g. `applyLens`, `applyGetter`
2. deprecate symbolic aliases to `applyX` e.g. `&<->`
3. add `optics` method which transaform any value `a: A` into a `ApplyIso[A, A, A , A]` i.e. a partlially applied optics that points to itself

What do you think of `optics` name? it needs to be short.