### PR TITLE
Focus withDefault feature, removed Eq constraint on withDefault everywhere

### DIFF
--- a/core/shared/src/main/scala-3.x/monocle/Focus.scala
+++ b/core/shared/src/main/scala-3.x/monocle/Focus.scala
@@ -21,6 +21,9 @@ object Focus extends AppliedFocusSyntax {
 
     extension [From, I, To] (from: From)
       def index(i: I)(using Index[From, I, To]): To = scala.sys.error("Extension method 'index(i)' should only be used within the monocle.Focus macro.")
+
+    extension [A] (from: Option[A])
+      def withDefault(defaultValue: A): A = scala.sys.error("Extension method 'withDefault(value)' should only be used within the monocle.Focus macro.")
   }
 
   def apply[S] = new MkFocus[S]

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/FocusBase.scala
@@ -19,6 +19,7 @@ private[focus] trait FocusBase {
     case KeywordEach(fromType: TypeRepr, toType: TypeRepr, eachInstance: Term)
     case KeywordAt(fromType: TypeRepr, toType: TypeRepr, index: Term, atInstance: Term)
     case KeywordIndex(fromType: TypeRepr, toType: TypeRepr, index: Term, indexInstance: Term)
+    case KeywordWithDefault(toType: TypeRepr, defaultValue: Term)
 
     override def toString(): String = this match {
       case FieldSelect(name, fromType, fromTypeArgs, toType) => s"FieldSelect($name, ${fromType.show}, ${fromTypeArgs.map(_.show)}, ${toType.show})"
@@ -27,6 +28,7 @@ private[focus] trait FocusBase {
       case KeywordEach(fromType, toType, _) => s"KeywordEach(${fromType.show}, ${toType.show}, ...)"
       case KeywordAt(fromType, toType, _, _) => s"KeywordAt(${fromType.show}, ${toType.show}, ..., ...)"
       case KeywordIndex(fromType, toType, _, _) => s"KeywordIndex(${fromType.show}, ${toType.show}, ..., ...)"
+      case KeywordWithDefault(toType, _) => s"KeywordWithDefault(${toType.show}, ...)"
     }
   }
 

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/GeneratorLoop.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/GeneratorLoop.scala
@@ -7,6 +7,7 @@ import monocle.internal.focus.features.as.AsGenerator
 import monocle.internal.focus.features.each.EachGenerator
 import monocle.internal.focus.features.at.AtGenerator
 import monocle.internal.focus.features.index.IndexGenerator
+import monocle.internal.focus.features.withdefault.WithDefaultGenerator
 import monocle.{Lens, Iso, Prism, Optional, Traversal}
 import scala.quoted.Type
 
@@ -19,6 +20,7 @@ private[focus] trait AllFeatureGenerators
   with EachGenerator
   with AtGenerator
   with IndexGenerator
+  with WithDefaultGenerator
 
 private[focus] trait GeneratorLoop {
   this: AllFeatureGenerators => 
@@ -41,6 +43,7 @@ private[focus] trait GeneratorLoop {
       case FocusAction.KeywordEach(fromType, toType, eachInstance) => generateEach(fromType, toType, eachInstance)
       case FocusAction.KeywordAt(fromType, toType, index, atInstance) => generateAt(fromType, toType, index, atInstance)
       case FocusAction.KeywordIndex(fromType, toType, index, indexInstance) => generateIndex(fromType, toType, index, indexInstance)
+      case FocusAction.KeywordWithDefault(toType, defaultValue) => generateWithDefault(toType, defaultValue)
     }
 
   private def composeOptics(lens1: Term, lens2: Term): FocusResult[Term] = {

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/ParserBase.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/ParserBase.scala
@@ -20,9 +20,12 @@ private[focus] trait ParserBase {
   case class ValueArgs(args: Term*)
 
   object FocusKeyword {
-    def unapply(term: Term): Option[(Name, FromType, TypeArgs, RemainingCode)] = term match {
+    def unapply(term: Term): Option[(Name, FromType, TypeArgs, ValueArgs, RemainingCode)] = term match {
       case Apply(TypeApply(Select(_, keyword), typeArgs), List(code)) => 
-        Some(Name(keyword), FromType(code.tpe.widen), TypeArgs(typeArgs.map(_.tpe): _*), RemainingCode(code))
+        Some(Name(keyword), FromType(code.tpe.widen), TypeArgs(typeArgs.map(_.tpe): _*), ValueArgs(), RemainingCode(code))
+
+      case Apply(Apply(TypeApply(Select(_, keyword), typeArgs), List(code)), valueArgs) => 
+        Some(Name(keyword), FromType(code.tpe.widen), TypeArgs(typeArgs.map(_.tpe): _*), ValueArgs(valueArgs: _*), RemainingCode(code))
 
       case _ => None
     }
@@ -30,11 +33,8 @@ private[focus] trait ParserBase {
 
   object FocusKeywordGiven {
     def unapply(term: Term): Option[(Name, FromType, TypeArgs, ValueArgs, GivenInstance, RemainingCode)] = term match {
-      case Apply(Apply(FocusKeyword(keyword, fromType, typeArgs, code), argList), List(instance)) => 
-        Some(keyword, fromType, typeArgs, ValueArgs(argList: _*), GivenInstance(instance), code)
-
-      case Apply(FocusKeyword(keyword, fromType, typeArgs, code), List(instance)) => 
-        Some(keyword, fromType, typeArgs, ValueArgs(), GivenInstance(instance), code)
+      case Apply(FocusKeyword(keyword, fromType, typeArgs, valueArgs, code), List(instance)) => 
+        Some(keyword, fromType, typeArgs, valueArgs, GivenInstance(instance), code)
 
       case _ => None
     }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/ParserLoop.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/ParserLoop.scala
@@ -8,6 +8,7 @@ import monocle.internal.focus.features.as.AsParser
 import monocle.internal.focus.features.each.EachParser
 import monocle.internal.focus.features.at.AtParser
 import monocle.internal.focus.features.index.IndexParser
+import monocle.internal.focus.features.withdefault.WithDefaultParser
 
 private[focus] trait AllFeatureParsers 
   extends FocusBase 
@@ -18,6 +19,7 @@ private[focus] trait AllFeatureParsers
   with EachParser
   with AtParser
   with IndexParser
+  with WithDefaultParser
 
 private[focus] trait ParserLoop {
   this: AllFeatureParsers => 
@@ -45,6 +47,9 @@ private[focus] trait ParserLoop {
 
         case KeywordAs(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
         case KeywordAs(Left(error)) => Left(error)
+
+        case KeywordWithDefault(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
+        case KeywordWithDefault(Left(error)) => Left(error)
 
         case FieldSelect(Right(remainingCode, action)) => loop(remainingCode, action :: listSoFar)
         case FieldSelect(Left(error)) => Left(error)

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/as/AsParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/as/AsParser.scala
@@ -10,7 +10,7 @@ private[focus] trait AsParser {
 
     def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
       
-      case FocusKeyword(Name("as"), FromType(fromType), TypeArgs(toType), remainingCode) => 
+      case FocusKeyword(Name("as"), FromType(fromType), TypeArgs(toType), ValueArgs(), remainingCode) => 
         if (toType <:< fromType) {
           val action = FocusAction.KeywordAs(fromType, toType)
           Some(Right(remainingCode, action))

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/some/SomeParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/some/SomeParser.scala
@@ -10,7 +10,7 @@ private[focus] trait SomeParser {
 
     def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
 
-      case FocusKeyword(Name("some"), _, TypeArgs(toType), remainingCode) => 
+      case FocusKeyword(Name("some"), _, TypeArgs(toType), ValueArgs(), remainingCode) => 
         val action = FocusAction.KeywordSome(toType)
         Some(Right(remainingCode, action))
 

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/withdefault/WithDefaultGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/withdefault/WithDefaultGenerator.scala
@@ -1,0 +1,16 @@
+package monocle.internal.focus.features.withdefault
+
+import monocle.internal.focus.FocusBase
+import monocle.std.option.withDefault
+
+private[focus] trait WithDefaultGenerator {
+  this: FocusBase => 
+
+  import macroContext.reflect._
+
+  def generateWithDefault(toType: TypeRepr, defaultValue: Term): Term = {
+    toType.asType match {
+      case '[t] => '{ withDefault[t](${defaultValue.asExprOf[t]}) }.asTerm
+    }
+  }
+}

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/withdefault/WithDefaultParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/withdefault/WithDefaultParser.scala
@@ -1,0 +1,20 @@
+package monocle.internal.focus.features.withdefault
+
+import monocle.internal.focus.FocusBase
+import monocle.internal.focus.features.ParserBase
+
+private[focus] trait WithDefaultParser {
+  this: FocusBase with ParserBase =>
+
+  object KeywordWithDefault extends FocusParser {
+
+    def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
+
+      case FocusKeyword(Name("withDefault"), _, TypeArgs(toType), ValueArgs(defaultValue), remainingCode) => 
+        val action = FocusAction.KeywordWithDefault(toType, defaultValue)
+        Some(Right(remainingCode, action))
+
+      case _ => None
+    }
+  }
+}

--- a/core/shared/src/main/scala/monocle/Fold.scala
+++ b/core/shared/src/main/scala/monocle/Fold.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Eq, Foldable, Monoid}
+import cats.{Foldable, Monoid}
 import cats.arrow.Choice
 import cats.instances.int._
 import cats.instances.list._
@@ -163,7 +163,7 @@ final case class FoldSyntax[S, A](private val self: Fold[S, A]) extends AnyVal {
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): Fold[S, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Fold[S, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Fold[S, A1] =
     self.adapt[Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): Fold[S, A1] =

--- a/core/shared/src/main/scala/monocle/Getter.scala
+++ b/core/shared/src/main/scala/monocle/Getter.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Eq, Monoid, Semigroupal}
+import cats.{Monoid, Semigroupal}
 import cats.arrow.{Arrow, Choice}
 import cats.implicits._
 import monocle.function.{At, Each, FilterIndex, Index}
@@ -141,7 +141,7 @@ final case class GetterSyntax[S, A](private val self: Getter[S, A]) extends AnyV
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): Fold[S, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Getter[S, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Getter[S, A1] =
     self.adapt[Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): Getter[S, A1] =

--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Applicative, Eq, Functor, Monoid}
+import cats.{Applicative, Functor, Monoid}
 import cats.arrow.Category
 import cats.evidence.{<~<, Is}
 import cats.syntax.either._
@@ -340,7 +340,7 @@ final case class IsoSyntax[S, A](private val self: Iso[S, A]) extends AnyVal {
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): Traversal[S, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Iso[S, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Iso[S, A1] =
     self.adapt[Option[A1], Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): Lens[S, A1] =

--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Applicative, Eq, Functor, Monoid}
+import cats.{Applicative, Functor, Monoid}
 import cats.arrow.Choice
 import cats.syntax.either._
 import monocle.function.{At, Each, FilterIndex, Index}
@@ -282,7 +282,7 @@ final case class LensSyntax[S, A](private val self: Lens[S, A]) extends AnyVal {
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): Traversal[S, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Lens[S, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Lens[S, A1] =
     self.adapt[Option[A1], Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): Lens[S, A1] =

--- a/core/shared/src/main/scala/monocle/Optional.scala
+++ b/core/shared/src/main/scala/monocle/Optional.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Applicative, Eq}
+import cats.{Applicative, Monoid}
 import cats.arrow.Choice
 import cats.syntax.either._
 import monocle.function.{At, Each, FilterIndex, Index}
@@ -336,7 +336,7 @@ final case class OptionalSyntax[S, A](private val self: Optional[S, A]) extends 
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): Traversal[S, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Optional[S, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Optional[S, A1] =
     self.adapt[Option[A1], Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): Optional[S, A1] =

--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -285,7 +285,7 @@ final case class PrismSyntax[S, A](private val self: Prism[S, A]) extends AnyVal
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): Traversal[S, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Prism[S, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Prism[S, A1] =
     self.adapt[Option[A1], Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): Optional[S, A1] =

--- a/core/shared/src/main/scala/monocle/Setter.scala
+++ b/core/shared/src/main/scala/monocle/Setter.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Contravariant, Eq, Functor}
+import cats.{Contravariant, Functor}
 import cats.arrow.Choice
 import cats.arrow.Profunctor
 import cats.syntax.either._
@@ -201,7 +201,7 @@ final case class SetterSyntax[S, A](private val self: Setter[S, A]) extends AnyV
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): Setter[S, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Setter[S, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Setter[S, A1] =
     self.adapt[Option[A1], Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): Setter[S, A1] =

--- a/core/shared/src/main/scala/monocle/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/Traversal.scala
@@ -1,6 +1,6 @@
 package monocle
 
-import cats.{Applicative, Eq, Functor, Id, Monoid, Parallel, Traverse}
+import cats.{Applicative, Functor, Id, Monoid, Parallel, Traverse}
 import cats.arrow.Choice
 import cats.data.Const
 import cats.syntax.either._
@@ -293,7 +293,7 @@ final case class TraversalSyntax[S, A](private val self: Traversal[S, A]) extend
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): Traversal[S, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Traversal[S, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): Traversal[S, A1] =
     self.adapt[Option[A1], Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): Traversal[S, A1] =

--- a/core/shared/src/main/scala/monocle/std/Option.scala
+++ b/core/shared/src/main/scala/monocle/std/Option.scala
@@ -1,7 +1,5 @@
 package monocle.std
 
-import cats.implicits._
-import cats.Eq
 import monocle.{Iso, PIso, PPrism, Prism}
 
 object option extends OptionOptics
@@ -39,6 +37,6 @@ trait OptionOptics {
     *
     * @see This method is called `non` in Haskell Lens.
     */
-  final def withDefault[A: Eq](defaultValue: A): Iso[Option[A], A] =
-    Iso[Option[A], A](_.getOrElse(defaultValue))(value => if (value === defaultValue) None else Some(value))
+  final def withDefault[A](defaultValue: A): Iso[Option[A], A] =
+    Iso[Option[A], A](_.getOrElse(defaultValue))(value => if (value == defaultValue) None else Some(value))
 }

--- a/core/shared/src/main/scala/monocle/syntax/ApplyFold.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyFold.scala
@@ -1,6 +1,6 @@
 package monocle.syntax
 
-import cats.{Eq, Monoid}
+import cats.Monoid
 import monocle.function.{At, Each, FilterIndex, Index}
 import monocle.{std, Fold, Getter, Optional, PIso, PLens, POptional, PPrism, PTraversal}
 
@@ -32,7 +32,7 @@ case class ApplyFold[S, A](s: S, _fold: Fold[S, A]) {
   def some[A1](implicit ev1: A =:= Option[A1]): ApplyFold[S, A1] =
     adapt[Option[A1]].andThen(std.option.some[A1])
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit ev1: A =:= Option[A1]): ApplyFold[S, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit ev1: A =:= Option[A1]): ApplyFold[S, A1] =
     adapt[Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): ApplyFold[S, A1] =

--- a/core/shared/src/main/scala/monocle/syntax/ApplyGetter.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyGetter.scala
@@ -1,6 +1,5 @@
 package monocle.syntax
 
-import cats.Eq
 import monocle.function.{At, Each, FilterIndex, Index}
 import monocle.{std, Fold, Getter, Optional, PIso, PLens, POptional, PPrism, PTraversal}
 
@@ -24,7 +23,7 @@ final case class ApplyGetter[S, A](s: S, getter: Getter[S, A]) {
   def some[A1](implicit ev1: A =:= Option[A1]): ApplyFold[S, A1] =
     adapt[Option[A1]].andThen(std.option.some[A1])
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit ev1: A =:= Option[A1]): ApplyGetter[S, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit ev1: A =:= Option[A1]): ApplyGetter[S, A1] =
     adapt[Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): ApplyGetter[S, A1] =

--- a/core/shared/src/main/scala/monocle/syntax/ApplyIso.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyIso.scala
@@ -1,6 +1,6 @@
 package monocle.syntax
 
-import cats.{Eq, Functor}
+import cats.Functor
 import monocle.function.{At, Each, FilterIndex, Index}
 import monocle.{std, Fold, Getter, Optional, PIso, PLens, POptional, PPrism, PSetter, PTraversal}
 
@@ -95,7 +95,7 @@ final case class ApplyIsoSyntax[S, A](private val self: ApplyIso[S, S, A, A]) ex
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): ApplyTraversal[S, S, A1, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): ApplyIso[S, S, A1, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): ApplyIso[S, S, A1, A1] =
     self.adapt[Option[A1], Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): ApplyLens[S, S, A1, A1] =

--- a/core/shared/src/main/scala/monocle/syntax/ApplyLens.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyLens.scala
@@ -1,6 +1,6 @@
 package monocle.syntax
 
-import cats.{Eq, Functor}
+import cats.Functor
 import monocle.function.{At, Each, FilterIndex, Index}
 import monocle.{std, Fold, Getter, Optional, PIso, PLens, POptional, PPrism, PSetter, PTraversal}
 
@@ -96,7 +96,7 @@ final case class ApplyLensSyntax[S, A](private val self: ApplyLens[S, S, A, A]) 
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): ApplyTraversal[S, S, A1, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): ApplyLens[S, S, A1, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): ApplyLens[S, S, A1, A1] =
     self.adapt[Option[A1], Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): ApplyLens[S, S, A1, A1] =

--- a/core/shared/src/main/scala/monocle/syntax/ApplyOptional.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyOptional.scala
@@ -1,6 +1,6 @@
 package monocle.syntax
 
-import cats.{Applicative, Eq}
+import cats.Applicative
 import monocle.function.{At, Each, FilterIndex, Index}
 import monocle.{std, Fold, Optional, PIso, PLens, POptional, PPrism, PSetter, PTraversal}
 
@@ -106,7 +106,7 @@ final case class ApplyOptionalSyntax[S, A](private val self: ApplyOptional[S, S,
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): ApplyTraversal[S, S, A1, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): ApplyOptional[S, S, A1, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): ApplyOptional[S, S, A1, A1] =
     self.adapt[Option[A1], Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): ApplyOptional[S, S, A1, A1] =

--- a/core/shared/src/main/scala/monocle/syntax/ApplyPrism.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyPrism.scala
@@ -1,6 +1,6 @@
 package monocle.syntax
 
-import cats.{Applicative, Eq}
+import cats.Applicative
 import monocle.function.{At, Each, FilterIndex, Index}
 import monocle.{std, Fold, Optional, PIso, PLens, POptional, PPrism, PSetter, PTraversal}
 
@@ -104,7 +104,7 @@ final case class ApplyPrismSyntax[S, A](private val self: ApplyPrism[S, S, A, A]
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): ApplyTraversal[S, S, A1, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): ApplyPrism[S, S, A1, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): ApplyPrism[S, S, A1, A1] =
     self.adapt[Option[A1], Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): ApplyOptional[S, S, A1, A1] =

--- a/core/shared/src/main/scala/monocle/syntax/ApplySetter.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplySetter.scala
@@ -1,6 +1,5 @@
 package monocle.syntax
 
-import cats.Eq
 import monocle.function.{At, Each, FilterIndex, Index}
 import monocle.{std, Optional, PIso, PLens, POptional, PPrism, PSetter, PTraversal}
 
@@ -84,7 +83,7 @@ final case class ApplySetterSyntax[S, A](private val self: ApplySetter[S, S, A, 
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): ApplySetter[S, S, A1, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): ApplySetter[S, S, A1, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): ApplySetter[S, S, A1, A1] =
     self.adapt[Option[A1], Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): ApplySetter[S, S, A1, A1] =

--- a/core/shared/src/main/scala/monocle/syntax/ApplyTraversal.scala
+++ b/core/shared/src/main/scala/monocle/syntax/ApplyTraversal.scala
@@ -1,6 +1,6 @@
 package monocle.syntax
 
-import cats.{Applicative, Eq}
+import cats.Applicative
 import monocle.function.{At, Each, FilterIndex, Index}
 import monocle.{std, Fold, Optional, PIso, PLens, POptional, PPrism, PSetter, PTraversal}
 
@@ -100,7 +100,7 @@ final case class ApplyTraversalSyntax[S, A](private val self: ApplyTraversal[S, 
   def filterIndex[I, A1](predicate: I => Boolean)(implicit ev: FilterIndex[A, I, A1]): ApplyTraversal[S, S, A1, A1] =
     self.andThen(ev.filterIndex(predicate))
 
-  def withDefault[A1: Eq](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): ApplyTraversal[S, S, A1, A1] =
+  def withDefault[A1](defaultValue: A1)(implicit evOpt: A =:= Option[A1]): ApplyTraversal[S, S, A1, A1] =
     self.adapt[Option[A1], Option[A1]].andThen(std.option.withDefault(defaultValue))
 
   def at[I, A1](i: I)(implicit evAt: At[A, i.type, A1]): ApplyTraversal[S, S, A1, A1] =

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusWithDefaultTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusWithDefaultTest.scala
@@ -1,0 +1,70 @@
+package monocle.focus
+
+import monocle.{Focus, Iso}
+
+final class FocusWithDefaultTest extends munit.FunSuite {
+
+  
+  test("Access `withDefault` directly on argument") {
+    val iso: Iso[Option[Int], Int] = Focus[Option[Int]](_.withDefault(555))
+    assertEquals(iso.get(Some(3)), 3)
+    assertEquals(iso.get(None), 555)
+  }
+
+  test("Access `withDefault` on field") {
+    case class User(name: String, address: Option[Address])
+    case class Address(streetNumber: Int, postcode: String)
+
+    val elise = User("Elise", Some(Address(12, "high street")))
+    val bob   = User("bob"  , None)
+
+    val streetNumber = Focus[User](_.address.withDefault(Address(333, "abc")).streetNumber)
+
+    assertEquals(streetNumber.get(elise), 12)
+    assertEquals(streetNumber.get(bob), 333)
+  }
+
+  test("Access `withDefault` on a parametric Option within a case class") {
+    case class IdOpt[+A](id: Long, value: Option[A])
+    case class User(name: String, age: Int)
+
+    val bob = User("bob", 24)
+    val idSome = IdOpt(1, Some(bob))
+    val idNone = IdOpt(1, None)
+
+    val age = Focus[IdOpt[User]](_.value.withDefault(User("Grug", 99)).age)
+
+    assertEquals(age.get(idSome), 24)
+    assertEquals(age.get(idNone), 99)
+  }
+
+  test("Access `withDefault` on top level Option") {
+    case class User(name: String, age: Int)
+    val bob = User("bob", 24)
+
+    val age = Focus[Option[User]](_.withDefault(User("Smee", 888)).age)
+
+    assertEquals(age.get(Some(bob)), 24)
+    assertEquals(age.get(None), 888)
+  }
+
+  test("Access `withDefault` on nested Option") {
+    case class User(name: String, age: Int)
+    val bob = User("Friedrich", 33)
+
+    val name = Focus[Option[Option[User]]](_.withDefault(Some(User("Gunther", 22))).withDefault(User("Brunhild", 44)).name)
+
+    assertEquals(name.get(Some(Some(bob))), "Friedrich")
+    assertEquals(name.get(Some(None)), "Brunhild")
+    assertEquals(name.get(None), "Gunther")
+  }
+
+
+  test("Focus operator `withDefault` commutes with standalone operator `withDefault`") {
+    val opt: Option[Int] = Some(33)
+
+    assertEquals(
+      Focus[Option[Int]](_.withDefault(99)).get(opt),
+      Focus[Option[Int]](a => a).withDefault(99).get(opt))
+  }
+}


### PR DESCRIPTION
Focus `withDefault` feature, resolving #1031 

Of note: 
- Removed the `Eq` constraint from `withDefault` in `std.option` and in all the optics, because it adds an intolerable usability hurdle to Focus, and provides little value for the `withDefault` usecase on its own
- Tweaked the `FocusKeyword` matcher in `ParserBase` to accomodate value parameters with no typeclass