### PR TITLE
add Focus to all syntax import

### DIFF
--- a/core/shared/src/main/scala-2.x/monocle/syntax/FocusSyntax.scala
+++ b/core/shared/src/main/scala-2.x/monocle/syntax/FocusSyntax.scala
@@ -1,0 +1,3 @@
+package monocle.syntax
+
+trait FocusSyntax

--- a/core/shared/src/main/scala-3.x/monocle/Focus.scala
+++ b/core/shared/src/main/scala-3.x/monocle/Focus.scala
@@ -1,19 +1,14 @@
 package monocle
 
 import monocle.internal.focus.{FocusImpl, AppliedFocusImpl}
+import monocle.syntax.FocusSyntax
 
-object Focus {
+object Focus extends FocusSyntax {
 
   extension [From, To] (from: From) 
     transparent inline def focus(inline lambda: (From => To)): Any = 
       ${AppliedFocusImpl[From, To]('from, 'lambda)}
 
-  extension [CastTo] (from: Any)
-    def as: CastTo = scala.sys.error("Extension method 'as[CastTo]' should only be used within the monocle.Focus macro.")
-
-  extension [A] (opt: Option[A])
-    def some: A = scala.sys.error("Extension method 'some' should only be used within the monocle.Focus macro.")
-  
   def apply[S] = new MkFocus[S]
 
   class MkFocus[From] {

--- a/core/shared/src/main/scala-3.x/monocle/syntax/FocusSyntax.scala
+++ b/core/shared/src/main/scala-3.x/monocle/syntax/FocusSyntax.scala
@@ -1,0 +1,9 @@
+package monocle.syntax
+
+trait FocusSyntax {
+  extension [CastTo] (from: Any)
+    def as: CastTo = scala.sys.error("Extension method 'as[CastTo]' should only be used within the monocle.Focus macro.")
+
+  extension [A] (opt: Option[A])
+   def some: A = scala.sys.error("Extension method 'some' should only be used within the monocle.Focus macro.")
+}

--- a/core/shared/src/main/scala/monocle/syntax/All.scala
+++ b/core/shared/src/main/scala/monocle/syntax/All.scala
@@ -2,4 +2,4 @@ package monocle.syntax
 
 object all extends Syntaxes
 
-trait Syntaxes extends ApplySyntax with FieldsSyntax
+trait Syntaxes extends ApplySyntax with FocusSyntax with FieldsSyntax

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusImportTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusImportTest.scala
@@ -1,0 +1,20 @@
+package monocle.focus
+
+import monocle.Focus
+
+final class FocusImportTest extends munit.FunSuite {
+
+  case class User(name: String, address: Option[Address])
+  case class Address(streetNumber: Int, postcode: String)
+
+  test("import Focus object") {
+    import monocle.Focus._
+    Focus[User](_.address.some.streetNumber)
+  }
+
+  test("import all syntax") {
+    import monocle.syntax.all._
+    Focus[User](_.address.some.streetNumber)
+  }
+
+}


### PR DESCRIPTION
This PR adds all the `Focus` extensions `as`, `some`, etc to the import `monocle.syntax.all._`

I wonder if we should create a simpler import such as `monocle.all._` or `monocle.implicits._`