### PR TITLE
'At', 'index' features + refactor of parsers for readability and type safety

### DIFF
--- a/core/shared/src/main/scala-3.x/monocle/Focus.scala
+++ b/core/shared/src/main/scala-3.x/monocle/Focus.scala
@@ -1,9 +1,8 @@
 package monocle
 
 import monocle.syntax.AppliedFocusSyntax
-import monocle.function.Each
 import monocle.internal.focus.FocusImpl
-import monocle.function.Each
+import monocle.function.{Each, At, Index}
 
 object Focus extends AppliedFocusSyntax {
 
@@ -16,6 +15,12 @@ object Focus extends AppliedFocusSyntax {
 
     extension [From, To] (from: From)(using Each[From, To])
       def each: To = scala.sys.error("Extension method 'each' should only be used within the monocle.Focus macro.")
+
+    extension [From, I, To] (from: From)
+      def at(i: I)(using At[From, i.type, To]): To = scala.sys.error("Extension method 'at(i)' should only be used within the monocle.Focus macro.")
+
+    extension [From, I, To] (from: From)
+      def index(i: I)(using Index[From, I, To]): To = scala.sys.error("Extension method 'index(i)' should only be used within the monocle.Focus macro.")
   }
 
   def apply[S] = new MkFocus[S]

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
@@ -17,12 +17,16 @@ private[focus] trait FocusBase {
     case OptionSome(toType: TypeRepr)
     case CastAs(fromType: TypeRepr, toType: TypeRepr)
     case Each(fromType: TypeRepr, toType: TypeRepr, eachInstance: Term)
+    case At(fromType: TypeRepr, toType: TypeRepr, index: Term, atInstance: Term)
+    case Index(fromType: TypeRepr, toType: TypeRepr, index: Term, indexInstance: Term)
 
     override def toString(): String = this match {
       case FieldSelect(name, fromType, fromTypeArgs, toType) => s"FieldSelect($name, ${fromType.show}, ${fromTypeArgs.map(_.show)}, ${toType.show})"
       case OptionSome(toType) => s"OptionSome(${toType.show})"
       case CastAs(fromType, toType) => s"CastAs(${fromType.show}, ${toType.show})"
-      case Each(fromType, toType, eachInstance) => s"Each(${fromType.show}, ${toType.show}, ...)"
+      case Each(fromType, toType, _) => s"Each(${fromType.show}, ${toType.show}, ...)"
+      case At(fromType, toType, _, _) => s"At(${fromType.show}, ${toType.show}, ..., ...)"
+      case Index(fromType, toType, _, _) => s"Index(${fromType.show}, ${toType.show}, ..., ...)"
     }
   }
 
@@ -39,21 +43,6 @@ private[focus] trait FocusBase {
 
     def asResult: FocusResult[Nothing] = Left(this)
   }
-
-  trait FocusParser {
-    def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]]
-
-    object FocusKeyword {
-      import macroContext.reflect._
-
-      def unapply(term: Term): Option[String] = term match {
-        case Select(_, keyword) => Some(keyword)
-        case _ => None
-      }
-    }
-  }
-
-
 
   type FocusResult[+A] = Either[FocusError, A]
 }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusImpl.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusImpl.scala
@@ -2,6 +2,7 @@ package monocle.internal.focus
 
 import monocle.{Lens, Focus}
 import scala.quoted.{Type, Expr, Quotes, quotes}
+import monocle.internal.focus.features.{ParserLoop, AllFeatureParsers, GeneratorLoop, AllFeatureGenerators}
 
 private[focus] class FocusImpl(val macroContext: Quotes)
     extends FocusBase

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/GeneratorLoop.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/GeneratorLoop.scala
@@ -1,9 +1,12 @@
-package monocle.internal.focus
+package monocle.internal.focus.features
 
+import monocle.internal.focus.FocusBase
 import monocle.internal.focus.features.fieldselect.FieldSelectGenerator
 import monocle.internal.focus.features.optionsome.OptionSomeGenerator
 import monocle.internal.focus.features.castas.CastAsGenerator
 import monocle.internal.focus.features.each.EachGenerator
+import monocle.internal.focus.features.at.AtGenerator
+import monocle.internal.focus.features.index.IndexGenerator
 import monocle.{Lens, Iso, Prism, Optional, Traversal}
 import scala.quoted.Type
 
@@ -14,9 +17,11 @@ private[focus] trait AllFeatureGenerators
   with OptionSomeGenerator
   with CastAsGenerator
   with EachGenerator
