### PR TITLE
[Focus] Each feature

### DIFF
--- a/core/shared/src/main/scala-3.x/monocle/Focus.scala
+++ b/core/shared/src/main/scala-3.x/monocle/Focus.scala
@@ -1,5 +1,6 @@
 package monocle
 
+import monocle.function.Each
 import monocle.internal.focus.{FocusImpl, AppliedFocusImpl}
 import monocle.syntax.FocusSyntax
 

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
@@ -14,11 +14,13 @@ private[focus] trait FocusBase {
     case FieldSelect(name: String, fromType: TypeRepr, fromTypeArgs: List[TypeRepr], toType: TypeRepr)
     case OptionSome(toType: TypeRepr)
     case CastAs(fromType: TypeRepr, toType: TypeRepr)
+    case Each(fromType: TypeRepr, toType: TypeRepr, eachInstance: Term)
 
     override def toString(): String = this match {
       case FieldSelect(name, fromType, fromTypeArgs, toType) => s"FieldSelect($name, ${fromType.show}, ${fromTypeArgs.map(_.show)}, ${toType.show})"
       case OptionSome(toType) => s"OptionSome(${toType.show})"
       case CastAs(fromType, toType) => s"CastAs(${fromType.show}, ${toType.show})"
+      case Each(fromType, toType, eachInstance) => s"Each(${fromType.show}, ${toType.show}, ...)"
     }
   }
 
@@ -40,5 +42,4 @@ private[focus] trait FocusBase {
   }
 
   type FocusResult[+A] = Either[FocusError, A]
-  type ParseResult = FocusResult[List[FocusAction]]
 }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/GeneratorLoop.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/GeneratorLoop.scala
