### PR TITLE
[Focus] `as` feature

### DIFF
--- a/core/shared/src/main/scala-3.x/monocle/Focus.scala
+++ b/core/shared/src/main/scala-3.x/monocle/Focus.scala
@@ -8,6 +8,9 @@ object Focus {
     transparent inline def focus(inline lambda: (From => To)): Any = 
       ${AppliedFocusImpl[From, To]('from, 'lambda)}
 
+  extension [CastTo] (from: Any)
+    def as: CastTo = scala.sys.error("Extension method 'as[CastTo]' should only be used within the monocle.Focus macro.")
+
   extension [A] (opt: Option[A])
     def some: A = scala.sys.error("Extension method 'some' should only be used within the monocle.Focus macro.")
   

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/ErrorHandling.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/ErrorHandling.scala
@@ -11,5 +11,6 @@ private[focus] trait ErrorHandling {
     case FocusError.ComposeMismatch(type1, type2) => s"Could not compose $type1.andThen($type2)"
     case FocusError.UnexpectedCodeStructure(code) => s"Unexpected code structure: $code"
     case FocusError.CouldntFindFieldType(fromType, fieldName) => s"Couldn't find type for $fromType.$fieldName"
+    case FocusError.InvalidDowncast(fromType, toType) => s"Type '$fromType' could not be cast to '$toType'"
   }
 }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/ErrorHandling.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/ErrorHandling.scala
