### PR TITLE
More consistent naming for Focus features

### DIFF
--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
@@ -14,19 +14,19 @@ private[focus] trait FocusBase {
 
   enum FocusAction {
     case FieldSelect(name: String, fromType: TypeRepr, fromTypeArgs: List[TypeRepr], toType: TypeRepr)
-    case OptionSome(toType: TypeRepr)
-    case CastAs(fromType: TypeRepr, toType: TypeRepr)
-    case Each(fromType: TypeRepr, toType: TypeRepr, eachInstance: Term)
-    case At(fromType: TypeRepr, toType: TypeRepr, index: Term, atInstance: Term)
-    case Index(fromType: TypeRepr, toType: TypeRepr, index: Term, indexInstance: Term)
+    case KeywordSome(toType: TypeRepr)
+    case KeywordAs(fromType: TypeRepr, toType: TypeRepr)
+    case KeywordEach(fromType: TypeRepr, toType: TypeRepr, eachInstance: Term)
+    case KeywordAt(fromType: TypeRepr, toType: TypeRepr, index: Term, atInstance: Term)
+    case KeywordIndex(fromType: TypeRepr, toType: TypeRepr, index: Term, indexInstance: Term)
 
     override def toString(): String = this match {
       case FieldSelect(name, fromType, fromTypeArgs, toType) => s"FieldSelect($name, ${fromType.show}, ${fromTypeArgs.map(_.show)}, ${toType.show})"
-      case OptionSome(toType) => s"OptionSome(${toType.show})"
-      case CastAs(fromType, toType) => s"CastAs(${fromType.show}, ${toType.show})"
-      case Each(fromType, toType, _) => s"Each(${fromType.show}, ${toType.show}, ...)"
-      case At(fromType, toType, _, _) => s"At(${fromType.show}, ${toType.show}, ..., ...)"
-      case Index(fromType, toType, _, _) => s"Index(${fromType.show}, ${toType.show}, ..., ...)"
+      case KeywordSome(toType) => s"KeywordSome(${toType.show})"
+      case KeywordAs(fromType, toType) => s"KeywordAs(${fromType.show}, ${toType.show})"
+      case KeywordEach(fromType, toType, _) => s"KeywordEach(${fromType.show}, ${toType.show}, ...)"
+      case KeywordAt(fromType, toType, _, _) => s"KeywordAt(${fromType.show}, ${toType.show}, ..., ...)"
+      case KeywordIndex(fromType, toType, _, _) => s"KeywordIndex(${fromType.show}, ${toType.show}, ..., ...)"
     }
   }
 

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/GeneratorLoop.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/GeneratorLoop.scala
@@ -2,8 +2,8 @@ package monocle.internal.focus.features
 
 import monocle.internal.focus.FocusBase
 import monocle.internal.focus.features.fieldselect.FieldSelectGenerator
-import monocle.internal.focus.features.optionsome.OptionSomeGenerator
-import monocle.internal.focus.features.castas.CastAsGenerator
+import monocle.internal.focus.features.some.SomeGenerator
+import monocle.internal.focus.features.as.AsGenerator
 import monocle.internal.focus.features.each.EachGenerator
 import monocle.internal.focus.features.at.AtGenerator
 import monocle.internal.focus.features.index.IndexGenerator
@@ -14,8 +14,8 @@ import scala.quoted.Type
 private[focus] trait AllFeatureGenerators
   extends FocusBase
   with FieldSelectGenerator 
-  with OptionSomeGenerator
-  with CastAsGenerator
+  with SomeGenerator
+  with AsGenerator
   with EachGenerator
   with AtGenerator
   with IndexGenerator
@@ -36,11 +36,11 @@ private[focus] trait GeneratorLoop {
   private def generateActionCode(action: FocusAction): Term = 
     action match {
       case FocusAction.FieldSelect(name, fromType, fromTypeArgs, toType) => generateFieldSelect(name, fromType, fromTypeArgs, toType)
-      case FocusAction.OptionSome(toType) => generateOptionSome(toType)
-      case FocusAction.CastAs(fromType, toType) => generateCastAs(fromType, toType)
-      case FocusAction.Each(fromType, toType, eachInstance) => generateEach(fromType, toType, eachInstance)
-      case FocusAction.At(fromType, toType, index, atInstance) => generateAt(fromType, toType, index, atInstance)
-      case FocusAction.Index(fromType, toType, index, indexInstance) => generateIndex(fromType, toType, index, indexInstance)
+      case FocusAction.KeywordSome(toType) => generateSome(toType)
+      case FocusAction.KeywordAs(fromType, toType) => generateAs(fromType, toType)
+      case FocusAction.KeywordEach(fromType, toType, eachInstance) => generateEach(fromType, toType, eachInstance)
+      case FocusAction.KeywordAt(fromType, toType, index, atInstance) => generateAt(fromType, toType, index, atInstance)
+      case FocusAction.KeywordIndex(fromType, toType, index, indexInstance) => generateIndex(fromType, toType, index, indexInstance)
     }
 
   private def composeOptics(lens1: Term, lens2: Term): FocusResult[Term] = {

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/ParserLoop.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/ParserLoop.scala
@@ -3,8 +3,8 @@ package monocle.internal.focus.features
 import scala.quoted.Type
 import monocle.internal.focus.FocusBase
 import monocle.internal.focus.features.fieldselect.FieldSelectParser
-import monocle.internal.focus.features.optionsome.OptionSomeParser
-import monocle.internal.focus.features.castas.CastAsParser
+import monocle.internal.focus.features.some.SomeParser
+import monocle.internal.focus.features.as.AsParser
 import monocle.internal.focus.features.each.EachParser
 import monocle.internal.focus.features.at.AtParser
 import monocle.internal.focus.features.index.IndexParser
@@ -13,8 +13,8 @@ private[focus] trait AllFeatureParsers
   extends FocusBase 
   with ParserBase
   with FieldSelectParser 
-  with OptionSomeParser
-  with CastAsParser
+  with SomeParser
+  with AsParser
   with EachParser
   with AtParser
   with IndexParser
@@ -31,20 +31,20 @@ private[focus] trait ParserLoop {
         case LambdaArgument(idName) if idName == config.argName => Right(listSoFar)
         case LambdaArgument(idName) => FocusError.DidNotDirectlyAccessArgument(idName).asResult
 
-        case OptionSome(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
-        case OptionSome(Left(error)) => Left(error)
+        case KeywordSome(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
+        case KeywordSome(Left(error)) => Left(error)
 
-        case Each(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
-        case Each(Left(error)) => Left(error)
+        case KeywordEach(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
+        case KeywordEach(Left(error)) => Left(error)
 
-        case At(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
-        case At(Left(error)) => Left(error)
+        case KeywordAt(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
+        case KeywordAt(Left(error)) => Left(error)
 
-        case Index(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
-        case Index(Left(error)) => Left(error)
+        case KeywordIndex(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
+        case KeywordIndex(Left(error)) => Left(error)
 
-        case CastAs(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
-        case CastAs(Left(error)) => Left(error)
+        case KeywordAs(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
+        case KeywordAs(Left(error)) => Left(error)
 
         case FieldSelect(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
         case FieldSelect(Left(error)) => Left(error)

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/as/AsGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/as/AsGenerator.scala
@@ -1,14 +1,14 @@
-package monocle.internal.focus.features.castas
+package monocle.internal.focus.features.as
 
 import monocle.Prism
 import monocle.internal.focus.FocusBase
 
-private[focus] trait CastAsGenerator {
+private[focus] trait AsGenerator {
   this: FocusBase => 
 
   import macroContext.reflect._
 
-  def generateCastAs(fromType: TypeRepr, toType: TypeRepr): Term = {
+  def generateAs(fromType: TypeRepr, toType: TypeRepr): Term = {
     (fromType.asType, toType.asType) match {
       case ('[f], '[t]) => '{ 
         Prism[f, t]((from: f) => if (from.isInstanceOf[t]) Some(from.asInstanceOf[t]) else None)

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/as/AsParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/as/AsParser.scala
@@ -1,18 +1,18 @@
-package monocle.internal.focus.features.castas
+package monocle.internal.focus.features.as
 
 import monocle.internal.focus.FocusBase
 import monocle.internal.focus.features.ParserBase
 
-private[focus] trait CastAsParser {
+private[focus] trait AsParser {
   this: FocusBase with ParserBase =>
 
-  object CastAs extends FocusParser {
+  object KeywordAs extends FocusParser {
 
     def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
       
       case FocusKeyword(Name("as"), FromType(fromType), TypeArgs(toType), remainingCode) => 
         if (toType <:< fromType) {
-          val action = FocusAction.CastAs(fromType, toType)
+          val action = FocusAction.KeywordAs(fromType, toType)
           Some(Right(remainingCode, action))
         }
         else Some(Left(FocusError.InvalidDowncast(fromType.show, toType.show)))

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/at/AtParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/at/AtParser.scala
@@ -6,12 +6,12 @@ import monocle.internal.focus.features.ParserBase
 private[focus] trait AtParser {
   this: FocusBase with ParserBase => 
 
-  object At extends FocusParser {
+  object KeywordAt extends FocusParser {
 
     def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
 
       case FocusKeywordGiven(Name("at"), FromType(fromType), TypeArgs(_, _, toType), ValueArgs(index), GivenInstance(atInstance), remainingCode) => 
-        val action = FocusAction.At(fromType, toType, index, atInstance)
+        val action = FocusAction.KeywordAt(fromType, toType, index, atInstance)
         Some(Right(remainingCode, action))
 
       case _ => None

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/each/EachParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/each/EachParser.scala
@@ -6,12 +6,12 @@ import monocle.internal.focus.features.ParserBase
 private[focus] trait EachParser {
   this: FocusBase with ParserBase => 
 
-  object Each extends FocusParser {
+  object KeywordEach extends FocusParser {
 
     def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
       
       case FocusKeywordGiven(Name("each"), FromType(fromType), TypeArgs(_, toType), ValueArgs(), GivenInstance(eachInstance), remainingCode) => 
-        val action = FocusAction.Each(fromType, toType, eachInstance)
+        val action = FocusAction.KeywordEach(fromType, toType, eachInstance)
         Some(Right(remainingCode, action))
         
       case _ => None

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/index/IndexParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/index/IndexParser.scala
@@ -6,12 +6,12 @@ import monocle.internal.focus.features.ParserBase
 private[focus] trait IndexParser {
   this: FocusBase with ParserBase => 
 
-  object Index extends FocusParser {
+  object KeywordIndex extends FocusParser {
 
     def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
       
       case FocusKeywordGiven(Name("index"), FromType(fromType), TypeArgs(_, _, toType), ValueArgs(index), GivenInstance(indexInstance), remainingCode) => 
-         val action = FocusAction.Index(fromType, toType, index, indexInstance)
+         val action = FocusAction.KeywordIndex(fromType, toType, index, indexInstance)
          Some(Right(remainingCode, action))
         
       case _ => None

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/some/SomeGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/some/SomeGenerator.scala
@@ -1,14 +1,14 @@
-package monocle.internal.focus.features.optionsome
+package monocle.internal.focus.features.some
 
 import monocle.internal.focus.FocusBase
 import monocle.std.option.some
 
-private[focus] trait OptionSomeGenerator {
+private[focus] trait SomeGenerator {
   this: FocusBase => 
 
   import macroContext.reflect._
 
-  def generateOptionSome(toType: TypeRepr): Term = {
+  def generateSome(toType: TypeRepr): Term = {
     toType.asType match {
       case '[t] => '{ some[t] }.asTerm
     }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/some/SomeParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/some/SomeParser.scala
@@ -1,17 +1,17 @@
-package monocle.internal.focus.features.optionsome
+package monocle.internal.focus.features.some
 
 import monocle.internal.focus.FocusBase
 import monocle.internal.focus.features.ParserBase
 
-private[focus] trait OptionSomeParser {
+private[focus] trait SomeParser {
   this: FocusBase with ParserBase =>
 
-  object OptionSome extends FocusParser {
+  object KeywordSome extends FocusParser {
 
     def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
 
       case FocusKeyword(Name("some"), _, TypeArgs(toType), remainingCode) => 
-        val action = FocusAction.OptionSome(toType)
+        val action = FocusAction.KeywordSome(toType)
         Some(Right(remainingCode, action))
 
       case _ => None

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusAsTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusAsTest.scala
@@ -6,7 +6,7 @@ import monocle.Focus._
 import scala.annotation.nowarn
 
 
-final class FocusCastAsTest extends munit.FunSuite {
+final class FocusAsTest extends munit.FunSuite {
 
   trait Food { def calories: Int }
   case class Banana(calories: Int, squishy: Boolean) extends Food


### PR DESCRIPTION
The inconsistent naming of Focus features was annoying me. 

The package names are now all exactly the keyword, and the `FocusAction` and matcher/parser are now called `KeywordXXX` to avoid naming collisions on things like `Some`, but still be consistent for all of them.

`FieldSelect` stays how it is. It will probably end up splitting into features called something like `SelectLens`, `SelectIso`, `SelectMulti`, `SelectGetter`, etc, so it will need its own pattern.