@@ -37,7 +37,7 @@ private[focus] trait GeneratorLoop {
     }
 
   private def composeOptics(lens1: Term, lens2: Term): FocusResult[Term] = {
-    lens2.tpe match {
+    lens2.tpe.widen match {
       // Won't yet work for polymorphism where A != B, nor for non-polymorphic optics Getter, Setter or Fold.
       case AppliedType(_, List(_, toType2)) => Right(Select.overloaded(lens1, "andThen", List(toType2, toType2), List(lens2)))
       case _ => FocusError.ComposeMismatch(lens1.tpe.show, lens2.tpe.show).asResult

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/castas/CastAsGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/castas/CastAsGenerator.scala
@@ -1,5 +1,6 @@
 package monocle.internal.focus.features.castas
 
+import monocle.Prism
 import monocle.internal.focus.FocusBase
 
 private[focus] trait CastAsGenerator {
@@ -10,8 +11,8 @@ private[focus] trait CastAsGenerator {
   def generateCastAs(fromType: TypeRepr, toType: TypeRepr): Term = {
     (fromType.asType, toType.asType) match {
       case ('[f], '[t]) => '{ 
-        _root_.monocle.Prism[f, t]((from: f) => if (from.isInstanceOf[t]) Some(from.asInstanceOf[t]) else None)
-                                   ((to: t) => to.asInstanceOf[f]) }.asTerm
+        Prism[f, t]((from: f) => if (from.isInstanceOf[t]) Some(from.asInstanceOf[t]) else None)
+                   ((to: t) => to.asInstanceOf[f]) }.asTerm
     }
   }
 }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/each/EachGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/each/EachGenerator.scala
@@ -1,0 +1,16 @@
+package monocle.internal.focus.features.each
+
+import monocle.function.Each
+import monocle.internal.focus.FocusBase
+
+private[focus] trait EachGenerator {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  def generateEach(fromType: TypeRepr, toType: TypeRepr, eachInstance: Term): Term = 
+    (fromType.asType, toType.asType) match {
+      case ('[f], '[t]) => '{(${eachInstance.asExprOf[Each[f, t]]}.each)}.asTerm
+    }
+    
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/each/EachParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/each/EachParser.scala
@@ -1,0 +1,22 @@
+package monocle.internal.focus.features.each
+
+import monocle.internal.focus.FocusBase
+
+private[focus] trait EachParser {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  object Each extends FocusParser {
+
+    def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]] = term match {
+      case Apply(Apply(TypeApply(Ident("each"), List(_, toTypeTree)), List(remainingCode)), List(eachInstance)) => 
+        val fromType = remainingCode.tpe.widen
+        val toType = toTypeTree.tpe
+        val action = FocusAction.Each(fromType, toType, eachInstance)
+        Some(Right(remainingCode, action))
+        
+      case _ => None
+    }
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/fieldselect/FieldSelectGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/fieldselect/FieldSelectGenerator.scala
@@ -19,7 +19,7 @@ private[focus] trait FieldSelectGenerator {
           val getter: f => t = (from: f) => 
             ${ generateGetter(field, '{from}.asTerm).asExprOf[t] }
 
-          _root_.monocle.Lens.apply[f, t](getter)(setter)
+           Lens.apply[f, t](getter)(setter)
         }.asTerm
     }
   }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/fieldselect/FieldSelectGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/fieldselect/FieldSelectGenerator.scala
@@ -19,7 +19,7 @@ private[focus] trait FieldSelectGenerator {
           val getter: f => t = (from: f) => 
             ${ generateGetter(field, '{from}.asTerm).asExprOf[t] }
 
-           Lens.apply[f, t](getter)(setter)
+          Lens.apply[f, t](getter)(setter)
         }.asTerm
     }
   }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/optionsome/OptionSomeGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/optionsome/OptionSomeGenerator.scala
@@ -1,6 +1,7 @@
 package monocle.internal.focus.features.optionsome
 
 import monocle.internal.focus.FocusBase
+import monocle.std.option.some
 
 private[focus] trait OptionSomeGenerator {
   this: FocusBase => 
@@ -9,7 +10,7 @@ private[focus] trait OptionSomeGenerator {
 
   def generateOptionSome(toType: TypeRepr): Term = {
     toType.asType match {
-      case '[t] => '{ _root_.monocle.std.option.some[t] }.asTerm
+      case '[t] => '{ some[t] }.asTerm
     }
   }
 }

--- a/core/shared/src/main/scala-3.x/monocle/syntax/FocusSyntax.scala
+++ b/core/shared/src/main/scala-3.x/monocle/syntax/FocusSyntax.scala
@@ -1,9 +1,14 @@
 package monocle.syntax
 
+import monocle.function.Each
+
 trait FocusSyntax {
   extension [CastTo] (from: Any)
     def as: CastTo = scala.sys.error("Extension method 'as[CastTo]' should only be used within the monocle.Focus macro.")
 
   extension [A] (opt: Option[A])
-   def some: A = scala.sys.error("Extension method 'some' should only be used within the monocle.Focus macro.")
+    def some: A = scala.sys.error("Extension method 'some' should only be used within the monocle.Focus macro.")
+
+  extension [From, To] (from: From)(using Each[From, To])
+    def each: To = scala.sys.error("Extension method 'each' should only be used within the monocle.Focus macro.")
 }

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusEachTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusEachTest.scala
@@ -1,0 +1,48 @@
+package monocle.focus
+
+import monocle.Focus
+import monocle.Focus._
+import monocle.function.Each._
+import monocle.std.list._
+
+final class FocusEachTest extends munit.FunSuite {
+
+  test("Direct each on the argument") {
+    val eachNumber = Focus[List[Int]](_.each)
+    val list = List(1,2,3)
+    assertEquals(eachNumber.getAll(list), List(1,2,3))
+    assertEquals(eachNumber.modify(_ + 1)(list), List(2,3,4))
+  }
+
+  test("Each on a field") {
+    case class School(name: String, students: List[Student])
+    case class Student(firstName: String, lastName: String, yearLevel: Int)
+
+    
+    val school = School("Sparkvale Primary School", List(
+      Student("Arlen", "Appleby", 5),
+      Student("Bob", "Bobson", 6),
+      Student("Carol", "Cornell", 7)
+    ))
+
+    val studentNames = Focus[School](_.students.each.firstName)
+    val studentYears = Focus[School](_.students.each.yearLevel)
+
+    assertEquals(studentNames.getAll(school), List("Arlen", "Bob", "Carol"))
+  }
+  
+  test("Focus operator each commutes with standalone operator each") {
+    case class School(name: String, students: List[Student])
+    case class Student(firstName: String, lastName: String, yearLevel: Int)
+    
+    val school = School("Sparkvale Primary School", List(
+      Student("Arlen", "Appleby", 5),
+      Student("Bob", "Bobson", 6),
+      Student("Carol", "Cornell", 7)
+    ))
+
+    assertEquals(
+      Focus[School](_.students.each).getAll(school), 
+      Focus[School](_.students).each.getAll(school))
+  }
+}


### PR DESCRIPTION
Adds `each` to the Focus macro, resolving #1029.

Some more bits and pieces:
- Fixed the ridiculous `composeOptics` method to be two lines, owing to a horrendous Dotty compiler space leak the old version was causing now that Traversals are in the mix.
- Removed the `ParseResult` type alias. Give it to me straight
- Removed the fully qualified `_root_.monocle.this.that....`, which is a habit I had picked up writing macros in stringier environments. They are real typechecked Scala symbols, there's no chance of ambiguity or accidental capture of some other symbol by the same name.