+  with AtGenerator
+  with IndexGenerator
 
 private[focus] trait GeneratorLoop {
-  this: FocusBase with AllFeatureGenerators => 
+  this: AllFeatureGenerators => 
 
   import macroContext.reflect._
 
@@ -34,6 +39,8 @@ private[focus] trait GeneratorLoop {
       case FocusAction.OptionSome(toType) => generateOptionSome(toType)
       case FocusAction.CastAs(fromType, toType) => generateCastAs(fromType, toType)
       case FocusAction.Each(fromType, toType, eachInstance) => generateEach(fromType, toType, eachInstance)
+      case FocusAction.At(fromType, toType, index, atInstance) => generateAt(fromType, toType, index, atInstance)
+      case FocusAction.Index(fromType, toType, index, indexInstance) => generateIndex(fromType, toType, index, indexInstance)
     }
 
   private def composeOptics(lens1: Term, lens2: Term): FocusResult[Term] = {

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/ParserBase.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/ParserBase.scala
@@ -1,0 +1,42 @@
+package monocle.internal.focus.features
+
+import scala.quoted.Quotes
+import monocle.internal.focus.FocusBase
+
+private[focus] trait ParserBase {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  trait FocusParser {
+    def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]]
+  }
+
+  case class Name(name: String)
+  case class GivenInstance(instance: Term)
+  case class RemainingCode(code: Term)
+  case class FromType(fromType: TypeRepr)
+  case class TypeArgs(args: TypeRepr*)
+  case class ValueArgs(args: Term*)
+
+  object FocusKeyword {
+    def unapply(term: Term): Option[(Name, FromType, TypeArgs, RemainingCode)] = term match {
+      case Apply(TypeApply(Select(_, keyword), typeArgs), List(code)) => 
+        Some(Name(keyword), FromType(code.tpe.widen), TypeArgs(typeArgs.map(_.tpe): _*), RemainingCode(code))
+
+      case _ => None
+    }
+  }
+
+  object FocusKeywordGiven {
+    def unapply(term: Term): Option[(Name, FromType, TypeArgs, ValueArgs, GivenInstance, RemainingCode)] = term match {
+      case Apply(Apply(FocusKeyword(keyword, fromType, typeArgs, code), argList), List(instance)) => 
+        Some(keyword, fromType, typeArgs, ValueArgs(argList: _*), GivenInstance(instance), code)
+
+      case Apply(FocusKeyword(keyword, fromType, typeArgs, code), List(instance)) => 
+        Some(keyword, fromType, typeArgs, ValueArgs(), GivenInstance(instance), code)
+
+      case _ => None
+    }
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/at/AtGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/at/AtGenerator.scala
@@ -1,0 +1,16 @@
+package monocle.internal.focus.features.at
+
+import monocle.function.At
+import monocle.internal.focus.FocusBase
+
+private[focus] trait AtGenerator {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  def generateAt(fromType: TypeRepr, toType: TypeRepr, index: Term, atInstance: Term): Term = 
+    (fromType.asType, index.tpe.asType, toType.asType) match {
+      case ('[f], '[i], '[t]) => '{(${atInstance.asExprOf[At[f, i, t]]}.at(${index.asExprOf[i]}))}.asTerm
+    }
+    
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/at/AtParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/at/AtParser.scala
@@ -1,0 +1,20 @@
+package monocle.internal.focus.features.at
+
+import monocle.internal.focus.FocusBase
+import monocle.internal.focus.features.ParserBase
+
+private[focus] trait AtParser {
+  this: FocusBase with ParserBase => 
+
+  object At extends FocusParser {
+
+    def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
+
+      case FocusKeywordGiven(Name("at"), FromType(fromType), TypeArgs(_, _, toType), ValueArgs(index), GivenInstance(atInstance), remainingCode) => 
+        val action = FocusAction.At(fromType, toType, index, atInstance)
+        Some(Right(remainingCode, action))
+
+      case _ => None
+    }
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/castas/CastAsParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/castas/CastAsParser.scala
@@ -1,21 +1,16 @@
 package monocle.internal.focus.features.castas
 
 import monocle.internal.focus.FocusBase
+import monocle.internal.focus.features.ParserBase
 
 private[focus] trait CastAsParser {
-  this: FocusBase =>
-
-  import macroContext.reflect._
+  this: FocusBase with ParserBase =>
 
   object CastAs extends FocusParser {
 
-    def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]] = term match {
-      case Apply(TypeApply(FocusKeyword("as"), List(typeArg)), List(remainingCode)) =>
-
-        val fromType = remainingCode.tpe.widen
-        val toType = typeArg.tpe
-
-
+    def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
+      
+      case FocusKeyword(Name("as"), FromType(fromType), TypeArgs(toType), remainingCode) => 
         if (toType <:< fromType) {
           val action = FocusAction.CastAs(fromType, toType)
           Some(Right(remainingCode, action))

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/each/EachParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/each/EachParser.scala
@@ -1,18 +1,16 @@
 package monocle.internal.focus.features.each
 
 import monocle.internal.focus.FocusBase
+import monocle.internal.focus.features.ParserBase
 
 private[focus] trait EachParser {
-  this: FocusBase => 
-
-  import macroContext.reflect._
+  this: FocusBase with ParserBase => 
 
   object Each extends FocusParser {
 
-    def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]] = term match {
-      case Apply(Apply(TypeApply(FocusKeyword("each"), List(_, toTypeTree)), List(remainingCode)), List(eachInstance)) => 
-        val fromType = remainingCode.tpe.widen
-        val toType = toTypeTree.tpe
+    def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
+      
+      case FocusKeywordGiven(Name("each"), FromType(fromType), TypeArgs(_, toType), ValueArgs(), GivenInstance(eachInstance), remainingCode) => 
         val action = FocusAction.Each(fromType, toType, eachInstance)
         Some(Right(remainingCode, action))
         

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/fieldselect/FieldSelectParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/fieldselect/FieldSelectParser.scala
@@ -1,18 +1,20 @@
 package monocle.internal.focus.features.fieldselect
 
 import monocle.internal.focus.FocusBase
+import monocle.internal.focus.features.ParserBase
 
 private[focus] trait FieldSelectParser {
-  this: FocusBase => 
+  this: FocusBase with ParserBase => 
 
   import this.macroContext.reflect._
   
   object FieldSelect extends FocusParser {
 
-    def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]] = term match {
+    def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
+      
       case Select(CaseClass(remainingCode), fieldName) => 
         val action = getFieldAction(getFromType(remainingCode), fieldName)
-        val remainingCodeWithAction = action.map(a => (remainingCode, a))
+        val remainingCodeWithAction = action.map(a => (RemainingCode(remainingCode), a))
         Some(remainingCodeWithAction)
 
       case Select(remainingCode, fieldName) => 

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/index/IndexGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/index/IndexGenerator.scala
@@ -1,0 +1,16 @@
+package monocle.internal.focus.features.index
+
+import monocle.function.Index
+import monocle.internal.focus.FocusBase
+
+private[focus] trait IndexGenerator {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  def generateIndex(fromType: TypeRepr, toType: TypeRepr, index: Term, indexInstance: Term): Term = 
+    (fromType.asType, index.tpe.widen.asType, toType.asType) match {
+      case ('[f], '[i], '[t]) => '{(${indexInstance.asExprOf[Index[f, i, t]]}.index(${index.asExprOf[i]}))}.asTerm
+    }
+    
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/index/IndexParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/index/IndexParser.scala
@@ -1,0 +1,20 @@
+package monocle.internal.focus.features.index
+
+import monocle.internal.focus.FocusBase
+import monocle.internal.focus.features.ParserBase
+
+private[focus] trait IndexParser {
+  this: FocusBase with ParserBase => 
+
+  object Index extends FocusParser {
+
+    def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
+      
+      case FocusKeywordGiven(Name("index"), FromType(fromType), TypeArgs(_, _, toType), ValueArgs(index), GivenInstance(indexInstance), remainingCode) => 
+         val action = FocusAction.Index(fromType, toType, index, indexInstance)
+         Some(Right(remainingCode, action))
+        
+      case _ => None
+    }
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/optionsome/OptionSomeParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/optionsome/OptionSomeParser.scala
@@ -1,19 +1,19 @@
 package monocle.internal.focus.features.optionsome
 
 import monocle.internal.focus.FocusBase
+import monocle.internal.focus.features.ParserBase
 
 private[focus] trait OptionSomeParser {
-  this: FocusBase =>
-
-  import macroContext.reflect._
+  this: FocusBase with ParserBase =>
 
   object OptionSome extends FocusParser {
 
-    def unapply(term: Term): Option[FocusResult[(Term, FocusAction)]] = term match {
-      case Apply(TypeApply(FocusKeyword("some"), List(typeArg)), List(remainingCode)) =>
-        val toType = typeArg.tpe
+    def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
+
+      case FocusKeyword(Name("some"), _, TypeArgs(toType), remainingCode) => 
         val action = FocusAction.OptionSome(toType)
         Some(Right(remainingCode, action))
+
       case _ => None
     }
   }

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusAtTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusAtTest.scala
@@ -1,0 +1,41 @@
+package monocle.focus
+
+import monocle.Focus
+import monocle.function.At._
+
+final class FocusAtTest extends munit.FunSuite {
+
+  test("Get direct `at` on the argument") {
+    val atA = Focus[Map[String,Int]](_.at("a"))
+    val map = Map("a" -> 1, "b" -> 2, "c" -> 3)
+
+    assertEquals(atA.get(map), Some(1))
+    assertEquals(atA.get(Map()), None)
+  }
+
+  test("Set direct `at` on the argument") {
+    val atB = Focus[Map[String,Int]](_.at("b"))
+    val map = Map("a" -> 1, "b" -> 2, "c" -> 3)
+
+    assertEquals(atB.replace(Some(55))(map), map.updated("b", 55))
+    assertEquals(atB.replace(None)(map), map - "b")
+  }
+
+  test("Get/set on tuples") {
+    val at3 = Focus[(Int,Int,Int)](_.at(3))
+
+    val tup = (2, 3, 4)
+
+    assertEquals(at3.get(tup), 4)
+    assertEquals(at3.replace(55)(tup), (2, 3, 55))
+  }
+
+  test("Focus operator `at` commutes with standalone operator `at`") {
+    type PeopleMap = Map[String,Int]
+    val map: PeopleMap = Map("Bob" -> 44, "Sue" -> 21, "Etienne" -> 33)
+
+    assertEquals(
+      Focus[PeopleMap](_.at("Bob")).get(map), 
+      Focus[PeopleMap](a => a).at("Bob").get(map))
+  }
+}

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusEachTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusEachTest.scala
@@ -31,7 +31,7 @@ final class FocusEachTest extends munit.FunSuite {
     assertEquals(studentNames.getAll(school), List("Arlen", "Bob", "Carol"))
   }
   
-  test("Focus operator each commutes with standalone operator each") {
+  test("Focus operator `each` commutes with standalone operator `each`") {
     case class School(name: String, students: List[Student])
     case class Student(firstName: String, lastName: String, yearLevel: Int)
     

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusImportTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusImportTest.scala
@@ -7,14 +7,16 @@ final class FocusImportTest extends munit.FunSuite {
   case class User(name: String, address: Option[Address])
   case class Address(streetNumber: Int, postcode: String)
 
+  val user = User("Edith", Some(Address(45, "2120")))
+
   test("import Focus object") {
     import monocle.Focus._
-    Focus[User](_.address.some.streetNumber)
+    user.focus(_.address.some.streetNumber)
   }
 
   test("import all syntax") {
     import monocle.syntax.all._
-    Focus[User](_.address.some.streetNumber)
+    user.focus(_.address.some.streetNumber)
   }
 
 }

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusIndexTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusIndexTest.scala
@@ -1,0 +1,31 @@
+package monocle.focus
+
+import monocle.Focus
+import monocle.function.Index._
+
+final class FocusIndexTest extends munit.FunSuite {
+
+  test("Get direct `index` on the argument") {
+    val index0 = Focus[List[Int]](_.index(0))
+    val list = List(1, 10, 100, 1000)
+
+    assertEquals(index0.getOption(list), Some(1))
+    assertEquals(index0.getOption(Nil), None)
+  }
+
+  test("Set direct `index` on the argument") {
+    val index3 = Focus[List[Int]](_.index(3))
+    val list = List(5, 4, -44, 2)
+
+    assertEquals(index3.replace(777)(list), List(5, 4, -44, 777))
+    assertEquals(index3.replace(777)(List(88)), List(88))
+  }
+
+  test("Focus operator `index` commutes with standalone operator `index`") {
+    val list = List("Melbourne", "Sydney", "Brisbane")
+
+    assertEquals(
+      Focus[List[String]](_.index(1)).getOption(list), 
+      Focus[List[String]](a => a).index(1).getOption(list))
+  }
+}

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusSomeTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusSomeTest.scala
@@ -52,4 +52,13 @@ final class FocusSomeTest extends munit.FunSuite {
     assertEquals(name.getOption(Some(None)), None)
     assertEquals(name.getOption(None), None)
   }
+
+  test("Focus operator `some` commutes with standalone operator `some`") {
+    
+    val opt: Option[Int] = Some(33)
+
+    assertEquals(
+      Focus[Option[Int]](_.some).getOption(opt),
+      Focus[Option[Int]](a => a).some.getOption(opt))
+  }
 }


### PR DESCRIPTION
Adds `at` and `index` features, resolving #1030.

Of note:
- `at` feature preserves singleton index types, so as to support tuple access in the same way as `monocle.function.At`.
- Big refactor of the parser matchers for readability and type safety, based on pulling out the obvious commonality between the matchers
- All of the features with keywords (ie not field select) now use the new pretty extractors with descriptive case classes wrapping outputs, and no longer need access to the `macroContext.reflect` object.
- As usual, the tests are fairly light, and will need to be made more comprehensive later
- New module `ParserBase` that contains the `FocusParser` interface, the new `FocusKeyword` and `FocusKeywordGiven` matches and all the typesafe case class wrappers.
- `ParserBase`, `ParserLoop` and `GeneratorLoop` now live in `monocle.internal.focus.features`, closer to the features they support and aggregate.