@@ -4,11 +4,11 @@ private[focus] trait ErrorHandling {
   this: FocusBase => 
   
   def errorMessage(error: FocusError): String = error match {
-    case FocusError.NotACaseClass(fromClass) => s"Expecting a case class in the 'From' position; found $fromClass"
+    case FocusError.NotACaseClass(fromClass, fieldName) => s"Cannot generate Lens for field '$fieldName', because '$fromClass' is not a case class"
     case FocusError.NotAConcreteClass(fromClass) => s"Expecting a concrete case class in the 'From' position; cannot reify type $fromClass"
     case FocusError.NotASimpleLambdaFunction => s"Expecting a lambda function that directly accesses a field. Example: `GenLens[Address](_.streetNumber)`"
     case FocusError.DidNotDirectlyAccessArgument(argName) => s"Expecting a lambda function that directly accesses the argument; other variable `$argName` found. Example: `GenLens[Address](_.streetNumber)`"
-    case FocusError.ComposeMismatch(type1, type2) => s"Could not compose $type1 >>> $type2"
+    case FocusError.ComposeMismatch(type1, type2) => s"Could not compose $type1.andThen($type2)"
     case FocusError.UnexpectedCodeStructure(code) => s"Unexpected code structure: $code"
     case FocusError.CouldntFindFieldType(fromType, fieldName) => s"Couldn't find type for $fromType.$fieldName"
   }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
@@ -13,15 +13,17 @@ private[focus] trait FocusBase {
   enum FocusAction {
     case FieldSelect(name: String, fromType: TypeRepr, fromTypeArgs: List[TypeRepr], toType: TypeRepr)
     case OptionSome(toType: TypeRepr)
+    case CastAs(fromType: TypeRepr, toType: TypeRepr)
 
     override def toString(): String = this match {
-      case FieldSelect(name, fromType, fromTypeArgs, toType) => s"FieldSelect($name, ${fromType.show}, ${fromTypeArgs.map(_.show).mkString("[", ",", "]")}, ${toType.show})"
+      case FieldSelect(name, fromType, fromTypeArgs, toType) => s"FieldSelect($name, ${fromType.show}, ${fromTypeArgs.map(_.show)}, ${toType.show})"
       case OptionSome(toType) => s"OptionSome(${toType.show})"
+      case CastAs(fromType, toType) => s"CastAs(${fromType.show}, ${toType.show})"
     }
   }
 
   enum FocusError {
-    case NotACaseClass(className: String)
+    case NotACaseClass(className: String, fieldName: String)
     case NotAConcreteClass(className: String)
     case DidNotDirectlyAccessArgument(argName: String)
     case NotASimpleLambdaFunction

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
@@ -30,6 +30,7 @@ private[focus] trait FocusBase {
     case UnexpectedCodeStructure(code: String)
     case CouldntFindFieldType(fromType: String, fieldName: String)
     case ComposeMismatch(type1: String, type2: String)
+    case InvalidDowncast(fromType: String, toType: String)
 
     def asResult: FocusResult[Nothing] = Left(this)
   }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/GeneratorLoop.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/GeneratorLoop.scala
@@ -2,6 +2,7 @@ package monocle.internal.focus
 
 import monocle.internal.focus.features.fieldselect.FieldSelectGenerator
 import monocle.internal.focus.features.optionsome.OptionSomeGenerator
+import monocle.internal.focus.features.castas.CastAsGenerator
 import monocle.{Lens, Iso, Prism, Optional}
 import scala.quoted.Type
 
@@ -10,6 +11,7 @@ private[focus] trait AllGenerators
   extends FocusBase
   with FieldSelectGenerator 
   with OptionSomeGenerator
+  with CastAsGenerator
 
 private[focus] trait GeneratorLoop {
   this: FocusBase with AllGenerators => 
@@ -28,6 +30,7 @@ private[focus] trait GeneratorLoop {
     action match {
       case FocusAction.FieldSelect(name, fromType, fromTypeArgs, toType) => generateFieldSelect(name, fromType, fromTypeArgs, toType)
       case FocusAction.OptionSome(toType) => generateOptionSome(toType)
+      case FocusAction.CastAs(fromType, toType) => generateCastAs(fromType, toType)
     }
 
   private def composeOptics(lens1: Term, lens2: Term): FocusResult[Term] = {

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/ParserLoop.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/ParserLoop.scala
@@ -3,11 +3,13 @@ package monocle.internal.focus
 import scala.quoted.Type
 import monocle.internal.focus.features.fieldselect.FieldSelectParser
 import monocle.internal.focus.features.optionsome.OptionSomeParser
+import monocle.internal.focus.features.castas.CastAsParser
 
 private[focus] trait AllParsers 
   extends FocusBase
   with FieldSelectParser 
   with OptionSomeParser
+  with CastAsParser
 
 private[focus] trait ParserLoop {
   this: FocusBase with AllParsers => 
@@ -43,10 +45,13 @@ private[focus] trait ParserLoop {
         case OptionSome(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
         case OptionSome(Left(error)) => Left(error)
 
+        case CastAs(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
+        case CastAs(Left(error)) => Left(error)
+
         case FieldSelect(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
         case FieldSelect(Left(error)) => Left(error)
 
-        case unexpected => FocusError.UnexpectedCodeStructure(unexpected.show).asResult
+        case unexpected => FocusError.UnexpectedCodeStructure(unexpected.toString).asResult
       }
     }
     loop(params.lambdaBody, Nil)

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/castas/CastAsGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/castas/CastAsGenerator.scala
@@ -1,0 +1,17 @@
+package monocle.internal.focus.features.castas
+
+import monocle.internal.focus.FocusBase
+
+private[focus] trait CastAsGenerator {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  def generateCastAs(fromType: TypeRepr, toType: TypeRepr): Term = {
+    (fromType.asType, toType.asType) match {
+      case ('[f], '[t]) => '{ 
+        _root_.monocle.Prism[f, t]((from: f) => if (from.isInstanceOf[t]) Some(from.asInstanceOf[t]) else None)
+                                   ((to: t) => to.asInstanceOf[f]) }.asTerm
+    }
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/castas/CastAsParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/castas/CastAsParser.scala
@@ -11,10 +11,14 @@ private[focus] trait CastAsParser {
 
     def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]] = term match {
       case Apply(TypeApply(Ident("as"), List(typeArg)), List(remainingCode)) => 
-        val toType = typeArg.tpe
         val fromType = remainingCode.tpe.widen
-        val action = FocusAction.CastAs(fromType, toType)
-        Some(Right(remainingCode, action))
+        val toType = typeArg.tpe
+
+        if (toType <:< fromType) {
+          val action = FocusAction.CastAs(fromType, toType)
+          Some(Right(remainingCode, action))
+        }
+        else Some(Left(FocusError.InvalidDowncast(fromType.show, toType.show)))
         
       case _ => None
     }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/castas/CastAsParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/castas/CastAsParser.scala
@@ -1,0 +1,22 @@
+package monocle.internal.focus.features.castas
+
+import monocle.internal.focus.FocusBase
+
+private[focus] trait CastAsParser {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  object CastAs extends FocusParser {
+
+    def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]] = term match {
+      case Apply(TypeApply(Ident("as"), List(typeArg)), List(remainingCode)) => 
+        val toType = typeArg.tpe
+        val fromType = remainingCode.tpe.widen
+        val action = FocusAction.CastAs(fromType, toType)
+        Some(Right(remainingCode, action))
+        
+      case _ => None
+    }
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/fieldselect/FieldSelectParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/fieldselect/FieldSelectParser.scala
@@ -15,8 +15,8 @@ private[focus] trait FieldSelectParser {
         val remainingCodeWithAction = action.map(a => (remainingCode, a))
         Some(remainingCodeWithAction)
 
-      case Select(remainingCode, _) => 
-        Some(FocusError.NotACaseClass(remainingCode.tpe.show).asResult)
+      case Select(remainingCode, fieldName) => 
+        Some(FocusError.NotACaseClass(remainingCode.tpe.show, fieldName).asResult)
         
       case _ => None
     }

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusCastAsTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusCastAsTest.scala
@@ -1,0 +1,54 @@
+package monocle.focus
+
+import monocle.Focus
+import monocle.Focus._
+
+import scala.annotation.nowarn
+
+
+final class FocusCastAsTest extends munit.FunSuite {
+
+  trait Food { def calories: Int }
+  case class Banana(calories: Int, squishy: Boolean) extends Food
+  case class Apple(calories: Int, color: String) extends Food
+  case class MysteryFood[A](mystery: A, calories: Int) extends Food
+  case class Meal(mainIngredient: Food)
+
+
+  test("Cast a broad thing to a narrow thing, directly on the argument") {
+    val asBanana = Focus[Food](_.as[Banana])
+
+    val foodA: Food = Apple(33, "red")
+    val foodB: Food = Banana(40, true)
+
+    assertEquals(asBanana.getOption(foodB), Some(Banana(40, true)))
+    assertEquals(asBanana.getOption(foodA), None)
+  }
+
+  test("Cast a broad thing to a narrow thing, nested") {
+    val mealAppleColor = Focus[Meal](_.mainIngredient.as[Apple].color)
+
+    val mealA = Meal(Apple(24, "green"))
+    val mealB = Meal(Banana(50, false))
+
+    assertEquals(mealAppleColor.getOption(mealA), Some("green"))
+    assertEquals(mealAppleColor.getOption(mealB), None)
+  }
+
+  test("Cast a narrow thing to a broad thing, which is useless but allowed") {
+    val asFood = Focus[Banana](_.as[Food])
+
+    val foodB = Banana(40, true)
+
+    assertEquals(asFood.getOption(foodB), Some(Banana(40, true)))
+  }
+
+  
+  test("Cast a broad thing to a narrow thing with type parameters") {
+    // Generates warning, but it is allowed
+    val getMystery = Focus[Food](_.as[MysteryFood[String]].mystery) 
+    val mysteryFood = MysteryFood[String]("abc", 44)
+
+    assertEquals(getMystery.getOption(mysteryFood), Some("abc"))
+  }
+}

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusCastAsTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusCastAsTest.scala
@@ -35,15 +35,6 @@ final class FocusCastAsTest extends munit.FunSuite {
     assertEquals(mealAppleColor.getOption(mealB), None)
   }
 
-  test("Cast a narrow thing to a broad thing, which is useless but allowed") {
-    val asFood = Focus[Banana](_.as[Food])
-
-    val foodB = Banana(40, true)
-
-    assertEquals(asFood.getOption(foodB), Some(Banana(40, true)))
-  }
-
-  
   test("Cast a broad thing to a narrow thing with type parameters") {
     // Generates warning, but it is allowed
     val getMystery = Focus[Food](_.as[MysteryFood[String]].mystery) 

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusFieldSelectTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusFieldSelectTest.scala
@@ -83,4 +83,13 @@ final class FocusFieldSelectTest extends munit.FunSuite {
       "Bob"
     )
   }*/
+
+  /*
+  test("Existential type field accessss") {
+    val existentialBox: Box[_] = Box("abc")
+    assertEquals(
+      Focus[Box[_]](_.a).get(existentialBox),
+      "abc"
+    )
+  }*/
 }


### PR DESCRIPTION
"As" feature in Focus, resolving #1028 .

Also some minor cleanup and error message improvements thrown in.  I tried to trip it up with an existential type (ie `Box[_]`), but it turned out that it was the FieldSelect feature that was really choking on this, so I've added a commented-out failing test for the FieldSelectTest.

I had to implement the `as` Prism by hand in the `CastAsGenerator` file; since it's useful enough to have privileged syntax inside Focus, it's worth thinking about whether to also add this as a standalone operator satisfying `Focus[Foo](_.bar.as[Baz]) == Focus[Foo](_.bar).as[Baz]`, then I can just reuse that one inside Focus.

If we can think of more error conditions and ways to trip it up, we can add these later.

