### PR TITLE
Update build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val buildSettings = Seq(
   scalacOptions in (Compile, console) -= "-Ywarn-unused:imports",
   scalacOptions ++= {
     if (isDotty.value)
-      Seq("-Ykind-projector", "-language:implicitConversions,higherKinds,postfixOps")
+      Seq("-source:3.0-migration", "-Ykind-projector", "-language:implicitConversions,higherKinds,postfixOps")
     else Seq(
       "-Ymacro-annotations",
       "-Ywarn-dead-code",
@@ -172,7 +172,8 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
     moduleName := "monocle-core",
     scalacOptions ~= (_.filterNot(
       Set(
-        "-Xfatal-warnings" // Workaround for sbt bug
+        "-Xfatal-warnings", // Workaround for sbt bug
+        "-source:3.0-migration",
       )
     )),
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val buildSettings = Seq(
 )
 
 lazy val catsVersion  = "2.3.1"
-lazy val dottyVersions = Seq("3.0.0-M3", "3.0.0-M2")
+lazy val dottyVersions = Seq("3.0.0-M3")
 
 lazy val cats              = Def.setting("org.typelevel" %%% "cats-core" % catsVersion)
 lazy val catsFree          = Def.setting("org.typelevel" %%% "cats-free" % catsVersion)

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val buildSettings = Seq(
 )
 
 lazy val catsVersion  = "2.3.0"
-lazy val dottyVersions = Seq("3.0.0-M1", "3.0.0-M2")
+lazy val dottyVersions = Seq("3.0.0-M3", "3.0.0-M2")
 
 lazy val cats              = Def.setting("org.typelevel" %%% "cats-core" % catsVersion)
 lazy val catsFree          = Def.setting("org.typelevel" %%% "cats-free" % catsVersion)

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val buildSettings = Seq(
   Compile / doc / sources := { if (isDotty.value) Seq() else (Compile / doc / sources).value }
 )
 
-lazy val catsVersion  = "2.3.0"
+lazy val catsVersion  = "2.3.1"
 lazy val dottyVersions = Seq("3.0.0-M3", "3.0.0-M2")
 
 lazy val cats              = Def.setting("org.typelevel" %%% "cats-core" % catsVersion)

--- a/build.sbt
+++ b/build.sbt
@@ -9,33 +9,20 @@ inThisBuild(List(
   organization := "com.github.julien-truffaut",
   homepage := Some(url("https://github.com/optics-dev/Monocle")),
   licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT")),
-  developers := List(
-    Developer(
-      "julien-truffaut",
-      "Julien Truffaut",
-      "truffaut.julien@gmail.com",
-      url("https://github.com/julien-truffaut")
-    ),
-    Developer(
-      "NightRa",
-      "Ilan Godik",
-      "",
-      url("https://github.com/NightRa")
-    ),
-    Developer(
-      "aoiroaoino",
-      "Naoki Aoyama",
-      "aoiro.aoino@gmail.com",
-      url("https://github.com/aoiroaoino")
-    ),
-    Developer(
-      "xuwei-k",
-      "Kenji Yoshida",
-      " 6b656e6a69@gmail.com",
-      url("https://github.com/xuwei-k")
-    ),
+  developers :=
+    List(
+      "aoiroaoino" -> "Naoki Aoyama",
+      "cquiroz" -> "Carlos Quiroz",
+      "kenbot" -> " Ken Scambler",
+      "julien-truffaut" -> "Julien Truffaut",
+      "NightRa" -> "Ilan Godik",
+      "xuwei-k" -> "Kenji Yoshida",
+      "yilinwei" -> "Yilin Wei",
+    ).map { case (username, fullName) =>
+      Developer(username, fullName, s"@$username", url(s"https://github.com/$username"))
+    }
   )
-))
+)
 
 lazy val kindProjector = "org.typelevel" % "kind-projector" % "0.11.3" cross CrossVersion.full
 

--- a/build.sbt
+++ b/build.sbt
@@ -88,11 +88,11 @@ lazy val catsFree          = Def.setting("org.typelevel" %%% "cats-free" % catsV
 lazy val catsLaws          = Def.setting("org.typelevel" %%% "cats-laws" % catsVersion)
 lazy val alleycats         = Def.setting("org.typelevel" %%% "alleycats-core" % catsVersion)
 lazy val shapeless         = Def.setting("com.chuusai" %%% "shapeless" % "2.3.3")
-lazy val refinedDep        = Def.setting("eu.timepit" %%% "refined" % "0.9.19")
-lazy val refinedScalacheck = Def.setting("eu.timepit" %%% "refined-scalacheck" % "0.9.19" % "test")
+lazy val refinedDep        = Def.setting("eu.timepit" %%% "refined" % "0.9.20")
+lazy val refinedScalacheck = Def.setting("eu.timepit" %%% "refined-scalacheck" % "0.9.20" % "test")
 
-lazy val discipline      = Def.setting("org.typelevel" %%% "discipline-core" % "1.1.2")
-lazy val munit           = Def.setting("org.scalameta" %% "munit" % "0.7.16" % Test)
+lazy val discipline      = Def.setting("org.typelevel" %%% "discipline-core" % "1.1.3")
+lazy val munit           = Def.setting("org.scalameta" %% "munit" % "0.7.21" % Test)
 lazy val munitDiscipline = Def.setting("org.typelevel" %% "discipline-munit" % "1.0.5" % Test)
 
 lazy val macroVersion = "2.1.1"

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
-import com.typesafe.tools.mima.plugin.MimaKeys.mimaPreviousArtifacts
-import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
+import com.typesafe.tools.mima.core._
 import sbt.Keys._
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
@@ -98,7 +97,7 @@ lazy val munitDiscipline = Def.setting("org.typelevel" %% "discipline-munit" % "
 
 lazy val macroVersion = "2.1.1"
 
-def mimaSettings(module: String): Seq[Setting[_]] = mimaDefaultSettings ++ Seq(
+def mimaSettings(module: String): Seq[Setting[_]] = Seq(
   mimaPreviousArtifacts := Set("com.github.julien-truffaut" %% s"monocle-${module}" % "2.0.0")
 )
 

--- a/core/shared/src/main/scala-3.x/monocle/Focus.scala
+++ b/core/shared/src/main/scala-3.x/monocle/Focus.scala
@@ -1,0 +1,17 @@
+package monocle
+
+import monocle.internal.focus.FocusImpl
+
+object Focus {
+
+  extension [A] (opt: Option[A])
+    def some: A = scala.sys.error("Extension method 'some' should only be used within the moocle.Focus macro.")
+
+
+  def apply[S] = new MkFocus[S]
+
+  class MkFocus[S] {
+    transparent inline def apply[T](inline get: (S => T)): Any = 
+      ${ FocusImpl('get) }
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/Focus.scala
+++ b/core/shared/src/main/scala-3.x/monocle/Focus.scala
@@ -6,8 +6,7 @@ object Focus {
 
   extension [A] (opt: Option[A])
     def some: A = scala.sys.error("Extension method 'some' should only be used within the moocle.Focus macro.")
-
-
+  
   def apply[S] = new MkFocus[S]
 
   class MkFocus[S] {

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/ErrorHandling.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/ErrorHandling.scala
@@ -1,0 +1,15 @@
+package monocle.internal.focus
+
+private[focus] trait ErrorHandling {
+  this: FocusBase => 
+  
+  def errorMessage(error: FocusError): String = error match {
+    case FocusError.NotACaseClass(fromClass) => s"Expecting a case class in the 'From' position; found $fromClass"
+    case FocusError.NotAConcreteClass(fromClass) => s"Expecting a concrete case class in the 'From' position; cannot reify type $fromClass"
+    case FocusError.NotASimpleLambdaFunction => s"Expecting a lambda function that directly accesses a field. Example: `GenLens[Address](_.streetNumber)`"
+    case FocusError.DidNotDirectlyAccessArgument(argName) => s"Expecting a lambda function that directly accesses the argument; other variable `$argName` found. Example: `GenLens[Address](_.streetNumber)`"
+    case FocusError.ComposeMismatch(type1, type2) => s"Could not compose $type1 >>> $type2"
+    case FocusError.UnexpectedCodeStructure(code) => s"Unexpected code structure: $code"
+    case FocusError.CouldntFindFieldType(fromType, fieldName) => s"Couldn't find type for $fromType.$fieldName"
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
@@ -1,0 +1,41 @@
+package monocle.internal.focus
+
+import scala.quoted.Quotes
+
+private[focus] trait FocusBase {
+  val macroContext: Quotes 
+
+  given Quotes = macroContext
+
+  type Term = macroContext.reflect.Term
+  type TypeRepr = macroContext.reflect.TypeRepr
+
+  enum FocusAction {
+    case FieldSelect(name: String, fromType: TypeRepr, fromTypeArgs: List[TypeRepr], toType: TypeRepr)
+    case OptionSome(toType: TypeRepr)
+
+    override def toString(): String = this match {
+      case FieldSelect(name, fromType, fromTypeArgs, toType) => s"FieldSelect($name, ${fromType.show}, ${fromTypeArgs.map(_.show).mkString("[", ",", "]")}, ${toType.show})"
+      case OptionSome(toType) => s"OptionSome(${toType.show})"
+    }
+  }
+
+  enum FocusError {
+    case NotACaseClass(className: String)
+    case NotAConcreteClass(className: String)
+    case DidNotDirectlyAccessArgument(argName: String)
+    case NotASimpleLambdaFunction
+    case UnexpectedCodeStructure(code: String)
+    case CouldntFindFieldType(fromType: String, fieldName: String)
+    case ComposeMismatch(type1: String, type2: String)
+
+    def asResult: FocusResult[Nothing] = Left(this)
+  }
+
+  trait FocusParser {
+    def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]]
+  }
+
+  type FocusResult[+A] = Either[FocusError, A]
+  type ParseResult = FocusResult[List[FocusAction]]
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusImpl.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusImpl.scala
@@ -1,0 +1,31 @@
+package monocle.internal.focus
+
+import monocle.Lens
+import scala.quoted.{Type, Expr, Quotes, quotes}
+
+private[focus] class FocusImpl(val macroContext: Quotes) 
+    extends FocusBase 
+    with ErrorHandling
+    with ParserLoop with AllParsers 
+    with GeneratorLoop with AllGenerators {
+
+  import macroContext.reflect._
+
+  def run[From: Type, To: Type](lambda: Expr[From => To]): Expr[Any] = {
+    val parseResult: FocusResult[List[FocusAction]] = 
+      parseLambda[From](lambda.asTerm)
+
+    val generatedCode: FocusResult[Term] = 
+      parseResult.flatMap(generateCode[From])
+      
+    generatedCode match {
+      case Right(code) => code.asExpr
+      case Left(error) => report.error(errorMessage(error)); '{???}
+    }
+  }
+}
+
+object FocusImpl {
+  def apply[From: Type, To: Type](lambda: Expr[From => To])(using Quotes): Expr[Any] =
+    new FocusImpl(quotes).run(lambda)
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/GeneratorLoop.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/GeneratorLoop.scala
@@ -1,0 +1,87 @@
+package monocle.internal.focus
+
+import monocle.internal.focus.features.fieldselect.FieldSelectGenerator
+import monocle.internal.focus.features.optionsome.OptionSomeGenerator
+import monocle.{Lens, Iso, Prism, Optional}
+import scala.quoted.Type
+
+
+private[focus] trait AllGenerators
+  extends FocusBase
+  with FieldSelectGenerator 
+  with OptionSomeGenerator
+
+private[focus] trait GeneratorLoop {
+  this: FocusBase with AllGenerators => 
+
+  import macroContext.reflect._
+
+  def generateCode[From: Type](actions: List[FocusAction]): FocusResult[Term] = {
+    val idOptic: FocusResult[Term] = Right('{Iso.id[From]}.asTerm)
+    
+    actions.foldLeft(idOptic) { (resultSoFar, action) => 
+      resultSoFar.flatMap(term => composeOptics(term, generateActionCode(action)))
+    }
+  }
+
+  private def generateActionCode(action: FocusAction): Term = 
+    action match {
+      case FocusAction.FieldSelect(name, fromType, fromTypeArgs, toType) => generateFieldSelect(name, fromType, fromTypeArgs, toType)
+      case FocusAction.OptionSome(toType) => generateOptionSome(toType)
+    }
+
+  private def composeOptics(lens1: Term, lens2: Term): FocusResult[Term] = {
+    (lens1.tpe.asType, lens2.tpe.asType) match {
+      case ('[Lens[from1, to1]], '[Lens[from2, to2]]) => 
+        Right('{ ${lens1.asExprOf[Lens[from1, to1]]}.andThen(${lens2.asExprOf[Lens[to1, to2]]}) }.asTerm)
+
+      case ('[Lens[from1, to1]], '[Prism[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Lens[from1, to1]]}.andThen(${lens2.asExprOf[Prism[to1, to2]]}) }.asTerm)
+
+      case ('[Lens[from1, to1]], '[Optional[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Lens[from1, to1]]}.andThen(${lens2.asExprOf[Optional[to1, to2]]}) }.asTerm)
+
+      case ('[Lens[from1, to1]], '[Iso[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Lens[from1, to1]]}.andThen(${lens2.asExprOf[Iso[to1, to2]]}) }.asTerm)
+
+      case ('[Prism[from1, to1]], '[Prism[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Prism[from1, to1]]}.andThen(${lens2.asExprOf[Prism[to1, to2]]}) }.asTerm)
+
+      case ('[Prism[from1, to1]], '[Lens[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Prism[from1, to1]]}.andThen(${lens2.asExprOf[Lens[to1, to2]]}) }.asTerm)
+
+      case ('[Prism[from1, to1]], '[Optional[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Prism[from1, to1]]}.andThen(${lens2.asExprOf[Optional[to1, to2]]}) }.asTerm)
+
+      case ('[Prism[from1, to1]], '[Iso[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Prism[from1, to1]]}.andThen(${lens2.asExprOf[Iso[to1, to2]]}) }.asTerm)
+
+      case ('[Optional[from1, to1]], '[Lens[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Optional[from1, to1]]}.andThen(${lens2.asExprOf[Lens[to1, to2]]}) }.asTerm)
+
+      case ('[Optional[from1, to1]], '[Optional[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Optional[from1, to1]]}.andThen(${lens2.asExprOf[Optional[to1, to2]]}) }.asTerm)
+
+      case ('[Optional[from1, to1]], '[Prism[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Optional[from1, to1]]}.andThen(${lens2.asExprOf[Prism[to1, to2]]}) }.asTerm)
+
+      case ('[Optional[from1, to1]], '[Iso[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Optional[from1, to1]]}.andThen(${lens2.asExprOf[Iso[to1, to2]]}) }.asTerm)
+
+      case ('[Iso[from1, to1]], '[Lens[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Iso[from1, to1]]}.andThen(${lens2.asExprOf[Lens[to1, to2]]}) }.asTerm)
+
+      case ('[Iso[from1, to1]], '[Iso[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Iso[from1, to1]]}.andThen(${lens2.asExprOf[Iso[to1, to2]]}) }.asTerm)
+
+      case ('[Iso[from1, to1]], '[Optional[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Iso[from1, to1]]}.andThen(${lens2.asExprOf[Optional[to1, to2]]}) }.asTerm)
+
+      case ('[Iso[from1, to1]], '[Prism[from2, to2]]) =>
+        Right('{ ${lens1.asExprOf[Iso[from1, to1]]}.andThen(${lens2.asExprOf[Prism[to1, to2]]}) }.asTerm)
+
+      case ('[a], '[b]) => 
+        FocusError.ComposeMismatch(TypeRepr.of[a].show, TypeRepr.of[b].show).asResult
+    }
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/ParserLoop.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/ParserLoop.scala
@@ -1,0 +1,70 @@
+package monocle.internal.focus
+
+import scala.quoted.Type
+import monocle.internal.focus.features.fieldselect.FieldSelectParser
+import monocle.internal.focus.features.optionsome.OptionSomeParser
+
+private[focus] trait AllParsers 
+  extends FocusBase
+  with FieldSelectParser 
+  with OptionSomeParser
+
+private[focus] trait ParserLoop {
+  this: FocusBase with AllParsers => 
+
+  import macroContext.reflect._
+  
+  def parseLambda[From: Type](lambda: Term): ParseResult = {
+    val fromTypeIsConcrete = TypeRepr.of[From].classSymbol.isDefined
+
+    lambda match {
+      case ExpectedLambdaFunction(params) if fromTypeIsConcrete => parseLambdaBody(params)
+      case ExpectedLambdaFunction(_) => FocusError.NotASimpleLambdaFunction.asResult
+      case _ => FocusError.NotAConcreteClass(Type.show[Type[From]]).asResult
+    }
+  }
+
+  private case class ParseParams(argName: String, argType: TypeRepr, lambdaBody: Term)
+
+  private object LambdaArgument {
+    def unapply(term: Term): Option[String] = term match {
+      case Ident(idName) => Some(idName)
+      case _ => None
+    }
+  }
+
+  private def parseLambdaBody(params: ParseParams): ParseResult = {
+    def loop(remainingBody: Term, listSoFar: List[FocusAction]): ParseResult = {
+
+      remainingBody match {
+        case LambdaArgument(idName) if idName == params.argName => Right(listSoFar)
+        case LambdaArgument(idName) => FocusError.DidNotDirectlyAccessArgument(idName).asResult
+
+        case OptionSome(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
+        case OptionSome(Left(error)) => Left(error)
+
+        case FieldSelect(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
+        case FieldSelect(Left(error)) => Left(error)
+
+        case unexpected => FocusError.UnexpectedCodeStructure(unexpected.show).asResult
+      }
+    }
+    loop(params.lambdaBody, Nil)
+  }
+
+  private def unwrap(term: Term): Term = {
+    term match {
+      case Block(List(), inner) => unwrap(inner)
+      case Inlined(_, _, inner) => unwrap(inner)
+      case x => x
+    }
+  }
+
+  private object ExpectedLambdaFunction {
+    def unapply(term: Term): Option[ParseParams] = 
+      unwrap(term) match {
+        case Lambda(List(ValDef(argName, typeTree, _)), body) => Some(ParseParams(argName, typeTree.tpe, body))
+        case _ => None
+      }
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/fieldselect/FieldSelectGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/fieldselect/FieldSelectGenerator.scala
@@ -1,0 +1,33 @@
+package monocle.internal.focus.features.fieldselect
+
+import monocle.internal.focus.FocusBase
+import monocle.Lens
+import scala.quoted.Quotes
+
+private[focus] trait FieldSelectGenerator {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  def generateFieldSelect(field: String, fromType: TypeRepr, fromTypeArgs: List[TypeRepr], toType: TypeRepr): Term = {
+    (fromType.asType, toType.asType) match {
+      case ('[f], '[t]) => 
+        '{
+          val setter: t => f => f = (to: t) => (from: f) => 
+            ${ generateSetter(field, '{from}.asTerm, '{to}.asTerm, fromTypeArgs).asExprOf[f] }
+
+          val getter: f => t = (from: f) => 
+            ${ generateGetter(field, '{from}.asTerm).asExprOf[t] }
+
+          _root_.monocle.Lens.apply[f, t](getter)(setter)
+        }.asTerm
+    }
+  }
+
+  private def generateGetter(field: String, from: Term): Term = 
+    Select.unique(from, field) // o.field
+
+  private def generateSetter(field: String, from: Term, to: Term, fromTypeArgs: List[TypeRepr]): Term = {
+    Select.overloaded(from, "copy", fromTypeArgs, NamedArg(field, to) :: Nil) // o.copy(field = value)
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/fieldselect/FieldSelectParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/fieldselect/FieldSelectParser.scala
@@ -1,0 +1,90 @@
+package monocle.internal.focus.features.fieldselect
+
+import monocle.internal.focus.FocusBase
+
+private[focus] trait FieldSelectParser {
+  this: FocusBase => 
+
+  import this.macroContext.reflect._
+  
+  object FieldSelect extends FocusParser {
+
+    def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]] = term match {
+      case Select(CaseClass(remainingCode), fieldName) => 
+        val action = getFieldAction(getFromType(remainingCode), fieldName)
+        val remainingCodeWithAction = action.map(a => (remainingCode, a))
+        Some(remainingCodeWithAction)
+
+      case Select(remainingCode, _) => 
+        Some(FocusError.NotACaseClass(remainingCode.tpe.show).asResult)
+        
+      case _ => None
+    }
+
+  }
+
+  private def getFieldAction(fromType: TypeRepr, fieldName: String): FocusResult[FocusAction] = {
+    getFieldType(fromType, fieldName) match {
+      case Some(toType) => Right(FocusAction.FieldSelect(fieldName, fromType, getSuppliedTypeArgs(fromType), toType))
+      case None => FocusError.CouldntFindFieldType(fromType.show, fieldName).asResult
+    }
+  }
+
+  private def getFromType(remainingCode: Term): TypeRepr = 
+    remainingCode.tpe.widen
+
+  private def getFieldType(fromType: TypeRepr, fieldName: String): Option[TypeRepr] = {
+    fromType.classSymbol.flatMap { 
+      _.memberField(fieldName) match {
+        case FieldType(possiblyTypeArg) => Some(swapWithSuppliedType(fromType, possiblyTypeArg))
+        case _ => None
+      }
+    }
+  }
+
+  private object FieldType {
+    def unapply(fieldSymbol: Symbol): Option[TypeRepr] = fieldSymbol match {
+      case sym if sym.isNoSymbol => None
+      case sym => sym.tree match {
+        case ValDef(_, typeTree, _) => Some(typeTree.tpe)
+        case _ => None
+      }
+    }
+  }
+
+  private def getSuppliedTypeArgs(fromType: TypeRepr): List[TypeRepr] = {
+    fromType match {
+      case AppliedType(_, argTypeReprs) => argTypeReprs 
+      case _ => Nil
+    }
+  }
+
+  object CaseClass {
+    def unapply(term: Term): Option[Term] =
+      term.tpe.classSymbol.flatMap { sym => 
+        Option.when(sym.flags.is(Flags.Case))(term)
+      }
+  }
+
+
+  private def getDeclaredTypeArgs(classType: TypeRepr): List[Symbol] = {
+    classType.classSymbol.map(_.primaryConstructor.paramSymss) match {
+      case Some(typeParamList :: _) if typeParamList.exists(_.isTypeParam) => typeParamList
+      case _ => Nil
+    }
+  }
+
+  private def swapWithSuppliedType(fromType: TypeRepr, possiblyContainsTypeArgs: TypeRepr): TypeRepr = {
+    val declared = getDeclaredTypeArgs(fromType)
+    val supplied = getSuppliedTypeArgs(fromType)
+    val swapDict = declared.view.map(_.name).zip(supplied).toMap
+    
+    def swapInto(candidate: TypeRepr): TypeRepr = {
+      candidate match {
+        case AppliedType(typeCons, args) => swapInto(typeCons).appliedTo(args.map(swapInto))
+        case leafType => swapDict.getOrElse(leafType.typeSymbol.name, leafType)
+      }
+    }
+    swapInto(possiblyContainsTypeArgs)
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/optionsome/OptionSomeGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/optionsome/OptionSomeGenerator.scala
@@ -1,0 +1,15 @@
+package monocle.internal.focus.features.optionsome
+
+import monocle.internal.focus.FocusBase
+
+private[focus] trait OptionSomeGenerator {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  def generateOptionSome(toType: TypeRepr): Term = {
+    toType.asType match {
+      case '[t] => '{ _root_.monocle.std.option.some[t] }.asTerm
+    }
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/optionsome/OptionSomeParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/optionsome/OptionSomeParser.scala
@@ -1,0 +1,21 @@
+package monocle.internal.focus.features.optionsome
+
+import monocle.internal.focus.FocusBase
+
+private[focus] trait OptionSomeParser {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  object OptionSome extends FocusParser {
+
+    def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]] = term match {
+      case Apply(TypeApply(Ident("some"), List(typeArg)), List(remainingCode)) => 
+        val toType = typeArg.tpe
+        val action = FocusAction.OptionSome(toType)
+        Some(Right(remainingCode, action))
+        
+      case _ => None
+    }
+  }
+}

--- a/core/shared/src/main/scala/monocle/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/Traversal.scala
@@ -8,6 +8,7 @@ import cats.instances.list._
 import cats.syntax.either._
 import monocle.function.{At, Each, FilterIndex, Index}
 import monocle.internal.Monoids
+import cats.catsInstancesForId
 
 /** A [[PTraversal]] can be seen as a [[POptional]] generalised to 0 to n targets
   * where n can be infinite.

--- a/core/shared/src/main/scala/monocle/law/OptionalLaws.scala
+++ b/core/shared/src/main/scala/monocle/law/OptionalLaws.scala
@@ -3,6 +3,7 @@ package monocle.law
 import monocle.Optional
 import monocle.internal.{IsEq, Monoids}
 import cats.Id
+import cats.catsInstancesForId
 import cats.data.Const
 import cats.kernel.Monoid
 

--- a/core/shared/src/main/scala/monocle/law/PrismLaws.scala
+++ b/core/shared/src/main/scala/monocle/law/PrismLaws.scala
@@ -1,6 +1,7 @@
 package monocle.law
 
 import cats.Id
+import cats.catsInstancesForId
 import cats.data.Const
 import cats.kernel.Monoid
 import monocle.Prism

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusFieldSelectTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusFieldSelectTest.scala
@@ -1,0 +1,86 @@
+package monocle.focus
+
+import monocle.Focus
+
+final class FocusFieldSelectTest extends munit.FunSuite {
+
+  case class Fub(bab: Int)
+  case class Bar(fub: Fub)
+  case class Foo(bar: Option[Bar])
+  case class Qux(foo: Either[String, Foo], moo: Map[Int, Fub])
+
+  case class Animal(name: String)
+  case class Owner(pet: Animal)
+  case class Shop(owner: Owner)
+  case class Box[A](a: A) 
+  case class MultiBox[A,B](a: A, b: B)
+  case class HigherBox[F[_], A](fa: F[A])
+  trait RefinedBox { type A; def a: A }
+  case class UnionBox[A,B](aOrB: A | B)
+  case class ConstraintBox[A <: AnyVal](a: A)
+  case class Varargs[A](a: A*)
+
+  test("Single field access") {
+    assertEquals(
+      Focus[Animal](_.name).get(Animal("Bob")),
+      "Bob"
+    )
+  }
+
+  test("Nested field access") {
+    assertEquals(
+      Focus[Shop](_.owner.pet.name).get(Shop(Owner(Animal("Fred")))),
+      "Fred"
+    )
+  }
+
+  test("Type parameter field access") {
+    assertEquals(
+      Focus[Box[String]](_.a).get(Box("Hello")),
+      "Hello"
+    )
+  }
+
+  test("Type parameter set field") {
+    assertEquals(
+      Focus[Box[Int]](_.a).replace(111)(Box(222)),
+      Box(111)
+    )
+  }
+
+  test("Nested type parameter set field") {
+    assertEquals(
+      Focus[Box[Box[String]]](_.a.a).replace("hello")(Box(Box("ok"))),
+      Box(Box("hello"))
+    )
+  }
+
+  test("Multiple type parameters get field") {
+    assertEquals(
+      Focus[MultiBox[Int, Boolean]](_.b).get(MultiBox(222, true)),
+      true
+    )
+  }
+
+  test("Multiple type parameters set field") {
+    assertEquals(
+      Focus[MultiBox[String, Int]](_.a).replace("abc")(MultiBox("whatevs",222)),
+      MultiBox("abc", 222)
+    )
+  }
+
+  test("Higher kinded type parameter get field") {
+    assertEquals(
+      Focus[HigherBox[Option, Int]](_.fa).get(HigherBox(Some(23))),
+      Some(23)
+    )
+  }
+
+  /*
+  test("Refined type field accessss") {
+    assertEquals(
+      Focus[RefinedBox { type A = String }](_.a).get(new RefinedBox { type A = String; def a = "Bob" }),
+      "Bob"
+    )
+  }*/
+}

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusSomeTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusSomeTest.scala
@@ -1,0 +1,55 @@
+package monocle.focus
+
+import monocle.Focus
+import monocle.Focus._
+
+final class FocusSomeTest extends munit.FunSuite {
+
+  test("Access Option within a case class") {
+    case class User(name: String, address: Option[Address])
+    case class Address(streetNumber: Int, postcode: String)
+
+    val elise = User("Elise", Some(Address(12, "high street")))
+    val bob   = User("bob"  , None)
+
+    val streetNumber = Focus[User](_.address.some.streetNumber)
+
+    assertEquals(streetNumber.getOption(elise), Some(12))
+    assertEquals(streetNumber.getOption(bob), None)
+  }
+
+  test("Access parametric Option within a case class") {
+    case class IdOpt[+A](id: Long, value: Option[A])
+    case class User(name: String, age: Int)
+
+    val bob = User("bob", 24)
+    val idSome = IdOpt(1, Some(bob))
+    val idNone = IdOpt(1, None)
+
+    val age = Focus[IdOpt[User]](_.value.some.age)
+
+    assertEquals(age.getOption(idSome), Some(24))
+    assertEquals(age.getOption(idNone), None)
+  }
+
+  test("Access top level Option") {
+    case class User(name: String, age: Int)
+    val bob = User("bob", 24)
+
+    val age = Focus[Option[User]](_.some.age)
+
+    assertEquals(age.getOption(Some(bob)), Some(24))
+    assertEquals(age.getOption(None), None)
+  }
+
+  test("Access nested Option") {
+    case class User(name: String, age: Int)
+    val bob = User("Friedrich", 33)
+
+    val name = Focus[Option[Option[User]]](_.some.some.name)
+
+    assertEquals(name.getOption(Some(Some(bob))), Some("Friedrich"))
+    assertEquals(name.getOption(Some(None)), None)
+    assertEquals(name.getOption(None), None)
+  }
+}


### PR DESCRIPTION
* bumped to latest scala 3.0.0 version (M3), I removed cross-compile to M2, refined wasn't available
* removed `-source:3.0-migration` scalac option from `code` because the `Focus` macro used new syntax. Can we make it specific to `Focus` macro?
* I tried to cross-compile test modules but I got some errors regarding mixed dependency (2.13/3.0.0)
* ported `Focus`  macro developed by @kenbot and @yilinwei in Monocly