### PR TITLE
Focus macro pre-applied to object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ project/metals.sbt
 /website/static/api/
 /website/variables.js
 /website/yarn.lock
+
+# VSCode
+.vscode/

--- a/core/shared/src/main/scala-3.x/monocle/Focus.scala
+++ b/core/shared/src/main/scala-3.x/monocle/Focus.scala
@@ -1,16 +1,20 @@
 package monocle
 
-import monocle.internal.focus.FocusImpl
+import monocle.internal.focus.{FocusImpl, AppliedFocusImpl}
 
 object Focus {
 
+  extension [From, To] (from: From) 
+    transparent inline def focus(inline lambda: (From => To)): Any = 
+      ${AppliedFocusImpl[From, To]('from, 'lambda)}
+
   extension [A] (opt: Option[A])
-    def some: A = scala.sys.error("Extension method 'some' should only be used within the moocle.Focus macro.")
+    def some: A = scala.sys.error("Extension method 'some' should only be used within the monocle.Focus macro.")
   
   def apply[S] = new MkFocus[S]
 
-  class MkFocus[S] {
-    transparent inline def apply[T](inline get: (S => T)): Any = 
-      ${ FocusImpl('get) }
+  class MkFocus[From] {
+    transparent inline def apply[To](inline lambda: (From => To)): Any = 
+      ${ FocusImpl('lambda) }
   }
 }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/AppliedFocusImpl.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/AppliedFocusImpl.scala
@@ -1,0 +1,20 @@
+package monocle.internal.focus
+
+import monocle.{Focus, Lens, Iso, Prism, Optional}
+import scala.quoted.{Type, Expr, Quotes, quotes}
+
+
+private[monocle] object AppliedFocusImpl {
+  def apply[From: Type, To: Type](from: Expr[From], lambda: Expr[From => To])(using Quotes): Expr[Any] = {
+    import quotes.reflect._
+
+    val generatedOptic = new FocusImpl(quotes).run(lambda)
+
+    generatedOptic.asTerm.tpe.asType match {
+      case '[Lens[f, t]] => '{ _root_.monocle.syntax.ApplyLens[From, From, To, To]($from, ${generatedOptic.asExprOf[Lens[From,To]]}) }
+      case '[Prism[f, t]] => '{ _root_.monocle.syntax.ApplyPrism[From, From, To, To]($from, ${generatedOptic.asExprOf[Prism[From,To]]}) }
+      case '[Iso[f, t]] => '{ _root_.monocle.syntax.ApplyIso[From, From, To, To]($from, ${generatedOptic.asExprOf[Iso[From,To]]}) }
+      case '[Optional[f, t]] => '{ _root_.monocle.syntax.ApplyOptional[From, From, To, To]($from, ${generatedOptic.asExprOf[Optional[From,To]]}) }
+    }
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusImpl.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusImpl.scala
@@ -25,7 +25,7 @@ private[focus] class FocusImpl(val macroContext: Quotes)
   }
 }
 
-object FocusImpl {
+private[monocle] object FocusImpl {
   def apply[From: Type, To: Type](lambda: Expr[From => To])(using Quotes): Expr[Any] =
     new FocusImpl(quotes).run(lambda)
 }

--- a/core/shared/src/test/scala-3.x/monocle/focus/AppliedFocusTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/AppliedFocusTest.scala
@@ -1,0 +1,33 @@
+package monocle.focus
+
+import monocle.Focus
+import monocle.Focus._
+
+final class AppliedFocusTest extends munit.FunSuite {
+
+  test("Applied focus returning an Optional") {
+    case class User(name: String, address: Option[Address])
+    case class Address(streetNumber: Int, postcode: String)
+
+    val elise = User("Elise", Some(Address(12, "high street")))
+
+    val streetNumber = elise.focus(_.address.some.streetNumber).getOption
+    val newElise = elise.focus(_.address.some.streetNumber).replace(50)
+
+    assertEquals(streetNumber, Some(12))
+    assertEquals(newElise, User("Elise", Some(Address(50, "high street"))))
+  }
+
+  test("Applied focus returning a Lens") {
+    case class User(name: String, address: Address)
+    case class Address(streetNumber: Int, postcode: String)
+
+    val bob = User("Bob", Address(5, "Bob St"))
+
+    val streetNumber = bob.focus(_.address.streetNumber).get
+    val newBob = bob.focus(_.address.streetNumber).replace(77)
+
+    assertEquals(streetNumber, 5)
+    assertEquals(newBob, User("Bob", Address(77, "Bob St")))
+  }
+}


### PR DESCRIPTION
Adds the fluent pre-applied syntax to the `Focus` macro, ie `address.focus(_.streetName)`, resolving #1027.

The solution uses the existing `monocle.syntax.ApplyXXX` classes.