### PR TITLE
add Focus[X]() and .focus() for Iso/ApplyIso

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ inThisBuild(
       List(
         "aoiroaoino"      -> "Naoki Aoyama",
         "cquiroz"         -> "Carlos Quiroz",
-        "kenbot"          -> " Ken Scambler",
+        "kenbot"          -> "Ken Scambler",
         "julien-truffaut" -> "Julien Truffaut",
         "NightRa"         -> "Ilan Godik",
         "xuwei-k"         -> "Kenji Yoshida",
@@ -285,7 +285,7 @@ lazy val unsafe = crossProject(JVMPlatform, JSPlatform)
   .settings(libraryDependencies ++= Seq(cats.value, alleycats.value))
 
 lazy val test = crossProject(JVMPlatform, JSPlatform)
-  .dependsOn(core, law, state, unsafe)
+  .dependsOn(core, law, state, unsafe, macros)
   .settings(moduleName := "monocle-test")
   .configureCross(
     _.jvmSettings(monocleJvmSettings),

--- a/core/shared/src/main/scala-3.x/monocle/Focus.scala
+++ b/core/shared/src/main/scala-3.x/monocle/Focus.scala
@@ -29,6 +29,8 @@ object Focus extends AppliedFocusSyntax {
   def apply[S] = new MkFocus[S]
 
   class MkFocus[From] {
+    def apply(): Iso[From, From] = Iso.id
+
     transparent inline def apply[To](inline lambda: (KeywordContext ?=> From => To)): Any = 
       ${ FocusImpl('lambda) }
   }

--- a/core/shared/src/main/scala-3.x/monocle/syntax/AppliedFocusSyntax.scala
+++ b/core/shared/src/main/scala-3.x/monocle/syntax/AppliedFocusSyntax.scala
@@ -1,11 +1,15 @@
 package monocle.syntax
 
-import monocle.Focus
+import monocle.{Focus, Iso}
 import monocle.internal.focus.AppliedFocusImpl
 
 trait AppliedFocusSyntax {
 
-  extension [From, To] (from: From) 
-    transparent inline def focus(inline lambda: (Focus.KeywordContext ?=> From => To)): Any = 
+  extension [From, To] (from: From) {
+    def focus(): ApplyIso[From, From, From, From] = ApplyIso(from, Iso.id)
+
+    transparent inline def focus(inline lambda: (Focus.KeywordContext ?=> From => To)): Any =
       ${AppliedFocusImpl[From, To]('from, 'lambda)}
+  }
+
 }

--- a/core/shared/src/main/scala/monocle/syntax/Apply.scala
+++ b/core/shared/src/main/scala/monocle/syntax/Apply.scala
@@ -5,8 +5,6 @@ import monocle._
 object apply extends ApplySyntax
 
 trait ApplySyntax {
-  implicit def toApplyOpticsOps[S](value: S): ApplyOpticsOps[S] = ApplyOpticsOps(value)
-
   implicit def toApplyFoldOps[S](value: S): ApplyFoldOps[S] =
     new ApplyFoldOps(value)
   implicit def toApplyGetterOps[S](value: S): ApplyGetterOps[S] =
@@ -25,79 +23,75 @@ trait ApplySyntax {
     new ApplyTraversalOps(value)
 }
 
-final case class ApplyOpticsOps[S](private val s: S) extends AnyVal {
-  def optics[T, A, B]: ApplyIso[S, S, S, S] = ApplyIso(s, Iso.id)
-}
-
 final case class ApplyFoldOps[S](private val s: S) extends AnyVal {
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def applyFold[A](fold: Fold[S, A]): ApplyFold[S, A] =
     new ApplyFold[S, A](s, fold)
 }
 
 final case class ApplyGetterOps[S](private val s: S) extends AnyVal {
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def applyGetter[A](getter: Getter[S, A]): ApplyGetter[S, A] =
     new ApplyGetter[S, A](s, getter)
 }
 
 final case class ApplyIsoOps[S](private val s: S) extends AnyVal {
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def applyIso[T, A, B](iso: PIso[S, T, A, B]): ApplyIso[S, T, A, B] =
     ApplyIso[S, T, A, B](s, iso)
 
   /** alias to applyIso */
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def &<->[T, A, B](iso: PIso[S, T, A, B]): ApplyIso[S, T, A, B] =
     applyIso(iso)
 }
 
 final case class ApplyLensOps[S](private val s: S) extends AnyVal {
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def applyLens[T, A, B](lens: PLens[S, T, A, B]): ApplyLens[S, T, A, B] =
     ApplyLens[S, T, A, B](s, lens)
 
   /** alias to applyLens */
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def &|->[T, A, B](lens: PLens[S, T, A, B]): ApplyLens[S, T, A, B] =
     applyLens(lens)
 }
 
 final case class ApplyOptionalOps[S](private val s: S) extends AnyVal {
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def applyOptional[T, A, B](optional: POptional[S, T, A, B]): ApplyOptional[S, T, A, B] =
     ApplyOptional[S, T, A, B](s, optional)
 
   /** alias to applyOptional */
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def &|-?[T, A, B](optional: POptional[S, T, A, B]): ApplyOptional[S, T, A, B] =
     applyOptional(optional)
 }
 
 final case class ApplyPrismOps[S](private val s: S) extends AnyVal {
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def applyPrism[T, A, B](prism: PPrism[S, T, A, B]): ApplyPrism[S, T, A, B] =
     ApplyPrism[S, T, A, B](s, prism)
 
   /** alias to applyPrism */
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def &<-?[T, A, B](prism: PPrism[S, T, A, B]): ApplyPrism[S, T, A, B] =
     applyPrism(prism)
 }
 
 final case class ApplySetterOps[S](private val s: S) extends AnyVal {
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def applySetter[T, A, B](setter: PSetter[S, T, A, B]): ApplySetter[S, T, A, B] =
     new ApplySetter[S, T, A, B](s, setter)
 }
 
 final case class ApplyTraversalOps[S](private val s: S) extends AnyVal {
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def applyTraversal[T, A, B](traversal: PTraversal[S, T, A, B]): ApplyTraversal[S, T, A, B] =
     ApplyTraversal[S, T, A, B](s, traversal)
 
   /** alias to applyTraversal */
-  @deprecated("use optics.andThen", since = "3.0.0-M1")
+  @deprecated("use focus.andThen", since = "3.0.0-M1")
   def &|->>[T, A, B](traversal: PTraversal[S, T, A, B]): ApplyTraversal[S, T, A, B] =
     applyTraversal(traversal)
 }

--- a/core/shared/src/main/scala/monocle/syntax/Apply.scala
+++ b/core/shared/src/main/scala/monocle/syntax/Apply.scala
@@ -24,74 +24,74 @@ trait ApplySyntax {
 }
 
 final case class ApplyFoldOps[S](private val s: S) extends AnyVal {
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def applyFold[A](fold: Fold[S, A]): ApplyFold[S, A] =
     new ApplyFold[S, A](s, fold)
 }
 
 final case class ApplyGetterOps[S](private val s: S) extends AnyVal {
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def applyGetter[A](getter: Getter[S, A]): ApplyGetter[S, A] =
     new ApplyGetter[S, A](s, getter)
 }
 
 final case class ApplyIsoOps[S](private val s: S) extends AnyVal {
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def applyIso[T, A, B](iso: PIso[S, T, A, B]): ApplyIso[S, T, A, B] =
     ApplyIso[S, T, A, B](s, iso)
 
   /** alias to applyIso */
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def &<->[T, A, B](iso: PIso[S, T, A, B]): ApplyIso[S, T, A, B] =
     applyIso(iso)
 }
 
 final case class ApplyLensOps[S](private val s: S) extends AnyVal {
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def applyLens[T, A, B](lens: PLens[S, T, A, B]): ApplyLens[S, T, A, B] =
     ApplyLens[S, T, A, B](s, lens)
 
   /** alias to applyLens */
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def &|->[T, A, B](lens: PLens[S, T, A, B]): ApplyLens[S, T, A, B] =
     applyLens(lens)
 }
 
 final case class ApplyOptionalOps[S](private val s: S) extends AnyVal {
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def applyOptional[T, A, B](optional: POptional[S, T, A, B]): ApplyOptional[S, T, A, B] =
     ApplyOptional[S, T, A, B](s, optional)
 
   /** alias to applyOptional */
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def &|-?[T, A, B](optional: POptional[S, T, A, B]): ApplyOptional[S, T, A, B] =
     applyOptional(optional)
 }
 
 final case class ApplyPrismOps[S](private val s: S) extends AnyVal {
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def applyPrism[T, A, B](prism: PPrism[S, T, A, B]): ApplyPrism[S, T, A, B] =
     ApplyPrism[S, T, A, B](s, prism)
 
   /** alias to applyPrism */
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def &<-?[T, A, B](prism: PPrism[S, T, A, B]): ApplyPrism[S, T, A, B] =
     applyPrism(prism)
 }
 
 final case class ApplySetterOps[S](private val s: S) extends AnyVal {
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def applySetter[T, A, B](setter: PSetter[S, T, A, B]): ApplySetter[S, T, A, B] =
     new ApplySetter[S, T, A, B](s, setter)
 }
 
 final case class ApplyTraversalOps[S](private val s: S) extends AnyVal {
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def applyTraversal[T, A, B](traversal: PTraversal[S, T, A, B]): ApplyTraversal[S, T, A, B] =
     ApplyTraversal[S, T, A, B](s, traversal)
 
   /** alias to applyTraversal */
-  @deprecated("use focus.andThen", since = "3.0.0-M1")
+  @deprecated("use focus().andThen", since = "3.0.0-M1")
   def &|->>[T, A, B](traversal: PTraversal[S, T, A, B]): ApplyTraversal[S, T, A, B] =
     applyTraversal(traversal)
 }

--- a/example/src/test/scala/monocle/LensExample.scala
+++ b/example/src/test/scala/monocle/LensExample.scala
@@ -1,7 +1,6 @@
 package monocle
 
 import monocle.macros.{GenLens, Lenses, PLenses}
-import monocle.macros.syntax.lens._
 import shapeless.test.illTyped
 
 class LensMonoExample extends MonocleSuite {

--- a/example/src/test/scala/monocle/function/AtExample.scala
+++ b/example/src/test/scala/monocle/function/AtExample.scala
@@ -10,17 +10,17 @@ import scala.collection.immutable.SortedMap
 
 class AtExample extends MonocleSuite {
   test("at creates a Lens from a Map, SortedMap to an optional value") {
-    assertEquals(Map("One" -> 2, "Two" -> 2).optics.at("Two").get, Some(2))
-    assertEquals(SortedMap("One" -> 2, "Two" -> 2).optics.at("Two").get, Some(2))
+    assertEquals(Map("One" -> 2, "Two" -> 2).focus().at("Two").get, Some(2))
+    assertEquals(SortedMap("One" -> 2, "Two" -> 2).focus().at("Two").get, Some(2))
 
-    assertEquals(Map("One" -> 1, "Two" -> 2).optics.at("One").replace(Some(-1)), Map("One" -> -1, "Two" -> 2))
+    assertEquals(Map("One" -> 1, "Two" -> 2).focus().at("One").replace(Some(-1)), Map("One" -> -1, "Two" -> 2))
 
     // can delete a value
-    assertEquals(Map("One" -> 1, "Two" -> 2).optics.at("Two").replace(None), Map("One" -> 1))
+    assertEquals(Map("One" -> 1, "Two" -> 2).focus().at("Two").replace(None), Map("One" -> 1))
 
     // add a new value
     assertEquals(
-      Map("One" -> 1, "Two" -> 2).optics.at("Three").replace(Some(3)),
+      Map("One" -> 1, "Two" -> 2).focus().at("Three").replace(Some(3)),
       Map(
         "One"   -> 1,
         "Two"   -> 2,
@@ -30,27 +30,27 @@ class AtExample extends MonocleSuite {
   }
 
   test("at creates a Lens from a Set to an optional element of the Set") {
-    assertEquals(Set(1, 2, 3).optics.at(2).get, true)
-    assertEquals(Set(1, 2, 3).optics.at(4).get, false)
+    assertEquals(Set(1, 2, 3).focus().at(2).get, true)
+    assertEquals(Set(1, 2, 3).focus().at(4).get, false)
 
-    assertEquals(Set(1, 2, 3).optics.at(4).replace(true), Set(1, 2, 3, 4))
-    assertEquals(Set(1, 2, 3).optics.at(2).replace(false), Set(1, 3))
+    assertEquals(Set(1, 2, 3).focus().at(4).replace(true), Set(1, 2, 3, 4))
+    assertEquals(Set(1, 2, 3).focus().at(2).replace(false), Set(1, 3))
   }
 
   test("at creates a Lens from Int to one of its bit") {
-    assertEquals(3.optics.at(0: IntBits).get, true)  // true  means bit is 1
-    assertEquals(4.optics.at(0: IntBits).get, false) // false means bit is 0
+    assertEquals(3.focus().at(0: IntBits).get, true)  // true  means bit is 1
+    assertEquals(4.focus().at(0: IntBits).get, false) // false means bit is 0
 
-    assertEquals(32.optics.at(0: IntBits).replace(true), 33)
-    assertEquals(3.optics.at(1: IntBits).modify(!_), 1) // toggle 2nd bit
+    assertEquals(32.focus().at(0: IntBits).replace(true), 33)
+    assertEquals(3.focus().at(1: IntBits).modify(!_), 1) // toggle 2nd bit
 
     illTyped("""0 applyLens at(79: IntBits) get""", "Right predicate.*fail.*")
     illTyped("""0 applyLens at(-1: IntBits) get""", "Left predicate.*fail.*")
   }
 
   test("at creates a Lens from Char to one of its bit") {
-    assertEquals('x'.optics.at(0: CharBits).get, false)
-    assertEquals('x'.optics.at(0: CharBits).replace(true), 'y')
+    assertEquals('x'.focus().at(0: CharBits).get, false)
+    assertEquals('x'.focus().at(0: CharBits).replace(true), 'y')
   }
 
   test("remove deletes an element of a Map") {

--- a/example/src/test/scala/monocle/function/EachExample.scala
+++ b/example/src/test/scala/monocle/function/EachExample.scala
@@ -9,26 +9,26 @@ import scala.annotation.nowarn
 
 class EachExample extends MonocleSuite {
   test("Each can be used on Option") {
-    assertEquals(Option(3).optics.each.modify(_ + 1), Some(4))
-    assertEquals((None: Option[Int]).optics.each.modify(_ + 1), None)
+    assertEquals(Option(3).focus().each.modify(_ + 1), Some(4))
+    assertEquals((None: Option[Int]).focus().each.modify(_ + 1), None)
   }
 
   test("Each can be used on List, IList, Vector, Stream and OneAnd") {
-    assertEquals(List(1, 2).optics.each.modify(_ + 1), List(2, 3))
-    assertEquals(Vector(1, 2).optics.each.modify(_ + 1), Vector(2, 3))
-    assertEquals(OneAnd(1, List(2, 3)).optics.each.modify(_ + 1), OneAnd(2, List(3, 4)))
+    assertEquals(List(1, 2).focus().each.modify(_ + 1), List(2, 3))
+    assertEquals(Vector(1, 2).focus().each.modify(_ + 1), Vector(2, 3))
+    assertEquals(OneAnd(1, List(2, 3)).focus().each.modify(_ + 1), OneAnd(2, List(3, 4)))
   }
 
   test("Each can be used on Map, IMap to update all values") {
     assertEquals(
-      SortedMap("One" -> 1, "Two" -> 2).optics.each.modify(_ + 1),
+      SortedMap("One" -> 1, "Two" -> 2).focus().each.modify(_ + 1),
       SortedMap("One" -> 2, "Two" -> 3)
     )
   }
 
   test("Each can be used on tuple of same type") {
-    assertEquals((1, 2).optics.each.modify(_ + 1), ((2, 3))): @nowarn
-    assertEquals((1, 2, 3).optics.each.modify(_ + 1), ((2, 3, 4))): @nowarn
-    assertEquals((1, 2, 3, 4, 5, 6).optics.each.modify(_ + 1), ((2, 3, 4, 5, 6, 7))): @nowarn
+    assertEquals((1, 2).focus().each.modify(_ + 1), ((2, 3))): @nowarn
+    assertEquals((1, 2, 3).focus().each.modify(_ + 1), ((2, 3, 4))): @nowarn
+    assertEquals((1, 2, 3, 4, 5, 6).focus().each.modify(_ + 1), ((2, 3, 4, 5, 6, 7))): @nowarn
   }
 }

--- a/example/src/test/scala/monocle/function/FieldsExample.scala
+++ b/example/src/test/scala/monocle/function/FieldsExample.scala
@@ -7,18 +7,18 @@ import scala.annotation.nowarn
 @nowarn
 class FieldsExample extends MonocleSuite {
   test("_1 creates a Lens from a 2-6 tuple to its first element") {
-    assertEquals(("Hello", 3).optics.composeLens(first).get, "Hello")
+    assertEquals(("Hello", 3).focus().composeLens(first).get, "Hello")
 
-    assertEquals(("Hello", 3, true).optics.composeLens(first).replace("World"), (("World", 3, true)))
+    assertEquals(("Hello", 3, true).focus().composeLens(first).replace("World"), (("World", 3, true)))
 
-    assertEquals(("Hello", 3, true, 5.6, 7L, 'c').optics.composeLens(first).get, "Hello")
+    assertEquals(("Hello", 3, true, 5.6, 7L, 'c').focus().composeLens(first).get, "Hello")
   }
 
   test("_2 creates a Lens from a 2-6 tuple to its second element") {
-    assertEquals(("Hello", 3).optics.composeLens(second).get, 3)
+    assertEquals(("Hello", 3).focus().composeLens(second).get, 3)
 
     assertEquals(
-      ("Hello", 3, true, 5.6, 7L, 'c').optics.composeLens(second).replace(4),
+      ("Hello", 3, true, 5.6, 7L, 'c').focus().composeLens(second).replace(4),
       (("Hello", 4, true, 5.6, 7L, 'c'))
     )
   }
@@ -26,10 +26,10 @@ class FieldsExample extends MonocleSuite {
   // ...
 
   test("_6 creates a Lens from a 6-tuple to its sixth element") {
-    assertEquals(("Hello", 3, true, 5.6, 7L, 'c').optics.composeLens(sixth).get, 'c')
+    assertEquals(("Hello", 3, true, 5.6, 7L, 'c').focus().composeLens(sixth).get, 'c')
 
     assertEquals(
-      ("Hello", 3, true, 5.6, 7L, 'c').optics.composeLens(sixth).replace('a'),
+      ("Hello", 3, true, 5.6, 7L, 'c').focus().composeLens(sixth).replace('a'),
       (("Hello", 3, true, 5.6, 7L, 'a'))
     )
   }

--- a/example/src/test/scala/monocle/function/FilterIndexExample.scala
+++ b/example/src/test/scala/monocle/function/FilterIndexExample.scala
@@ -7,16 +7,20 @@ import scala.collection.immutable.SortedMap
 class FilterIndexExample extends MonocleSuite {
   test("filterIndexes creates Traversal from a SortedMap, IMap to all values where the index matches the predicate") {
     assertEquals(
-      SortedMap("One" -> 1, "Two" -> 2).optics.filterIndex { k: String =>
-        k.toLowerCase.contains("o")
-      }.getAll,
+      SortedMap("One" -> 1, "Two" -> 2)
+        .focus()
+        .filterIndex { k: String =>
+          k.toLowerCase.contains("o")
+        }
+        .getAll,
       List(
         1,
         2
       )
     )
     assertEquals(
-      SortedMap("One" -> 1, "Two" -> 2).optics
+      SortedMap("One" -> 1, "Two" -> 2)
+        .focus()
         .filterIndex { k: String =>
           k.startsWith("T")
         }
@@ -31,11 +35,11 @@ class FilterIndexExample extends MonocleSuite {
   test(
     "filterIndexes creates Traversal from a List, IList, Vector or Stream to all values where the index matches the predicate"
   ) {
-    assertEquals(List(1, 3, 5, 7).optics.filterIndex { i: Int => i % 2 == 0 }.getAll, List(1, 5))
+    assertEquals(List(1, 3, 5, 7).focus().filterIndex { i: Int => i % 2 == 0 }.getAll, List(1, 5))
 
-    assertEquals(List(1, 3, 5, 7).optics.filterIndex { i: Int => i >= 2 }.modify(_ + 2), List(1, 3, 7, 9))
+    assertEquals(List(1, 3, 5, 7).focus().filterIndex { i: Int => i >= 2 }.modify(_ + 2), List(1, 3, 7, 9))
     assertEquals(
-      Vector(1, 3, 5, 7).optics.filterIndex { i: Int => i >= 2 }.modify(_ + 2),
+      Vector(1, 3, 5, 7).focus().filterIndex { i: Int => i >= 2 }.modify(_ + 2),
       Vector(1, 3, 7, 9)
     )
   }

--- a/example/src/test/scala/monocle/function/IndexExample.scala
+++ b/example/src/test/scala/monocle/function/IndexExample.scala
@@ -7,24 +7,24 @@ import cats.data.OneAnd
 
 class IndexExample extends MonocleSuite {
   test("index creates an Optional from a Map, IMap to a value at the index") {
-    assertEquals(Map("One" -> 1, "Two" -> 2).optics.index("One").getOption, Some(1))
+    assertEquals(Map("One" -> 1, "Two" -> 2).focus().index("One").getOption, Some(1))
 
-    assertEquals(Map("One" -> 1, "Two" -> 2).optics.index("One").replace(2), Map("One" -> 2, "Two" -> 2))
+    assertEquals(Map("One" -> 1, "Two" -> 2).focus().index("One").replace(2), Map("One" -> 2, "Two" -> 2))
   }
 
   test("index creates an Optional from a List, Vector or Stream to a value at the index") {
-    assertEquals(List(0, 1, 2, 3).optics.index(1).getOption, Some(1))
-    assertEquals(List(0, 1, 2, 3).optics.index(8).getOption, None)
+    assertEquals(List(0, 1, 2, 3).focus().index(1).getOption, Some(1))
+    assertEquals(List(0, 1, 2, 3).focus().index(8).getOption, None)
 
-    assertEquals(Vector(0, 1, 2, 3).optics.index(1).modify(_ + 1), Vector(0, 2, 2, 3))
+    assertEquals(Vector(0, 1, 2, 3).focus().index(1).modify(_ + 1), Vector(0, 2, 2, 3))
   }
 
   test("index creates an Optional from a OneAnd to a value at the index") {
-    assertEquals(OneAnd(1, List(2, 3)).optics.index(0).getOption, Some(1))
-    assertEquals(OneAnd(1, List(2, 3)).optics.index(1).getOption, Some(2))
+    assertEquals(OneAnd(1, List(2, 3)).focus().index(0).getOption, Some(1))
+    assertEquals(OneAnd(1, List(2, 3)).focus().index(1).getOption, Some(2))
   }
 
   test("index creates an Optional from a String to a Char") {
-    assertEquals("Hello World".optics.index(2).getOption, Some('l'))
+    assertEquals("Hello World".focus().index(2).getOption, Some('l'))
   }
 }

--- a/macro/src/main/scala-2.x/monocle/macros/GenLens.scala
+++ b/macro/src/main/scala-2.x/monocle/macros/GenLens.scala
@@ -1,9 +1,10 @@
 package monocle.macros
 
-import monocle.Lens
+import monocle.{Iso, Lens}
 import monocle.macros.internal.MacroImpl
 
 class GenLens[A] {
+  def apply(): Iso[A, A] = Iso.id
 
   /** generate a [[Lens]] between a case class `S` and one of its field */
   def apply[B](field: A => B): Lens[A, B] = macro MacroImpl.genLens_impl[A, B]

--- a/macro/src/main/scala-2.x/monocle/macros/syntax/ApplyFocusSyntax.scala
+++ b/macro/src/main/scala-2.x/monocle/macros/syntax/ApplyFocusSyntax.scala
@@ -1,15 +1,19 @@
 package monocle.macros.syntax
-import scala.reflect.macros.blackbox
-import monocle.syntax.ApplyLens
+import monocle.Iso
 
-trait GenApplyLensSyntax {
-  implicit def toGenApplyLensOps[S](value: S): GenApplyLensOps[S] = new GenApplyLensOps(value)
+import scala.reflect.macros.blackbox
+import monocle.syntax.{ApplyIso, ApplyLens}
+
+trait ApplyFocusSyntax {
+  implicit def toApplyFocusOps[S](value: S): ApplyFocusOps[S] = new ApplyFocusOps(value)
 }
 
-class GenApplyLensOps[A](private val value: A) extends AnyVal {
+class ApplyFocusOps[A](private val value: A) extends AnyVal {
   @deprecated("use focus", since = "3.0.0-M1")
   def lens[C](field: A => C): ApplyLens[A, A, C, C] = macro GenApplyLensOpsImpl.lens_impl[A, C]
   def focus[C](field: A => C): ApplyLens[A, A, C, C] = macro GenApplyLensOpsImpl.lens_impl[A, C]
+
+  def focus(): ApplyIso[A, A, A, A] = ApplyIso(value, Iso.id)
 }
 
 class GenApplyLensOpsImpl(val c: blackbox.Context) {

--- a/macro/src/main/scala-2.x/monocle/macros/syntax/all.scala
+++ b/macro/src/main/scala-2.x/monocle/macros/syntax/all.scala
@@ -1,3 +1,3 @@
 package monocle.macros.syntax
 
-object all extends GenApplyLensSyntax
+object all extends ApplyFocusSyntax

--- a/macro/src/main/scala-2.x/monocle/macros/syntax/lens.scala
+++ b/macro/src/main/scala-2.x/monocle/macros/syntax/lens.scala
@@ -1,3 +1,3 @@
 package monocle.macros.syntax
 
-object lens extends GenApplyLensSyntax
+object lens extends ApplyFocusSyntax

--- a/macro/src/main/scala-3.x/monocle/macros/syntax/ApplyFocusSyntax.scala
+++ b/macro/src/main/scala-3.x/monocle/macros/syntax/ApplyFocusSyntax.scala
@@ -1,0 +1,4 @@
+package monocle.macros.syntax
+
+// Do nothing, for compatibility with Scala 2
+trait ApplyFocusSyntax

--- a/test/shared/src/test/scala/monocle/FoldSpec.scala
+++ b/test/shared/src/test/scala/monocle/FoldSpec.scala
@@ -107,7 +107,7 @@ class FoldSpec extends MonocleSuite {
     val fold    = Fold.fromFoldable[List, Option[Int]]
 
     assertEquals(fold.some.getAll(numbers), List(1, 2))
-    assertEquals(numbers.optics.andThen(fold).some.getAll, List(1, 2))
+    assertEquals(numbers.focus().andThen(fold).some.getAll, List(1, 2))
   }
 
   test("withDefault") {
@@ -115,7 +115,7 @@ class FoldSpec extends MonocleSuite {
     val fold    = Fold.fromFoldable[List, Option[Int]]
 
     assertEquals(fold.withDefault(0).getAll(numbers), List(1, 0, 2, 0))
-    assertEquals(numbers.optics.andThen(fold).withDefault(0).getAll, List(1, 0, 2, 0))
+    assertEquals(numbers.focus().andThen(fold).withDefault(0).getAll, List(1, 0, 2, 0))
   }
 
   test("each") {
@@ -123,7 +123,7 @@ class FoldSpec extends MonocleSuite {
     val fold    = Fold.fromFoldable[List, List[Int]]
 
     assertEquals(fold.each.getAll(numbers), List(1, 2, 3, 4))
-    assertEquals(numbers.optics.andThen(fold).each.getAll, List(1, 2, 3, 4))
+    assertEquals(numbers.focus().andThen(fold).each.getAll, List(1, 2, 3, 4))
   }
 
   test("filter") {
@@ -131,7 +131,7 @@ class FoldSpec extends MonocleSuite {
     val fold    = Fold.fromFoldable[List, Int]
 
     assertEquals(fold.filter(_ > 1).getAll(numbers), List(2, 3))
-    assertEquals(numbers.optics.andThen(fold).filter(_ > 1).getAll, List(2, 3))
+    assertEquals(numbers.focus().andThen(fold).filter(_ > 1).getAll, List(2, 3))
   }
 
   test("filterIndex") {
@@ -139,7 +139,7 @@ class FoldSpec extends MonocleSuite {
     val fold  = Fold.fromFoldable[List, List[String]]
 
     assertEquals(fold.filterIndex((_: Int) > 0).getAll(words), List("world", "hi"))
-    assertEquals(words.optics.andThen(fold).filterIndex((_: Int) > 0).getAll, List("world", "hi"))
+    assertEquals(words.focus().andThen(fold).filterIndex((_: Int) > 0).getAll, List("world", "hi"))
   }
 
   test("at") {
@@ -147,29 +147,29 @@ class FoldSpec extends MonocleSuite {
     val sortedMapFold = Iso.id[immutable.SortedMap[Int, String]].asFold
     assertEquals(sortedMapFold.at(1).getAll(sortedMap), List(Some("one")))
     assertEquals(sortedMapFold.at(0).getAll(sortedMap), List(None))
-    assertEquals(sortedMap.optics.andThen(sortedMapFold).at(1).getAll, List(Some("one")))
-    assertEquals(sortedMap.optics.andThen(sortedMapFold).at(0).getAll, List(None))
+    assertEquals(sortedMap.focus().andThen(sortedMapFold).at(1).getAll, List(Some("one")))
+    assertEquals(sortedMap.focus().andThen(sortedMapFold).at(0).getAll, List(None))
 
     val listMap     = immutable.ListMap(1 -> "one")
     val listMapFold = Iso.id[immutable.ListMap[Int, String]].asFold
     assertEquals(listMapFold.at(1).getAll(listMap), List(Some("one")))
     assertEquals(listMapFold.at(0).getAll(listMap), List(None))
-    assertEquals(listMap.optics.andThen(listMapFold).at(1).getAll, List(Some("one")))
-    assertEquals(listMap.optics.andThen(listMapFold).at(0).getAll, List(None))
+    assertEquals(listMap.focus().andThen(listMapFold).at(1).getAll, List(Some("one")))
+    assertEquals(listMap.focus().andThen(listMapFold).at(0).getAll, List(None))
 
     val map     = immutable.Map(1 -> "one")
     val mapFold = Iso.id[Map[Int, String]].asFold
     assertEquals(mapFold.at(1).getAll(map), List(Some("one")))
     assertEquals(mapFold.at(0).getAll(map), List(None))
-    assertEquals(map.optics.andThen(mapFold).at(1).getAll, List(Some("one")))
-    assertEquals(map.optics.andThen(mapFold).at(0).getAll, List(None))
+    assertEquals(map.focus().andThen(mapFold).at(1).getAll, List(Some("one")))
+    assertEquals(map.focus().andThen(mapFold).at(0).getAll, List(None))
 
     val set     = Set(1)
     val setFold = Iso.id[Set[Int]].asFold
     assertEquals(setFold.at(1).getAll(set), List(true))
     assertEquals(setFold.at(0).getAll(set), List(false))
-    assertEquals(set.optics.andThen(setFold).at(1).getAll, List(true))
-    assertEquals(set.optics.andThen(setFold).at(0).getAll, List(false))
+    assertEquals(set.focus().andThen(setFold).at(1).getAll, List(true))
+    assertEquals(set.focus().andThen(setFold).at(0).getAll, List(false))
   }
 
   test("index") {
@@ -177,70 +177,70 @@ class FoldSpec extends MonocleSuite {
     val listFold = Iso.id[List[Int]].asFold
     assertEquals(listFold.index(0).getAll(list), List(1))
     assertEquals(listFold.index(1).getAll(list), Nil)
-    assertEquals(list.optics.andThen(listFold).index(0).getAll, List(1))
-    assertEquals(list.optics.andThen(listFold).index(1).getAll, Nil)
+    assertEquals(list.focus().andThen(listFold).index(0).getAll, List(1))
+    assertEquals(list.focus().andThen(listFold).index(1).getAll, Nil)
 
     val lazyList     = LazyList(1)
     val lazyListFold = Iso.id[LazyList[Int]].asFold
     assertEquals(lazyListFold.index(0).getAll(lazyList), List(1))
     assertEquals(lazyListFold.index(1).getAll(lazyList), Nil)
-    assertEquals(lazyList.optics.andThen(lazyListFold).index(0).getAll, List(1))
-    assertEquals(lazyList.optics.andThen(lazyListFold).index(1).getAll, Nil)
+    assertEquals(lazyList.focus().andThen(lazyListFold).index(0).getAll, List(1))
+    assertEquals(lazyList.focus().andThen(lazyListFold).index(1).getAll, Nil)
 
     val listMap     = immutable.ListMap(1 -> "one")
     val listMapFold = Iso.id[immutable.ListMap[Int, String]].asFold
     assertEquals(listMapFold.index(0).getAll(listMap), Nil)
     assertEquals(listMapFold.index(1).getAll(listMap), List("one"))
-    assertEquals(listMap.optics.andThen(listMapFold).index(0).getAll, Nil)
-    assertEquals(listMap.optics.andThen(listMapFold).index(1).getAll, List("one"))
+    assertEquals(listMap.focus().andThen(listMapFold).index(0).getAll, Nil)
+    assertEquals(listMap.focus().andThen(listMapFold).index(1).getAll, List("one"))
 
     val map     = Map(1 -> "one")
     val mapFold = Iso.id[Map[Int, String]].asFold
     assertEquals(mapFold.index(0).getAll(map), Nil)
     assertEquals(mapFold.index(1).getAll(map), List("one"))
-    assertEquals(map.optics.andThen(mapFold).index(0).getAll, Nil)
-    assertEquals(map.optics.andThen(mapFold).index(1).getAll, List("one"))
+    assertEquals(map.focus().andThen(mapFold).index(0).getAll, Nil)
+    assertEquals(map.focus().andThen(mapFold).index(1).getAll, List("one"))
 
     val sortedMap     = immutable.SortedMap(1 -> "one")
     val sortedMapFold = Iso.id[immutable.SortedMap[Int, String]].asFold
     assertEquals(sortedMapFold.index(0).getAll(sortedMap), Nil)
     assertEquals(sortedMapFold.index(1).getAll(sortedMap), List("one"))
-    assertEquals(sortedMap.optics.andThen(sortedMapFold).index(0).getAll, Nil)
-    assertEquals(sortedMap.optics.andThen(sortedMapFold).index(1).getAll, List("one"))
+    assertEquals(sortedMap.focus().andThen(sortedMapFold).index(0).getAll, Nil)
+    assertEquals(sortedMap.focus().andThen(sortedMapFold).index(1).getAll, List("one"))
 
     val vector     = Vector(1)
     val vectorFold = Iso.id[Vector[Int]].asFold
     assertEquals(vectorFold.index(0).getAll(vector), List(1))
     assertEquals(vectorFold.index(1).getAll(vector), Nil)
-    assertEquals(vector.optics.andThen(vectorFold).index(0).getAll, List(1))
-    assertEquals(vector.optics.andThen(vectorFold).index(1).getAll, Nil)
+    assertEquals(vector.focus().andThen(vectorFold).index(0).getAll, List(1))
+    assertEquals(vector.focus().andThen(vectorFold).index(1).getAll, Nil)
 
     val chain     = Chain.one(1)
     val chainFold = Iso.id[Chain[Int]].asFold
     assertEquals(chainFold.index(0).getAll(chain), List(1))
     assertEquals(chainFold.index(1).getAll(chain), Nil)
-    assertEquals(chain.optics.andThen(chainFold).index(0).getAll, List(1))
-    assertEquals(chain.optics.andThen(chainFold).index(1).getAll, Nil)
+    assertEquals(chain.focus().andThen(chainFold).index(0).getAll, List(1))
+    assertEquals(chain.focus().andThen(chainFold).index(1).getAll, Nil)
 
     val nec     = NonEmptyChain.one(1)
     val necFold = Iso.id[NonEmptyChain[Int]].asFold
     assertEquals(necFold.index(0).getAll(nec), List(1))
     assertEquals(necFold.index(1).getAll(nec), Nil)
-    assertEquals(nec.optics.andThen(necFold).index(0).getAll, List(1))
-    assertEquals(nec.optics.andThen(necFold).index(1).getAll, Nil)
+    assertEquals(nec.focus().andThen(necFold).index(0).getAll, List(1))
+    assertEquals(nec.focus().andThen(necFold).index(1).getAll, Nil)
 
     val nev     = NonEmptyVector.one(1)
     val nevFold = Iso.id[NonEmptyVector[Int]].asFold
     assertEquals(nevFold.index(0).getAll(nev), List(1))
     assertEquals(nevFold.index(1).getAll(nev), Nil)
-    assertEquals(nev.optics.andThen(nevFold).index(0).getAll, List(1))
-    assertEquals(nev.optics.andThen(nevFold).index(1).getAll, Nil)
+    assertEquals(nev.focus().andThen(nevFold).index(0).getAll, List(1))
+    assertEquals(nev.focus().andThen(nevFold).index(1).getAll, Nil)
 
     val nel     = NonEmptyList.one(1)
     val nelFold = Iso.id[NonEmptyList[Int]].asFold
     assertEquals(nelFold.index(0).getAll(nel), List(1))
     assertEquals(nelFold.index(1).getAll(nel), Nil)
-    assertEquals(nel.optics.andThen(nelFold).index(0).getAll, List(1))
-    assertEquals(nel.optics.andThen(nelFold).index(1).getAll, Nil)
+    assertEquals(nel.focus().andThen(nelFold).index(0).getAll, List(1))
+    assertEquals(nel.focus().andThen(nelFold).index(1).getAll, Nil)
   }
 }

--- a/test/shared/src/test/scala/monocle/GetterSpec.scala
+++ b/test/shared/src/test/scala/monocle/GetterSpec.scala
@@ -82,7 +82,7 @@ class GetterSpec extends MonocleSuite {
     val getter = Getter((_: SomeTest).y)
 
     assertEquals(getter.some.getAll(obj), List(2))
-    assertEquals(obj.optics.andThen(getter).some.getAll, List(2))
+    assertEquals(obj.focus().andThen(getter).some.getAll, List(2))
   }
 
   test("withDefault") {
@@ -95,8 +95,8 @@ class GetterSpec extends MonocleSuite {
     assertEquals(getter.withDefault(0).get(objSome), 2)
     assertEquals(getter.withDefault(0).get(objNone), 0)
 
-    assertEquals(objSome.optics.andThen(getter).withDefault(0).get, 2)
-    assertEquals(objNone.optics.andThen(getter).withDefault(0).get, 0)
+    assertEquals(objSome.focus().andThen(getter).withDefault(0).get, 2)
+    assertEquals(objNone.focus().andThen(getter).withDefault(0).get, 0)
   }
 
   test("each") {
@@ -106,7 +106,7 @@ class GetterSpec extends MonocleSuite {
     val getter = Getter((_: SomeTest).y)
 
     assertEquals(getter.each.getAll(obj), List(1, 2, 3))
-    assertEquals(obj.optics.andThen(getter).each.getAll, List(1, 2, 3))
+    assertEquals(obj.focus().andThen(getter).each.getAll, List(1, 2, 3))
   }
 
   test("filter") {
@@ -116,7 +116,7 @@ class GetterSpec extends MonocleSuite {
     val getter = Getter[SomeTest, Int](_.y)
 
     assertEquals(getter.filter(_ > 0).getAll(obj), List(2))
-    assertEquals(obj.optics.andThen(getter).filter(_ > 0).getAll, List(2))
+    assertEquals(obj.focus().andThen(getter).filter(_ > 0).getAll, List(2))
   }
 
   test("filterIndex") {
@@ -126,7 +126,7 @@ class GetterSpec extends MonocleSuite {
     val getter = Getter[SomeTest, List[String]](_.y)
 
     assertEquals(getter.filterIndex((_: Int) > 0).getAll(obj), List("world"))
-    assertEquals(obj.optics.andThen(getter).filterIndex((_: Int) > 0).getAll, List("world"))
+    assertEquals(obj.focus().andThen(getter).filterIndex((_: Int) > 0).getAll, List("world"))
   }
 
   test("at") {
@@ -134,29 +134,29 @@ class GetterSpec extends MonocleSuite {
     val sortedMapGetter = Iso.id[immutable.SortedMap[Int, String]].asGetter
     assertEquals(sortedMapGetter.at(1).get(sortedMap), Some("one"))
     assertEquals(sortedMapGetter.at(0).get(sortedMap), None)
-    assertEquals(sortedMap.optics.andThen(sortedMapGetter).at(1).get, Some("one"))
-    assertEquals(sortedMap.optics.andThen(sortedMapGetter).at(0).get, None)
+    assertEquals(sortedMap.focus().andThen(sortedMapGetter).at(1).get, Some("one"))
+    assertEquals(sortedMap.focus().andThen(sortedMapGetter).at(0).get, None)
 
     val listMap       = immutable.ListMap(1 -> "one")
     val listMapGetter = Iso.id[immutable.ListMap[Int, String]].asGetter
     assertEquals(listMapGetter.at(1).get(listMap), Some("one"))
     assertEquals(listMapGetter.at(0).get(listMap), None)
-    assertEquals(listMap.optics.andThen(listMapGetter).at(1).get, Some("one"))
-    assertEquals(listMap.optics.andThen(listMapGetter).at(0).get, None)
+    assertEquals(listMap.focus().andThen(listMapGetter).at(1).get, Some("one"))
+    assertEquals(listMap.focus().andThen(listMapGetter).at(0).get, None)
 
     val map       = immutable.Map(1 -> "one")
     val mapGetter = Iso.id[Map[Int, String]].asGetter
     assertEquals(mapGetter.at(1).get(map), Some("one"))
     assertEquals(mapGetter.at(0).get(map), None)
-    assertEquals(map.optics.andThen(mapGetter).at(1).get, Some("one"))
-    assertEquals(map.optics.andThen(mapGetter).at(0).get, None)
+    assertEquals(map.focus().andThen(mapGetter).at(1).get, Some("one"))
+    assertEquals(map.focus().andThen(mapGetter).at(0).get, None)
 
     val set       = Set(1)
     val setGetter = Iso.id[Set[Int]].asGetter
     assertEquals(setGetter.at(1).get(set), true)
     assertEquals(setGetter.at(0).get(set), false)
-    assertEquals(set.optics.andThen(setGetter).at(1).get, true)
-    assertEquals(set.optics.andThen(setGetter).at(0).get, false)
+    assertEquals(set.focus().andThen(setGetter).at(1).get, true)
+    assertEquals(set.focus().andThen(setGetter).at(0).get, false)
   }
 
   test("index") {
@@ -164,70 +164,70 @@ class GetterSpec extends MonocleSuite {
     val listGetter = Iso.id[List[Int]].asGetter
     assertEquals(listGetter.index(0).getAll(list), List(1))
     assertEquals(listGetter.index(1).getAll(list), Nil)
-    assertEquals(list.optics.andThen(listGetter).index(0).getAll, List(1))
-    assertEquals(list.optics.andThen(listGetter).index(1).getAll, Nil)
+    assertEquals(list.focus().andThen(listGetter).index(0).getAll, List(1))
+    assertEquals(list.focus().andThen(listGetter).index(1).getAll, Nil)
 
     val lazyList       = LazyList(1)
     val lazyListGetter = Iso.id[LazyList[Int]].asGetter
     assertEquals(lazyListGetter.index(0).getAll(lazyList), List(1))
     assertEquals(lazyListGetter.index(1).getAll(lazyList), Nil)
-    assertEquals(lazyList.optics.andThen(lazyListGetter).index(0).getAll, List(1))
-    assertEquals(lazyList.optics.andThen(lazyListGetter).index(1).getAll, Nil)
+    assertEquals(lazyList.focus().andThen(lazyListGetter).index(0).getAll, List(1))
+    assertEquals(lazyList.focus().andThen(lazyListGetter).index(1).getAll, Nil)
 
     val listMap       = immutable.ListMap(1 -> "one")
     val listMapGetter = Iso.id[immutable.ListMap[Int, String]].asGetter
     assertEquals(listMapGetter.index(0).getAll(listMap), Nil)
     assertEquals(listMapGetter.index(1).getAll(listMap), List("one"))
-    assertEquals(listMap.optics.andThen(listMapGetter).index(0).getAll, Nil)
-    assertEquals(listMap.optics.andThen(listMapGetter).index(1).getAll, List("one"))
+    assertEquals(listMap.focus().andThen(listMapGetter).index(0).getAll, Nil)
+    assertEquals(listMap.focus().andThen(listMapGetter).index(1).getAll, List("one"))
 
     val map       = Map(1 -> "one")
     val mapGetter = Iso.id[Map[Int, String]].asGetter
     assertEquals(mapGetter.index(0).getAll(map), Nil)
     assertEquals(mapGetter.index(1).getAll(map), List("one"))
-    assertEquals(map.optics.andThen(mapGetter).index(0).getAll, Nil)
-    assertEquals(map.optics.andThen(mapGetter).index(1).getAll, List("one"))
+    assertEquals(map.focus().andThen(mapGetter).index(0).getAll, Nil)
+    assertEquals(map.focus().andThen(mapGetter).index(1).getAll, List("one"))
 
     val sortedMap       = immutable.SortedMap(1 -> "one")
     val sortedMapGetter = Iso.id[immutable.SortedMap[Int, String]].asGetter
     assertEquals(sortedMapGetter.index(0).getAll(sortedMap), Nil)
     assertEquals(sortedMapGetter.index(1).getAll(sortedMap), List("one"))
-    assertEquals(sortedMap.optics.andThen(sortedMapGetter).index(0).getAll, Nil)
-    assertEquals(sortedMap.optics.andThen(sortedMapGetter).index(1).getAll, List("one"))
+    assertEquals(sortedMap.focus().andThen(sortedMapGetter).index(0).getAll, Nil)
+    assertEquals(sortedMap.focus().andThen(sortedMapGetter).index(1).getAll, List("one"))
 
     val vector       = Vector(1)
     val vectorGetter = Iso.id[Vector[Int]].asGetter
     assertEquals(vectorGetter.index(0).getAll(vector), List(1))
     assertEquals(vectorGetter.index(1).getAll(vector), Nil)
-    assertEquals(vector.optics.andThen(vectorGetter).index(0).getAll, List(1))
-    assertEquals(vector.optics.andThen(vectorGetter).index(1).getAll, Nil)
+    assertEquals(vector.focus().andThen(vectorGetter).index(0).getAll, List(1))
+    assertEquals(vector.focus().andThen(vectorGetter).index(1).getAll, Nil)
 
     val chain       = Chain.one(1)
     val chainGetter = Iso.id[Chain[Int]].asGetter
     assertEquals(chainGetter.index(0).getAll(chain), List(1))
     assertEquals(chainGetter.index(1).getAll(chain), Nil)
-    assertEquals(chain.optics.andThen(chainGetter).index(0).getAll, List(1))
-    assertEquals(chain.optics.andThen(chainGetter).index(1).getAll, Nil)
+    assertEquals(chain.focus().andThen(chainGetter).index(0).getAll, List(1))
+    assertEquals(chain.focus().andThen(chainGetter).index(1).getAll, Nil)
 
     val nec       = NonEmptyChain.one(1)
     val necGetter = Iso.id[NonEmptyChain[Int]].asGetter
     assertEquals(necGetter.index(0).getAll(nec), List(1))
     assertEquals(necGetter.index(1).getAll(nec), Nil)
-    assertEquals(nec.optics.andThen(necGetter).index(0).getAll, List(1))
-    assertEquals(nec.optics.andThen(necGetter).index(1).getAll, Nil)
+    assertEquals(nec.focus().andThen(necGetter).index(0).getAll, List(1))
+    assertEquals(nec.focus().andThen(necGetter).index(1).getAll, Nil)
 
     val nev       = NonEmptyVector.one(1)
     val nevGetter = Iso.id[NonEmptyVector[Int]].asGetter
     assertEquals(nevGetter.index(0).getAll(nev), List(1))
     assertEquals(nevGetter.index(1).getAll(nev), Nil)
-    assertEquals(nev.optics.andThen(nevGetter).index(0).getAll, List(1))
-    assertEquals(nev.optics.andThen(nevGetter).index(1).getAll, Nil)
+    assertEquals(nev.focus().andThen(nevGetter).index(0).getAll, List(1))
+    assertEquals(nev.focus().andThen(nevGetter).index(1).getAll, Nil)
 
     val nel       = NonEmptyList.one(1)
     val nelGetter = Iso.id[NonEmptyList[Int]].asGetter
     assertEquals(nelGetter.index(0).getAll(nel), List(1))
     assertEquals(nelGetter.index(1).getAll(nel), Nil)
-    assertEquals(nel.optics.andThen(nelGetter).index(0).getAll, List(1))
-    assertEquals(nel.optics.andThen(nelGetter).index(1).getAll, Nil)
+    assertEquals(nel.focus().andThen(nelGetter).index(0).getAll, List(1))
+    assertEquals(nel.focus().andThen(nelGetter).index(1).getAll, Nil)
   }
 }

--- a/test/shared/src/test/scala/monocle/IsoSpec.scala
+++ b/test/shared/src/test/scala/monocle/IsoSpec.scala
@@ -148,7 +148,7 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     val iso = Iso[SomeTest, Option[Int]](_.y)(SomeTest.apply)
 
     assertEquals(iso.some.getOption(obj), Some(2))
-    assertEquals(obj.optics.andThen(iso).some.getOption, Some(2))
+    assertEquals(obj.focus().andThen(iso).some.getOption, Some(2))
   }
 
   test("withDefault") {
@@ -161,7 +161,7 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     assertEquals(iso.withDefault(0).get(objSome), 2)
     assertEquals(iso.withDefault(0).get(objNone), 0)
 
-    assertEquals(objNone.optics.andThen(iso).withDefault(0).get, 0)
+    assertEquals(objNone.focus().andThen(iso).withDefault(0).get, 0)
   }
 
   test("each") {
@@ -171,7 +171,7 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     val iso = Iso[SomeTest, List[Int]](_.y)(SomeTest.apply)
 
     assertEquals(iso.each.getAll(obj), List(1, 2, 3))
-    assertEquals(obj.optics.andThen(iso).each.getAll, List(1, 2, 3))
+    assertEquals(obj.focus().andThen(iso).each.getAll, List(1, 2, 3))
   }
 
   test("filter") {
@@ -181,7 +181,7 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     val iso = Iso[SomeTest, Int](_.y)(SomeTest.apply)
 
     assertEquals(iso.filter(_ > 0).getOption(obj), Some(2))
-    assertEquals(obj.optics.andThen(iso).filter(_ > 0).getOption, Some(2))
+    assertEquals(obj.focus().andThen(iso).filter(_ > 0).getOption, Some(2))
   }
 
   test("filterIndex") {
@@ -191,7 +191,7 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     val iso = Iso[SomeTest, List[String]](_.y)(SomeTest.apply)
 
     assertEquals(iso.filterIndex((_: Int) > 0).getAll(obj), List("world"))
-    assertEquals(obj.optics.andThen(iso).filterIndex((_: Int) > 0).getAll, List("world"))
+    assertEquals(obj.focus().andThen(iso).filterIndex((_: Int) > 0).getAll, List("world"))
   }
 
   test("at") {
@@ -199,29 +199,29 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     val sortedMapLens = Iso.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapLens.at(1).get(sortedMap), Some("one"))
     assertEquals(sortedMapLens.at(2).get(sortedMap), None)
-    assertEquals(sortedMap.optics.andThen(sortedMapLens).at(1).get, Some("one"))
-    assertEquals(sortedMap.optics.andThen(sortedMapLens).at(2).get, None)
+    assertEquals(sortedMap.focus().andThen(sortedMapLens).at(1).get, Some("one"))
+    assertEquals(sortedMap.focus().andThen(sortedMapLens).at(2).get, None)
 
     val listMap     = immutable.ListMap(1 -> "one")
     val listMapLens = Iso.id[immutable.ListMap[Int, String]]
     assertEquals(listMapLens.at(1).get(listMap), Some("one"))
     assertEquals(listMapLens.at(2).get(listMap), None)
-    assertEquals(listMap.optics.andThen(listMapLens).at(1).get, Some("one"))
-    assertEquals(listMap.optics.andThen(listMapLens).at(2).get, None)
+    assertEquals(listMap.focus().andThen(listMapLens).at(1).get, Some("one"))
+    assertEquals(listMap.focus().andThen(listMapLens).at(2).get, None)
 
     val map     = immutable.Map(1 -> "one")
     val mapLens = Iso.id[Map[Int, String]]
     assertEquals(mapLens.at(1).get(map), Some("one"))
     assertEquals(mapLens.at(2).get(map), None)
-    assertEquals(map.optics.andThen(mapLens).at(1).get, Some("one"))
-    assertEquals(map.optics.andThen(mapLens).at(2).get, None)
+    assertEquals(map.focus().andThen(mapLens).at(1).get, Some("one"))
+    assertEquals(map.focus().andThen(mapLens).at(2).get, None)
 
     val set     = Set(1)
     val setLens = Iso.id[Set[Int]]
     assertEquals(setLens.at(1).get(set), true)
     assertEquals(setLens.at(2).get(set), false)
-    assertEquals(set.optics.andThen(setLens).at(1).get, true)
-    assertEquals(set.optics.andThen(setLens).at(2).get, false)
+    assertEquals(set.focus().andThen(setLens).at(1).get, true)
+    assertEquals(set.focus().andThen(setLens).at(2).get, false)
   }
 
   test("index") {
@@ -229,70 +229,70 @@ assertEquals(    (Nullary() match { case _nullary(unit) => unit }) ,  (()))
     val listLens = Iso.id[List[Int]]
     assertEquals(listLens.index(0).getOption(list), Some(1))
     assertEquals(listLens.index(1).getOption(list), None)
-    assertEquals(list.optics.andThen(listLens).index(0).getOption, Some(1))
-    assertEquals(list.optics.andThen(listLens).index(1).getOption, None)
+    assertEquals(list.focus().andThen(listLens).index(0).getOption, Some(1))
+    assertEquals(list.focus().andThen(listLens).index(1).getOption, None)
 
     val lazyList     = LazyList(1)
     val lazyListLens = Iso.id[LazyList[Int]]
     assertEquals(lazyListLens.index(0).getOption(lazyList), Some(1))
     assertEquals(lazyListLens.index(1).getOption(lazyList), None)
-    assertEquals(lazyList.optics.andThen(lazyListLens).index(0).getOption, Some(1))
-    assertEquals(lazyList.optics.andThen(lazyListLens).index(1).getOption, None)
+    assertEquals(lazyList.focus().andThen(lazyListLens).index(0).getOption, Some(1))
+    assertEquals(lazyList.focus().andThen(lazyListLens).index(1).getOption, None)
 
     val listMap     = immutable.ListMap(1 -> "one")
     val listMapLens = Iso.id[immutable.ListMap[Int, String]]
     assertEquals(listMapLens.index(0).getOption(listMap), None)
     assertEquals(listMapLens.index(1).getOption(listMap), Some("one"))
-    assertEquals(listMap.optics.andThen(listMapLens).index(0).getOption, None)
-    assertEquals(listMap.optics.andThen(listMapLens).index(1).getOption, Some("one"))
+    assertEquals(listMap.focus().andThen(listMapLens).index(0).getOption, None)
+    assertEquals(listMap.focus().andThen(listMapLens).index(1).getOption, Some("one"))
 
     val map     = Map(1 -> "one")
     val mapLens = Iso.id[Map[Int, String]]
     assertEquals(mapLens.index(1).getOption(map), Some("one"))
     assertEquals(mapLens.index(0).getOption(map), None)
-    assertEquals(map.optics.andThen(mapLens).index(1).getOption, Some("one"))
-    assertEquals(map.optics.andThen(mapLens).index(0).getOption, None)
+    assertEquals(map.focus().andThen(mapLens).index(1).getOption, Some("one"))
+    assertEquals(map.focus().andThen(mapLens).index(0).getOption, None)
 
     val sortedMap     = immutable.SortedMap(1 -> "one")
     val sortedMapLens = Iso.id[immutable.SortedMap[Int, String]]
     assertEquals(sortedMapLens.index(1).getOption(sortedMap), Some("one"))
     assertEquals(sortedMapLens.index(0).getOption(sortedMap), None)
-    assertEquals(sortedMap.optics.andThen(sortedMapLens).index(1).getOption, Some("one"))
-    assertEquals(sortedMap.optics.andThen(sortedMapLens).index(0).getOption, None)
+    assertEquals(sortedMap.focus().andThen(sortedMapLens).index(1).getOption, Some("one"))
+    assertEquals(sortedMap.focus().andThen(sortedMapLens).index(0).getOption, None)
 
     val vector     = Vector(1)
     val vectorLens = Iso.id[Vector[Int]]
     assertEquals(vectorLens.index(0).getOption(vector), Some(1))
     assertEquals(vectorLens.index(1).getOption(vector), None)
-    assertEquals(vector.optics.andThen(vectorLens).index(0).getOption, Some(1))
-    assertEquals(vector.optics.andThen(vectorLens).index(1).getOption, None)
+    assertEquals(vector.focus().andThen(vectorLens).index(0).getOption, Some(1))
+    assertEquals(vector.focus().andThen(vectorLens).index(1).getOption, None)
 
     val chain     = Chain.one(1)
     val chainLens = Iso.id[Chain[Int]]
     assertEquals(chainLens.index(0).getOption(chain), Some(1))
     assertEquals(chainLens.index(1).getOption(chain), None)
-    assertEquals(chain.optics.andThen(chainLens).index(0).getOption, Some(1))
-    assertEquals(chain.optics.andThen(chainLens).index(1).getOption, None)
+    assertEquals(chain.focus().andThen(chainLens).index(0).getOption, Some(1))
+    assertEquals(chain.focus().andThen(chainLens).index(1).getOption, None)
 
     val nec     = NonEmptyChain.one(1)
     val necLens = Iso.id[NonEmptyChain[Int]]
     assertEquals(necLens.index(0).getOption(nec), Some(1))
     assertEquals(necLens.index(1).getOption(nec), None)
-    assertEquals(nec.optics.andThen(necLens).index(0).getOption, Some(1))
-    assertEquals(nec.optics.andThen(necLens).index(1).getOption, None)
+    assertEquals(nec.focus().andThen(necLens).index(0).getOption, Some(1))
+    assertEquals(nec.focus().andThen(necLens).index(1).getOption, None)
 
     val nev     = NonEmptyVector.one(1)
     val nevLens = Iso.id[NonEmptyVector[Int]]
     assertEquals(nevLens.index(0).getOption(nev), Some(1))
     assertEquals(nevLens.index(1).getOption(nev), None)
-    assertEquals(nev.optics.andThen(nevLens).index(0).getOption, Some(1))
-    assertEquals(nev.optics.andThen(nevLens).index(1).getOption, None)
+    assertEquals(nev.focus().andThen(nevLens).index(0).getOption, Some(1))
+    assertEquals(nev.focus().andThen(nevLens).index(1).getOption, None)
 
     val nel     = NonEmptyList.one(1)
     val nelLens = Iso.id[NonEmptyList[Int]]
     assertEquals(nelLens.index(0).getOption(nel), Some(1))
     assertEquals(nelLens.index(1).getOption(nel), None)
-    assertEquals(nel.optics.andThen(nelLens).index(0).getOption, Some(1))
-    assertEquals(nel.optics.andThen(nelLens).index(1).getOption, None)
+    assertEquals(nel.focus().andThen(nelLens).index(0).getOption, Some(1))
+    assertEquals(nel.focus().andThen(nelLens).index(1).getOption, None)
   }
 }

--- a/test/shared/src/test/scala/monocle/LensSpec.scala
+++ b/test/shared/src/test/scala/monocle/LensSpec.scala
@@ -84,7 +84,7 @@ class LensSpec extends MonocleSuite {
     val lens = Lens((_: SomeTest).y)(newValue => _.copy(y = newValue))
 
     assertEquals(lens.some.getOption(obj), Some(2))
-    assertEquals(obj.optics.andThen(lens).some.getOption, Some(2))
+    assertEquals(obj.focus().andThen(lens).some.getOption, Some(2))
   }
 
   test("withDefault") {
@@ -97,7 +97,7 @@ class LensSpec extends MonocleSuite {
     assertEquals(lens.withDefault(0).get(objSome), 2)
     assertEquals(lens.withDefault(0).get(objNone), 0)
 
-    assertEquals(objNone.optics.andThen(lens).withDefault(0).get, 0)
+    assertEquals(objNone.focus().andThen(lens).withDefault(0).get, 0)
   }
 
   test("each") {
@@ -107,7 +107,7 @@ class LensSpec extends MonocleSuite {
     val lens = Lens((_: SomeTest).y)(newValue => _.copy(y = newValue))
 
     assertEquals(lens.each.getAll(obj), List(1, 2, 3))
-    assertEquals(obj.optics.andThen(lens).each.getAll, List(1, 2, 3))
+    assertEquals(obj.focus().andThen(lens).each.getAll, List(1, 2, 3))
   }
 
   test("filter") {
@@ -117,7 +117,7 @@ class LensSpec extends MonocleSuite {
     val lens = Lens((_: SomeTest).y)(newValue => _.copy(y = newValue))
 
     assertEquals(lens.filter(_ > 0).getOption(obj), Some(2))
-    assertEquals(obj.optics.andThen(lens).filter(_ > 0).getOption, Some(2))
+    assertEquals(obj.focus().andThen(lens).filter(_ > 0).getOption, Some(2))
   }
 
   test("filterIndex") {
@@ -127,7 +127,7 @@ class LensSpec extends MonocleSuite {
     val lens = Lens((_: SomeTest).y)(newValue => _.copy(y = newValue))
 
     assertEquals(lens.filterIndex((_: Int) > 0).getAll(obj), List("world"))
-    assertEquals(obj.optics.andThen(lens).filterIndex((_: Int) > 0).getAll, List("world"))
+    assertEquals(obj.focus().andThen(lens).filterIndex((_: Int) > 0).getAll, List("world"))
   }
 
   test("at") {
@@ -135,29 +135,29 @@ class LensSpec extends MonocleSuite {
     val sortedMapLens = Iso.id[immutable.SortedMap[Int, String]].asLens
     assertEquals(sortedMapLens.at(1).get(sortedMap), Some("one"))
     assertEquals(sortedMapLens.at(2).get(sortedMap), None)
-    assertEquals(sortedMap.optics.andThen(sortedMapLens).at(1).get, Some("one"))
-    assertEquals(sortedMap.optics.andThen(sortedMapLens).at(2).get, None)
+    assertEquals(sortedMap.focus().andThen(sortedMapLens).at(1).get, Some("one"))
+    assertEquals(sortedMap.focus().andThen(sortedMapLens).at(2).get, None)
 
     val listMap     = immutable.ListMap(1 -> "one")
     val listMapLens = Iso.id[immutable.ListMap[Int, String]].asLens
     assertEquals(listMapLens.at(1).get(listMap), Some("one"))
     assertEquals(listMapLens.at(2).get(listMap), None)
-    assertEquals(listMap.optics.andThen(listMapLens).at(1).get, Some("one"))
-    assertEquals(listMap.optics.andThen(listMapLens).at(2).get, None)
+    assertEquals(listMap.focus().andThen(listMapLens).at(1).get, Some("one"))
+    assertEquals(listMap.focus().andThen(listMapLens).at(2).get, None)
 
     val map     = immutable.Map(1 -> "one")
     val mapLens = Iso.id[Map[Int, String]].asLens
     assertEquals(mapLens.at(1).get(map), Some("one"))
     assertEquals(mapLens.at(2).get(map), None)
-    assertEquals(map.optics.andThen(mapLens).at(1).get, Some("one"))
-    assertEquals(map.optics.andThen(mapLens).at(2).get, None)
+    assertEquals(map.focus().andThen(mapLens).at(1).get, Some("one"))
+    assertEquals(map.focus().andThen(mapLens).at(2).get, None)
 
     val set     = Set(1)
     val setLens = Iso.id[Set[Int]].asLens
     assertEquals(setLens.at(1).get(set), true)
     assertEquals(setLens.at(2).get(set), false)
-    assertEquals(set.optics.andThen(setLens).at(1).get, true)
-    assertEquals(set.optics.andThen(setLens).at(2).get, false)
+    assertEquals(set.focus().andThen(setLens).at(1).get, true)
+    assertEquals(set.focus().andThen(setLens).at(2).get, false)
   }
 
   test("index") {
@@ -165,70 +165,70 @@ class LensSpec extends MonocleSuite {
     val listLens = Iso.id[List[Int]].asLens
     assertEquals(listLens.index(0).getOption(list), Some(1))
     assertEquals(listLens.index(1).getOption(list), None)
-    assertEquals(list.optics.andThen(listLens).index(0).getOption, Some(1))
-    assertEquals(list.optics.andThen(listLens).index(1).getOption, None)
+    assertEquals(list.focus().andThen(listLens).index(0).getOption, Some(1))
+    assertEquals(list.focus().andThen(listLens).index(1).getOption, None)
 
     val lazyList     = LazyList(1)
     val lazyListLens = Iso.id[LazyList[Int]].asLens
     assertEquals(lazyListLens.index(0).getOption(lazyList), Some(1))
     assertEquals(lazyListLens.index(1).getOption(lazyList), None)
-    assertEquals(lazyList.optics.andThen(lazyListLens).index(0).getOption, Some(1))
-    assertEquals(lazyList.optics.andThen(lazyListLens).index(1).getOption, None)
+    assertEquals(lazyList.focus().andThen(lazyListLens).index(0).getOption, Some(1))
+    assertEquals(lazyList.focus().andThen(lazyListLens).index(1).getOption, None)
 
     val listMap     = immutable.ListMap(1 -> "one")
     val listMapLens = Iso.id[immutable.ListMap[Int, String]].asLens
     assertEquals(listMapLens.index(0).getOption(listMap), None)
     assertEquals(listMapLens.index(1).getOption(listMap), Some("one"))
-    assertEquals(listMap.optics.andThen(listMapLens).index(0).getOption, None)
-    assertEquals(listMap.optics.andThen(listMapLens).index(1).getOption, Some("one"))
+    assertEquals(listMap.focus().andThen(listMapLens).index(0).getOption, None)
+    assertEquals(listMap.focus().andThen(listMapLens).index(1).getOption, Some("one"))
 
     val map     = Map(1 -> "one")
     val mapLens = Iso.id[Map[Int, String]].asLens
     assertEquals(mapLens.index(1).getOption(map), Some("one"))
     assertEquals(mapLens.index(0).getOption(map), None)
-    assertEquals(map.optics.andThen(mapLens).index(1).getOption, Some("one"))
-    assertEquals(map.optics.andThen(mapLens).index(0).getOption, None)
+    assertEquals(map.focus().andThen(mapLens).index(1).getOption, Some("one"))
+    assertEquals(map.focus().andThen(mapLens).index(0).getOption, None)
 
     val sortedMap     = immutable.SortedMap(1 -> "one")
     val sortedMapLens = Iso.id[immutable.SortedMap[Int, String]].asLens
     assertEquals(sortedMapLens.index(1).getOption(sortedMap), Some("one"))
     assertEquals(sortedMapLens.index(0).getOption(sortedMap), None)
-    assertEquals(sortedMap.optics.andThen(sortedMapLens).index(1).getOption, Some("one"))
-    assertEquals(sortedMap.optics.andThen(sortedMapLens).index(0).getOption, None)
+    assertEquals(sortedMap.focus().andThen(sortedMapLens).index(1).getOption, Some("one"))
+    assertEquals(sortedMap.focus().andThen(sortedMapLens).index(0).getOption, None)
 
     val vector     = Vector(1)
     val vectorLens = Iso.id[Vector[Int]].asLens
     assertEquals(vectorLens.index(0).getOption(vector), Some(1))
     assertEquals(vectorLens.index(1).getOption(vector), None)
-    assertEquals(vector.optics.andThen(vectorLens).index(0).getOption, Some(1))
-    assertEquals(vector.optics.andThen(vectorLens).index(1).getOption, None)
+    assertEquals(vector.focus().andThen(vectorLens).index(0).getOption, Some(1))
+    assertEquals(vector.focus().andThen(vectorLens).index(1).getOption, None)
 
     val chain     = Chain.one(1)
     val chainLens = Iso.id[Chain[Int]].asLens
     assertEquals(chainLens.index(0).getOption(chain), Some(1))
     assertEquals(chainLens.index(1).getOption(chain), None)
-    assertEquals(chain.optics.andThen(chainLens).index(0).getOption, Some(1))
-    assertEquals(chain.optics.andThen(chainLens).index(1).getOption, None)
+    assertEquals(chain.focus().andThen(chainLens).index(0).getOption, Some(1))
+    assertEquals(chain.focus().andThen(chainLens).index(1).getOption, None)
 
     val nec     = NonEmptyChain.one(1)
     val necLens = Iso.id[NonEmptyChain[Int]].asLens
     assertEquals(necLens.index(0).getOption(nec), Some(1))
     assertEquals(necLens.index(1).getOption(nec), None)
-    assertEquals(nec.optics.andThen(necLens).index(0).getOption, Some(1))
-    assertEquals(nec.optics.andThen(necLens).index(1).getOption, None)
+    assertEquals(nec.focus().andThen(necLens).index(0).getOption, Some(1))
+    assertEquals(nec.focus().andThen(necLens).index(1).getOption, None)
 
     val nev     = NonEmptyVector.one(1)
     val nevLens = Iso.id[NonEmptyVector[Int]].asLens
     assertEquals(nevLens.index(0).getOption(nev), Some(1))
     assertEquals(nevLens.index(1).getOption(nev), None)
-    assertEquals(nev.optics.andThen(nevLens).index(0).getOption, Some(1))
-    assertEquals(nev.optics.andThen(nevLens).index(1).getOption, None)
+    assertEquals(nev.focus().andThen(nevLens).index(0).getOption, Some(1))
+    assertEquals(nev.focus().andThen(nevLens).index(1).getOption, None)
 
     val nel     = NonEmptyList.one(1)
     val nelLens = Iso.id[NonEmptyList[Int]].asLens
     assertEquals(nelLens.index(0).getOption(nel), Some(1))
     assertEquals(nelLens.index(1).getOption(nel), None)
-    assertEquals(nel.optics.andThen(nelLens).index(0).getOption, Some(1))
-    assertEquals(nel.optics.andThen(nelLens).index(1).getOption, None)
+    assertEquals(nel.focus().andThen(nelLens).index(0).getOption, Some(1))
+    assertEquals(nel.focus().andThen(nelLens).index(1).getOption, None)
   }
 }

--- a/test/shared/src/test/scala/monocle/MonocleSuite.scala
+++ b/test/shared/src/test/scala/monocle/MonocleSuite.scala
@@ -1,6 +1,7 @@
 package monocle
 
 import monocle.function.GenericOptics
+import monocle.macros.syntax.ApplyFocusSyntax
 import monocle.state._
 import monocle.std.StdInstances
 import monocle.syntax.Syntaxes
@@ -10,6 +11,7 @@ trait MonocleSuite
     extends DisciplineSuite
     with TestInstances
     with StdInstances
+    with ApplyFocusSyntax
     with GenericOptics
     with Syntaxes
     with StateLensSyntax

--- a/test/shared/src/test/scala/monocle/OptionalSpec.scala
+++ b/test/shared/src/test/scala/monocle/OptionalSpec.scala
@@ -148,7 +148,7 @@ class OptionalSpec extends MonocleSuite {
     val optional = Lens((_: SomeTest).y)(newValue => _.copy(y = newValue)).asOptional
 
     assertEquals(optional.some.getOption(obj), Some(2))
-    assertEquals(obj.optics.andThen(optional).some.getOption, Some(2))
+    assertEquals(obj.focus().andThen(optional).some.getOption, Some(2))
   }
 
   test("withDefault") {
@@ -161,7 +161,7 @@ class OptionalSpec extends MonocleSuite {
     assertEquals(optional.withDefault(0).getOption(objSome), Some(2))
     assertEquals(optional.withDefault(0).getOption(objNone), Some(0))
 
-    assertEquals(objNone.optics.andThen(optional).withDefault(0).getOption, Some(0))
+    assertEquals(objNone.focus().andThen(optional).withDefault(0).getOption, Some(0))
   }
 
   test("each") {
@@ -171,7 +171,7 @@ class OptionalSpec extends MonocleSuite {
     val optional = Lens((_: SomeTest).y)(newValue => _.copy(y = newValue)).asOptional
 
     assertEquals(optional.each.getAll(obj), List(1, 2, 3))
-    assertEquals(obj.optics.andThen(optional).each.getAll, List(1, 2, 3))
+    assertEquals(obj.focus().andThen(optional).each.getAll, List(1, 2, 3))
   }
 
   test("at") {
@@ -179,29 +179,29 @@ class OptionalSpec extends MonocleSuite {
     val sortedMapOptional = Iso.id[immutable.SortedMap[Int, String]].asOptional
     assertEquals(sortedMapOptional.at(1).getOption(sortedMap), Some(Some("one")))
     assertEquals(sortedMapOptional.at(0).getOption(sortedMap), Some(None))
-    assertEquals(sortedMap.optics.andThen(sortedMapOptional).at(1).getOption, Some(Some("one")))
-    assertEquals(sortedMap.optics.andThen(sortedMapOptional).at(0).getOption, Some(None))
+    assertEquals(sortedMap.focus().andThen(sortedMapOptional).at(1).getOption, Some(Some("one")))
+    assertEquals(sortedMap.focus().andThen(sortedMapOptional).at(0).getOption, Some(None))
 
     val listMap         = immutable.ListMap(1 -> "one")
     val listMapOptional = Iso.id[immutable.ListMap[Int, String]].asOptional
     assertEquals(listMapOptional.at(1).getOption(listMap), Some(Some("one")))
     assertEquals(listMapOptional.at(0).getOption(listMap), Some(None))
-    assertEquals(listMap.optics.andThen(listMapOptional).at(1).getOption, Some(Some("one")))
-    assertEquals(listMap.optics.andThen(listMapOptional).at(0).getOption, Some(None))
+    assertEquals(listMap.focus().andThen(listMapOptional).at(1).getOption, Some(Some("one")))
+    assertEquals(listMap.focus().andThen(listMapOptional).at(0).getOption, Some(None))
 
     val map         = immutable.Map(1 -> "one")
     val mapOptional = Iso.id[Map[Int, String]].asOptional
     assertEquals(mapOptional.at(1).getOption(map), Some(Some("one")))
     assertEquals(mapOptional.at(0).getOption(map), Some(None))
-    assertEquals(map.optics.andThen(mapOptional).at(1).getOption, Some(Some("one")))
-    assertEquals(map.optics.andThen(mapOptional).at(0).getOption, Some(None))
+    assertEquals(map.focus().andThen(mapOptional).at(1).getOption, Some(Some("one")))
+    assertEquals(map.focus().andThen(mapOptional).at(0).getOption, Some(None))
 
     val set         = Set(1)
     val setOptional = Iso.id[Set[Int]].asOptional
     assertEquals(setOptional.at(1).getOption(set), Some(true))
     assertEquals(setOptional.at(0).getOption(set), Some(false))
-    assertEquals(set.optics.andThen(setOptional).at(1).getOption, Some(true))
-    assertEquals(set.optics.andThen(setOptional).at(0).getOption, Some(false))
+    assertEquals(set.focus().andThen(setOptional).at(1).getOption, Some(true))
+    assertEquals(set.focus().andThen(setOptional).at(0).getOption, Some(false))
   }
 
   test("index") {
@@ -209,71 +209,71 @@ class OptionalSpec extends MonocleSuite {
     val listOptional = Iso.id[List[Int]].asOptional
     assertEquals(listOptional.index(0).getOption(list), Some(1))
     assertEquals(listOptional.index(1).getOption(list), None)
-    assertEquals(list.optics.andThen(listOptional).index(0).getOption, Some(1))
-    assertEquals(list.optics.andThen(listOptional).index(1).getOption, None)
+    assertEquals(list.focus().andThen(listOptional).index(0).getOption, Some(1))
+    assertEquals(list.focus().andThen(listOptional).index(1).getOption, None)
 
     val lazyList         = LazyList(1)
     val lazyListOptional = Iso.id[LazyList[Int]].asOptional
     assertEquals(lazyListOptional.index(0).getOption(lazyList), Some(1))
     assertEquals(lazyListOptional.index(1).getOption(lazyList), None)
-    assertEquals(lazyList.optics.andThen(lazyListOptional).index(0).getOption, Some(1))
-    assertEquals(lazyList.optics.andThen(lazyListOptional).index(1).getOption, None)
+    assertEquals(lazyList.focus().andThen(lazyListOptional).index(0).getOption, Some(1))
+    assertEquals(lazyList.focus().andThen(lazyListOptional).index(1).getOption, None)
 
     val listMap         = immutable.ListMap(1 -> "one")
     val listMapOptional = Iso.id[immutable.ListMap[Int, String]].asOptional
     assertEquals(listMapOptional.index(0).getOption(listMap), None)
     assertEquals(listMapOptional.index(1).getOption(listMap), Some("one"))
-    assertEquals(listMap.optics.andThen(listMapOptional).index(0).getOption, None)
-    assertEquals(listMap.optics.andThen(listMapOptional).index(1).getOption, Some("one"))
+    assertEquals(listMap.focus().andThen(listMapOptional).index(0).getOption, None)
+    assertEquals(listMap.focus().andThen(listMapOptional).index(1).getOption, Some("one"))
 
     val map         = Map(1 -> "one")
     val mapOptional = Iso.id[Map[Int, String]].asOptional
     assertEquals(mapOptional.index(0).getOption(map), None)
     assertEquals(mapOptional.index(1).getOption(map), Some("one"))
-    assertEquals(map.optics.andThen(mapOptional).index(0).getOption, None)
-    assertEquals(map.optics.andThen(mapOptional).index(1).getOption, Some("one"))
+    assertEquals(map.focus().andThen(mapOptional).index(0).getOption, None)
+    assertEquals(map.focus().andThen(mapOptional).index(1).getOption, Some("one"))
 
     val sortedMap         = immutable.SortedMap(1 -> "one")
     val sortedMapOptional = Iso.id[immutable.SortedMap[Int, String]].asOptional
     assertEquals(sortedMapOptional.index(0).getOption(sortedMap), None)
     assertEquals(sortedMapOptional.index(1).getOption(sortedMap), Some("one"))
-    assertEquals(sortedMap.optics.andThen(sortedMapOptional).index(0).getOption, None)
-    assertEquals(sortedMap.optics.andThen(sortedMapOptional).index(1).getOption, Some("one"))
+    assertEquals(sortedMap.focus().andThen(sortedMapOptional).index(0).getOption, None)
+    assertEquals(sortedMap.focus().andThen(sortedMapOptional).index(1).getOption, Some("one"))
 
     val vector         = Vector(1)
     val vectorOptional = Iso.id[Vector[Int]].asOptional
     assertEquals(vectorOptional.index(0).getOption(vector), Some(1))
     assertEquals(vectorOptional.index(1).getOption(vector), None)
-    assertEquals(vector.optics.andThen(vectorOptional).index(0).getOption, Some(1))
-    assertEquals(vector.optics.andThen(vectorOptional).index(1).getOption, None)
+    assertEquals(vector.focus().andThen(vectorOptional).index(0).getOption, Some(1))
+    assertEquals(vector.focus().andThen(vectorOptional).index(1).getOption, None)
 
     val chain         = Chain.one(1)
     val chainOptional = Iso.id[Chain[Int]].asOptional
     assertEquals(chainOptional.index(0).getOption(chain), Some(1))
     assertEquals(chainOptional.index(1).getOption(chain), None)
-    assertEquals(chain.optics.andThen(chainOptional).index(0).getOption, Some(1))
-    assertEquals(chain.optics.andThen(chainOptional).index(1).getOption, None)
+    assertEquals(chain.focus().andThen(chainOptional).index(0).getOption, Some(1))
+    assertEquals(chain.focus().andThen(chainOptional).index(1).getOption, None)
 
     val nec         = NonEmptyChain.one(1)
     val necOptional = Iso.id[NonEmptyChain[Int]].asOptional
     assertEquals(necOptional.index(0).getOption(nec), Some(1))
     assertEquals(necOptional.index(1).getOption(nec), None)
-    assertEquals(nec.optics.andThen(necOptional).index(0).getOption, Some(1))
-    assertEquals(nec.optics.andThen(necOptional).index(1).getOption, None)
+    assertEquals(nec.focus().andThen(necOptional).index(0).getOption, Some(1))
+    assertEquals(nec.focus().andThen(necOptional).index(1).getOption, None)
 
     val nev         = NonEmptyVector.one(1)
     val nevOptional = Iso.id[NonEmptyVector[Int]].asOptional
     assertEquals(nevOptional.index(0).getOption(nev), Some(1))
     assertEquals(nevOptional.index(1).getOption(nev), None)
-    assertEquals(nev.optics.andThen(nevOptional).index(0).getOption, Some(1))
-    assertEquals(nev.optics.andThen(nevOptional).index(1).getOption, None)
+    assertEquals(nev.focus().andThen(nevOptional).index(0).getOption, Some(1))
+    assertEquals(nev.focus().andThen(nevOptional).index(1).getOption, None)
 
     val nel         = NonEmptyList.one(1)
     val nelOptional = Iso.id[NonEmptyList[Int]].asOptional
     assertEquals(nelOptional.index(0).getOption(nel), Some(1))
     assertEquals(nelOptional.index(1).getOption(nel), None)
-    assertEquals(nel.optics.andThen(nelOptional).index(0).getOption, Some(1))
-    assertEquals(nel.optics.andThen(nelOptional).index(1).getOption, None)
+    assertEquals(nel.focus().andThen(nelOptional).index(0).getOption, Some(1))
+    assertEquals(nel.focus().andThen(nelOptional).index(1).getOption, None)
   }
 
   test("filter") {
@@ -290,7 +290,7 @@ class OptionalSpec extends MonocleSuite {
     val optional = Lens((_: SomeTest).y)(newValue => _.copy(y = newValue)).asOptional
 
     assertEquals(optional.filterIndex((_: Int) > 0).getAll(obj), List("world"))
-    assertEquals(obj.optics.andThen(optional).filterIndex((_: Int) > 0).getAll, List("world"))
+    assertEquals(obj.focus().andThen(optional).filterIndex((_: Int) > 0).getAll, List("world"))
   }
 
   test("filter can break the fusion property") {

--- a/test/shared/src/test/scala/monocle/PrismSpec.scala
+++ b/test/shared/src/test/scala/monocle/PrismSpec.scala
@@ -172,7 +172,7 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     val prism = Iso[SomeTest, Option[Int]](_.y)(SomeTest.apply).asPrism
 
     assertEquals(prism.some.getOption(obj), Some(2))
-    assertEquals(obj.optics.andThen(prism).some.getOption, Some(2))
+    assertEquals(obj.focus().andThen(prism).some.getOption, Some(2))
   }
 
   test("withDefault") {
@@ -185,7 +185,7 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     assertEquals(prism.withDefault(0).getOption(objSome), Some(2))
     assertEquals(prism.withDefault(0).getOption(objNone), Some(0))
 
-    assertEquals(objNone.optics.andThen(prism).withDefault(0).getOption, Some(0))
+    assertEquals(objNone.focus().andThen(prism).withDefault(0).getOption, Some(0))
   }
 
   test("each") {
@@ -195,7 +195,7 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     val prism = Iso[SomeTest, List[Int]](_.y)(SomeTest.apply).asPrism
 
     assertEquals(prism.each.getAll(obj), List(1, 2, 3))
-    assertEquals(obj.optics.andThen(prism).each.getAll, List(1, 2, 3))
+    assertEquals(obj.focus().andThen(prism).each.getAll, List(1, 2, 3))
   }
 
   test("filter") {
@@ -205,7 +205,7 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     val prism = Iso[SomeTest, Int](_.y)(SomeTest.apply).asPrism
 
     assertEquals(prism.filter(_ > 0).getOption(obj), Some(2))
-    assertEquals(obj.optics.andThen(prism).filter(_ > 0).getOption, Some(2))
+    assertEquals(obj.focus().andThen(prism).filter(_ > 0).getOption, Some(2))
   }
 
   test("filterIndex") {
@@ -215,7 +215,7 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     val prism = Iso[SomeTest, List[String]](_.y)(SomeTest.apply).asPrism
 
     assertEquals(prism.filterIndex((_: Int) > 0).getAll(obj), List("world"))
-    assertEquals(obj.optics.andThen(prism).filterIndex((_: Int) > 0).getAll, List("world"))
+    assertEquals(obj.focus().andThen(prism).filterIndex((_: Int) > 0).getAll, List("world"))
   }
 
   test("at") {
@@ -223,29 +223,29 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     val sortedMapPrism = Iso.id[immutable.SortedMap[Int, String]].asPrism
     assertEquals(sortedMapPrism.at(1).getOption(sortedMap), Some(Some("one")))
     assertEquals(sortedMapPrism.at(0).getOption(sortedMap), Some(None))
-    assertEquals(sortedMap.optics.andThen(sortedMapPrism).at(1).getOption, Some(Some("one")))
-    assertEquals(sortedMap.optics.andThen(sortedMapPrism).at(0).getOption, Some(None))
+    assertEquals(sortedMap.focus().andThen(sortedMapPrism).at(1).getOption, Some(Some("one")))
+    assertEquals(sortedMap.focus().andThen(sortedMapPrism).at(0).getOption, Some(None))
 
     val listMap      = immutable.ListMap(1 -> "one")
     val listMapPrism = Iso.id[immutable.ListMap[Int, String]].asPrism
     assertEquals(listMapPrism.at(1).getOption(listMap), Some(Some("one")))
     assertEquals(listMapPrism.at(0).getOption(listMap), Some(None))
-    assertEquals(listMap.optics.andThen(listMapPrism).at(1).getOption, Some(Some("one")))
-    assertEquals(listMap.optics.andThen(listMapPrism).at(0).getOption, Some(None))
+    assertEquals(listMap.focus().andThen(listMapPrism).at(1).getOption, Some(Some("one")))
+    assertEquals(listMap.focus().andThen(listMapPrism).at(0).getOption, Some(None))
 
     val map      = immutable.Map(1 -> "one")
     val mapPrism = Iso.id[Map[Int, String]].asPrism
     assertEquals(mapPrism.at(1).getOption(map), Some(Some("one")))
     assertEquals(mapPrism.at(0).getOption(map), Some(None))
-    assertEquals(map.optics.andThen(mapPrism).at(1).getOption, Some(Some("one")))
-    assertEquals(map.optics.andThen(mapPrism).at(0).getOption, Some(None))
+    assertEquals(map.focus().andThen(mapPrism).at(1).getOption, Some(Some("one")))
+    assertEquals(map.focus().andThen(mapPrism).at(0).getOption, Some(None))
 
     val set      = Set(1)
     val setPrism = Iso.id[Set[Int]].asPrism
     assertEquals(setPrism.at(1).getOption(set), Some(true))
     assertEquals(setPrism.at(0).getOption(set), Some(false))
-    assertEquals(set.optics.andThen(setPrism).at(1).getOption, Some(true))
-    assertEquals(set.optics.andThen(setPrism).at(0).getOption, Some(false))
+    assertEquals(set.focus().andThen(setPrism).at(1).getOption, Some(true))
+    assertEquals(set.focus().andThen(setPrism).at(0).getOption, Some(false))
   }
 
   test("index") {
@@ -253,70 +253,70 @@ assertEquals(    ((Nullary(): Arities) match { case _nullary(unit) => unit }) , 
     val listPrism = Iso.id[List[Int]].asPrism
     assertEquals(listPrism.index(0).getOption(list), Some(1))
     assertEquals(listPrism.index(1).getOption(list), None)
-    assertEquals(list.optics.andThen(listPrism).index(0).getOption, Some(1))
-    assertEquals(list.optics.andThen(listPrism).index(1).getOption, None)
+    assertEquals(list.focus().andThen(listPrism).index(0).getOption, Some(1))
+    assertEquals(list.focus().andThen(listPrism).index(1).getOption, None)
 
     val lazyList      = LazyList(1)
     val lazyListPrism = Iso.id[LazyList[Int]].asPrism
     assertEquals(lazyListPrism.index(0).getOption(lazyList), Some(1))
     assertEquals(lazyListPrism.index(1).getOption(lazyList), None)
-    assertEquals(lazyList.optics.andThen(lazyListPrism).index(0).getOption, Some(1))
-    assertEquals(lazyList.optics.andThen(lazyListPrism).index(1).getOption, None)
+    assertEquals(lazyList.focus().andThen(lazyListPrism).index(0).getOption, Some(1))
+    assertEquals(lazyList.focus().andThen(lazyListPrism).index(1).getOption, None)
 
     val listMap      = immutable.ListMap(1 -> "one")
     val listMapPrism = Iso.id[immutable.ListMap[Int, String]].asPrism
     assertEquals(listMapPrism.index(0).getOption(listMap), None)
     assertEquals(listMapPrism.index(1).getOption(listMap), Some("one"))
-    assertEquals(listMap.optics.andThen(listMapPrism).index(0).getOption, None)
-    assertEquals(listMap.optics.andThen(listMapPrism).index(1).getOption, Some("one"))
+    assertEquals(listMap.focus().andThen(listMapPrism).index(0).getOption, None)
+    assertEquals(listMap.focus().andThen(listMapPrism).index(1).getOption, Some("one"))
 
     val map      = Map(1 -> "one")
     val mapPrism = Iso.id[Map[Int, String]].asPrism
     assertEquals(mapPrism.index(0).getOption(map), None)
     assertEquals(mapPrism.index(1).getOption(map), Some("one"))
-    assertEquals(map.optics.andThen(mapPrism).index(0).getOption, None)
-    assertEquals(map.optics.andThen(mapPrism).index(1).getOption, Some("one"))
+    assertEquals(map.focus().andThen(mapPrism).index(0).getOption, None)
+    assertEquals(map.focus().andThen(mapPrism).index(1).getOption, Some("one"))
 
     val sortedMap      = immutable.SortedMap(1 -> "one")
     val sortedMapPrism = Iso.id[immutable.SortedMap[Int, String]].asPrism
     assertEquals(sortedMapPrism.index(0).getOption(sortedMap), None)
     assertEquals(sortedMapPrism.index(1).getOption(sortedMap), Some("one"))
-    assertEquals(sortedMap.optics.andThen(sortedMapPrism).index(0).getOption, None)
-    assertEquals(sortedMap.optics.andThen(sortedMapPrism).index(1).getOption, Some("one"))
+    assertEquals(sortedMap.focus().andThen(sortedMapPrism).index(0).getOption, None)
+    assertEquals(sortedMap.focus().andThen(sortedMapPrism).index(1).getOption, Some("one"))
 
     val vector      = Vector(1)
     val vectorPrism = Iso.id[Vector[Int]].asPrism
     assertEquals(vectorPrism.index(0).getOption(vector), Some(1))
     assertEquals(vectorPrism.index(1).getOption(vector), None)
-    assertEquals(vector.optics.andThen(vectorPrism).index(0).getOption, Some(1))
-    assertEquals(vector.optics.andThen(vectorPrism).index(1).getOption, None)
+    assertEquals(vector.focus().andThen(vectorPrism).index(0).getOption, Some(1))
+    assertEquals(vector.focus().andThen(vectorPrism).index(1).getOption, None)
 
     val chain      = Chain.one(1)
     val chainPrism = Iso.id[Chain[Int]].asPrism
     assertEquals(chainPrism.index(0).getOption(chain), Some(1))
     assertEquals(chainPrism.index(1).getOption(chain), None)
-    assertEquals(chain.optics.andThen(chainPrism).index(0).getOption, Some(1))
-    assertEquals(chain.optics.andThen(chainPrism).index(1).getOption, None)
+    assertEquals(chain.focus().andThen(chainPrism).index(0).getOption, Some(1))
+    assertEquals(chain.focus().andThen(chainPrism).index(1).getOption, None)
 
     val nec      = NonEmptyChain.one(1)
     val necPrism = Iso.id[NonEmptyChain[Int]].asPrism
     assertEquals(necPrism.index(0).getOption(nec), Some(1))
     assertEquals(necPrism.index(1).getOption(nec), None)
-    assertEquals(nec.optics.andThen(necPrism).index(0).getOption, Some(1))
-    assertEquals(nec.optics.andThen(necPrism).index(1).getOption, None)
+    assertEquals(nec.focus().andThen(necPrism).index(0).getOption, Some(1))
+    assertEquals(nec.focus().andThen(necPrism).index(1).getOption, None)
 
     val nev      = NonEmptyVector.one(1)
     val nevPrism = Iso.id[NonEmptyVector[Int]].asPrism
     assertEquals(nevPrism.index(0).getOption(nev), Some(1))
     assertEquals(nevPrism.index(1).getOption(nev), None)
-    assertEquals(nev.optics.andThen(nevPrism).index(0).getOption, Some(1))
-    assertEquals(nev.optics.andThen(nevPrism).index(1).getOption, None)
+    assertEquals(nev.focus().andThen(nevPrism).index(0).getOption, Some(1))
+    assertEquals(nev.focus().andThen(nevPrism).index(1).getOption, None)
 
     val nel      = NonEmptyList.one(1)
     val nelPrism = Iso.id[NonEmptyList[Int]].asPrism
     assertEquals(nelPrism.index(0).getOption(nel), Some(1))
     assertEquals(nelPrism.index(1).getOption(nel), None)
-    assertEquals(nel.optics.andThen(nelPrism).index(0).getOption, Some(1))
-    assertEquals(nel.optics.andThen(nelPrism).index(1).getOption, None)
+    assertEquals(nel.focus().andThen(nelPrism).index(0).getOption, Some(1))
+    assertEquals(nel.focus().andThen(nelPrism).index(1).getOption, None)
   }
 }

--- a/test/shared/src/test/scala/monocle/SetterSpec.scala
+++ b/test/shared/src/test/scala/monocle/SetterSpec.scala
@@ -52,7 +52,7 @@ class SetterSpec extends MonocleSuite {
     val setter = Lens((_: SomeTest).y)(newValue => _.copy(y = newValue)).asSetter
 
     assertEquals(setter.some.replace(3)(obj), SomeTest(1, Some(3)))
-    assertEquals(obj.optics.andThen(setter).some.replace(3), SomeTest(1, Some(3)))
+    assertEquals(obj.focus().andThen(setter).some.replace(3), SomeTest(1, Some(3)))
   }
 
   test("withDefault") {
@@ -65,7 +65,7 @@ class SetterSpec extends MonocleSuite {
     assertEquals(setter.withDefault(0).modify(_ + 1)(objSome), SomeTest(1, Some(3)))
     assertEquals(setter.withDefault(0).modify(_ + 1)(objNone), SomeTest(1, Some(1)))
 
-    assertEquals(objNone.optics.andThen(setter).withDefault(0).modify(_ + 1), SomeTest(1, Some(1)))
+    assertEquals(objNone.focus().andThen(setter).withDefault(0).modify(_ + 1), SomeTest(1, Some(1)))
   }
 
   test("each") {
@@ -75,7 +75,7 @@ class SetterSpec extends MonocleSuite {
     val setter = Lens((_: SomeTest).y)(newValue => _.copy(y = newValue)).asSetter
 
     assertEquals(setter.each.replace(3)(obj), SomeTest(1, List(3, 3, 3)))
-    assertEquals(obj.optics.andThen(setter).each.replace(3), SomeTest(1, List(3, 3, 3)))
+    assertEquals(obj.focus().andThen(setter).each.replace(3), SomeTest(1, List(3, 3, 3)))
   }
 
   test("filter") {
@@ -85,7 +85,7 @@ class SetterSpec extends MonocleSuite {
     val setter = Lens((_: SomeTest).y)(newValue => _.copy(y = newValue)).asSetter
 
     assertEquals(setter.filter(_ > 0).replace(3)(obj), SomeTest(1, 3))
-    assertEquals(obj.optics.andThen(setter).filter(_ > 0).replace(3), SomeTest(1, 3))
+    assertEquals(obj.focus().andThen(setter).filter(_ > 0).replace(3), SomeTest(1, 3))
   }
 
   test("filterIndex") {
@@ -95,7 +95,7 @@ class SetterSpec extends MonocleSuite {
     val setter = Lens((_: SomeTest).y)(newValue => _.copy(y = newValue)).asSetter
 
     assertEquals(setter.filterIndex((_: Int) > 0).replace("!")(obj), SomeTest(1, List("hello", "!")))
-    assertEquals(obj.optics.andThen(setter).filterIndex((_: Int) > 0).replace("!"), SomeTest(1, List("hello", "!")))
+    assertEquals(obj.focus().andThen(setter).filterIndex((_: Int) > 0).replace("!"), SomeTest(1, List("hello", "!")))
   }
 
   test("at") {
@@ -103,9 +103,9 @@ class SetterSpec extends MonocleSuite {
     val sortedMapSetter = Iso.id[immutable.SortedMap[Int, String]].asSetter
     assertEquals(sortedMapSetter.at(1).replace(Some("two"))(sortedMap), immutable.SortedMap(1 -> "two"))
     assertEquals(sortedMapSetter.at(0).replace(Some("two"))(sortedMap), immutable.SortedMap(0 -> "two", 1 -> "one"))
-    assertEquals(sortedMap.optics.andThen(sortedMapSetter).at(1).replace(Some("two")), immutable.SortedMap(1 -> "two"))
+    assertEquals(sortedMap.focus().andThen(sortedMapSetter).at(1).replace(Some("two")), immutable.SortedMap(1 -> "two"))
     assertEquals(
-      sortedMap.optics.andThen(sortedMapSetter).at(0).replace(Some("two")),
+      sortedMap.focus().andThen(sortedMapSetter).at(0).replace(Some("two")),
       immutable.SortedMap(0 -> "two", 1 -> "one")
     )
 
@@ -113,9 +113,9 @@ class SetterSpec extends MonocleSuite {
     val listMapSetter = Iso.id[immutable.ListMap[Int, String]].asSetter
     assertEquals(listMapSetter.at(1).replace(Some("two"))(listMap), immutable.ListMap(1 -> "two"))
     assertEquals(listMapSetter.at(0).replace(Some("two"))(listMap), immutable.ListMap(1 -> "one", 0 -> "two"))
-    assertEquals(listMap.optics.andThen(listMapSetter).at(1).replace(Some("two")), immutable.ListMap(1 -> "two"))
+    assertEquals(listMap.focus().andThen(listMapSetter).at(1).replace(Some("two")), immutable.ListMap(1 -> "two"))
     assertEquals(
-      listMap.optics.andThen(listMapSetter).at(0).replace(Some("two")),
+      listMap.focus().andThen(listMapSetter).at(0).replace(Some("two")),
       immutable.ListMap(1 -> "one", 0 -> "two")
     )
 
@@ -123,15 +123,15 @@ class SetterSpec extends MonocleSuite {
     val mapSetter = Iso.id[Map[Int, String]].asSetter
     assertEquals(mapSetter.at(1).replace(Some("two"))(map), Map(1 -> "two"))
     assertEquals(mapSetter.at(0).replace(Some("two"))(map), Map(1 -> "one", 0 -> "two"))
-    assertEquals(map.optics.andThen(mapSetter).at(1).replace(Some("two")), Map(1 -> "two"))
-    assertEquals(map.optics.andThen(mapSetter).at(0).replace(Some("two")), Map(1 -> "one", 0 -> "two"))
+    assertEquals(map.focus().andThen(mapSetter).at(1).replace(Some("two")), Map(1 -> "two"))
+    assertEquals(map.focus().andThen(mapSetter).at(0).replace(Some("two")), Map(1 -> "one", 0 -> "two"))
 
     val set       = Set(1)
     val setSetter = Iso.id[Set[Int]].asSetter
     assertEquals(setSetter.at(1).replace(true)(set), Set(1))
     assertEquals(setSetter.at(2).replace(false)(set), Set(1))
-    assertEquals(set.optics.andThen(setSetter).at(1).replace(true), Set(1))
-    assertEquals(set.optics.andThen(setSetter).at(2).replace(false), Set(1))
+    assertEquals(set.focus().andThen(setSetter).at(1).replace(true), Set(1))
+    assertEquals(set.focus().andThen(setSetter).at(2).replace(false), Set(1))
   }
 
   test("index") {
@@ -139,70 +139,70 @@ class SetterSpec extends MonocleSuite {
     val listSetter = Iso.id[List[Int]].asSetter
     assertEquals(listSetter.index(0).replace(2)(list), List(2))
     assertEquals(listSetter.index(1).replace(2)(list), list)
-    assertEquals(list.optics.andThen(listSetter).index(0).replace(2), List(2))
-    assertEquals(list.optics.andThen(listSetter).index(1).replace(2), list)
+    assertEquals(list.focus().andThen(listSetter).index(0).replace(2), List(2))
+    assertEquals(list.focus().andThen(listSetter).index(1).replace(2), list)
 
     val lazyList       = LazyList(1)
     val lazyListSetter = Iso.id[LazyList[Int]].asSetter
     assertEquals(lazyListSetter.index(0).replace(2)(lazyList), LazyList(2))
     assertEquals(lazyListSetter.index(1).replace(2)(lazyList), lazyList)
-    assertEquals(lazyList.optics.andThen(lazyListSetter).index(0).replace(2), LazyList(2))
-    assertEquals(lazyList.optics.andThen(lazyListSetter).index(1).replace(2), lazyList)
+    assertEquals(lazyList.focus().andThen(lazyListSetter).index(0).replace(2), LazyList(2))
+    assertEquals(lazyList.focus().andThen(lazyListSetter).index(1).replace(2), lazyList)
 
     val listMap       = immutable.ListMap(1 -> "one")
     val listMapSetter = Iso.id[immutable.ListMap[Int, String]].asSetter
     assertEquals(listMapSetter.index(0).replace("two")(listMap), listMap)
     assertEquals(listMapSetter.index(1).replace("two")(listMap), immutable.ListMap(1 -> "two"))
-    assertEquals(listMap.optics.andThen(listMapSetter).index(0).replace("two"), listMap)
-    assertEquals(listMap.optics.andThen(listMapSetter).index(1).replace("two"), immutable.ListMap(1 -> "two"))
+    assertEquals(listMap.focus().andThen(listMapSetter).index(0).replace("two"), listMap)
+    assertEquals(listMap.focus().andThen(listMapSetter).index(1).replace("two"), immutable.ListMap(1 -> "two"))
 
     val map       = Map(1 -> "one")
     val mapSetter = Iso.id[Map[Int, String]].asSetter
     assertEquals(mapSetter.index(0).replace("two")(map), map)
     assertEquals(mapSetter.index(1).replace("two")(map), Map(1 -> "two"))
-    assertEquals(map.optics.andThen(mapSetter).index(0).replace("two"), map)
-    assertEquals(map.optics.andThen(mapSetter).index(1).replace("two"), Map(1 -> "two"))
+    assertEquals(map.focus().andThen(mapSetter).index(0).replace("two"), map)
+    assertEquals(map.focus().andThen(mapSetter).index(1).replace("two"), Map(1 -> "two"))
 
     val sortedMap       = immutable.SortedMap(1 -> "one")
     val sortedMapSetter = Iso.id[immutable.SortedMap[Int, String]].asSetter
     assertEquals(sortedMapSetter.index(0).replace("two")(sortedMap), sortedMap)
     assertEquals(sortedMapSetter.index(1).replace("two")(sortedMap), immutable.SortedMap(1 -> "two"))
-    assertEquals(sortedMap.optics.andThen(sortedMapSetter).index(0).replace("two"), sortedMap)
-    assertEquals(sortedMap.optics.andThen(sortedMapSetter).index(1).replace("two"), immutable.SortedMap(1 -> "two"))
+    assertEquals(sortedMap.focus().andThen(sortedMapSetter).index(0).replace("two"), sortedMap)
+    assertEquals(sortedMap.focus().andThen(sortedMapSetter).index(1).replace("two"), immutable.SortedMap(1 -> "two"))
 
     val vector       = Vector(1)
     val vectorSetter = Iso.id[Vector[Int]].asSetter
     assertEquals(vectorSetter.index(0).replace(2)(vector), Vector(2))
     assertEquals(vectorSetter.index(1).replace(2)(vector), vector)
-    assertEquals(vector.optics.andThen(vectorSetter).index(0).replace(2), Vector(2))
-    assertEquals(vector.optics.andThen(vectorSetter).index(1).replace(2), vector)
+    assertEquals(vector.focus().andThen(vectorSetter).index(0).replace(2), Vector(2))
+    assertEquals(vector.focus().andThen(vectorSetter).index(1).replace(2), vector)
 
     val chain       = Chain.one(1)
     val chainSetter = Iso.id[Chain[Int]].asSetter
     assertEquals(chainSetter.index(0).replace(2)(chain), Chain(2))
     assertEquals(chainSetter.index(1).replace(2)(chain), chain)
-    assertEquals(chain.optics.andThen(chainSetter).index(0).replace(2), Chain(2))
-    assertEquals(chain.optics.andThen(chainSetter).index(1).replace(2), chain)
+    assertEquals(chain.focus().andThen(chainSetter).index(0).replace(2), Chain(2))
+    assertEquals(chain.focus().andThen(chainSetter).index(1).replace(2), chain)
 
     val nec       = NonEmptyChain.one(1)
     val necSetter = Iso.id[NonEmptyChain[Int]].asSetter
     assertEquals(necSetter.index(0).replace(2)(nec), NonEmptyChain(2))
     assertEquals(necSetter.index(1).replace(2)(nec), nec)
-    assertEquals(nec.optics.andThen(necSetter).index(0).replace(2), NonEmptyChain(2))
-    assertEquals(nec.optics.andThen(necSetter).index(1).replace(2), nec)
+    assertEquals(nec.focus().andThen(necSetter).index(0).replace(2), NonEmptyChain(2))
+    assertEquals(nec.focus().andThen(necSetter).index(1).replace(2), nec)
 
     val nev       = NonEmptyVector.one(1)
     val nevSetter = Iso.id[NonEmptyVector[Int]].asSetter
     assertEquals(nevSetter.index(0).replace(2)(nev), NonEmptyVector.one(2))
     assertEquals(nevSetter.index(1).replace(2)(nev), nev)
-    assertEquals(nev.optics.andThen(nevSetter).index(0).replace(2), NonEmptyVector.one(2))
-    assertEquals(nev.optics.andThen(nevSetter).index(1).replace(2), nev)
+    assertEquals(nev.focus().andThen(nevSetter).index(0).replace(2), NonEmptyVector.one(2))
+    assertEquals(nev.focus().andThen(nevSetter).index(1).replace(2), nev)
 
     val nel       = NonEmptyList.one(1)
     val nelSetter = Iso.id[NonEmptyList[Int]].asSetter
     assertEquals(nelSetter.index(0).replace(2)(nel), NonEmptyList.one(2))
     assertEquals(nelSetter.index(1).replace(2)(nel), nel)
-    assertEquals(nel.optics.andThen(nelSetter).index(0).replace(2), NonEmptyList.one(2))
-    assertEquals(nel.optics.andThen(nelSetter).index(1).replace(2), nel)
+    assertEquals(nel.focus().andThen(nelSetter).index(0).replace(2), NonEmptyList.one(2))
+    assertEquals(nel.focus().andThen(nelSetter).index(1).replace(2), nel)
   }
 }

--- a/test/shared/src/test/scala/monocle/TraversalSpec.scala
+++ b/test/shared/src/test/scala/monocle/TraversalSpec.scala
@@ -166,7 +166,7 @@ class TraversalSpec extends MonocleSuite {
     val traversal = Traversal.fromTraverse[List, Option[Int]]
 
     assertEquals(traversal.some.replace(5)(numbers), List(Some(5), None, Some(5), None))
-    assertEquals(numbers.optics.andThen(traversal).some.replace(5), List(Some(5), None, Some(5), None))
+    assertEquals(numbers.focus().andThen(traversal).some.replace(5), List(Some(5), None, Some(5), None))
   }
 
   test("withDefault") {
@@ -175,7 +175,7 @@ class TraversalSpec extends MonocleSuite {
 
     assertEquals(traversal.withDefault(0).modify(_ + 1)(numbers), List(Some(2), Some(1), Some(3), Some(1)))
     assertEquals(
-      numbers.optics.andThen(traversal).withDefault(0).modify(_ + 1),
+      numbers.focus().andThen(traversal).withDefault(0).modify(_ + 1),
       List(Some(2), Some(1), Some(3), Some(1))
     )
   }
@@ -185,7 +185,7 @@ class TraversalSpec extends MonocleSuite {
     val traversal = Traversal.fromTraverse[List, List[Int]]
 
     assertEquals(traversal.each.getAll(numbers), List(1, 2, 3, 4))
-    assertEquals(numbers.optics.andThen(traversal).each.getAll, List(1, 2, 3, 4))
+    assertEquals(numbers.focus().andThen(traversal).each.getAll, List(1, 2, 3, 4))
   }
 
   test("filter") {
@@ -193,7 +193,7 @@ class TraversalSpec extends MonocleSuite {
     val traversal = Traversal.fromTraverse[List, Int]
 
     assertEquals(traversal.filter(_ > 1).getAll(numbers), List(2, 3))
-    assertEquals(numbers.optics.andThen(traversal).filter(_ > 1).getAll, List(2, 3))
+    assertEquals(numbers.focus().andThen(traversal).filter(_ > 1).getAll, List(2, 3))
   }
 
   test("filterIndex") {
@@ -201,7 +201,7 @@ class TraversalSpec extends MonocleSuite {
     val traversal = Traversal.fromTraverse[List, List[String]]
 
     assertEquals(traversal.filterIndex((_: Int) > 0).getAll(words), List("world", "hi"))
-    assertEquals(words.optics.andThen(traversal).filterIndex((_: Int) > 0).getAll, List("world", "hi"))
+    assertEquals(words.focus().andThen(traversal).filterIndex((_: Int) > 0).getAll, List("world", "hi"))
   }
 
   test("at") {
@@ -209,29 +209,29 @@ class TraversalSpec extends MonocleSuite {
     val sortedMapTraversal = Iso.id[immutable.SortedMap[Int, String]].asTraversal
     assertEquals(sortedMapTraversal.at(1).getAll(sortedMap), List(Some("one")))
     assertEquals(sortedMapTraversal.at(0).getAll(sortedMap), List(None))
-    assertEquals(sortedMap.optics.andThen(sortedMapTraversal).at(1).getAll, List(Some("one")))
-    assertEquals(sortedMap.optics.andThen(sortedMapTraversal).at(0).getAll, List(None))
+    assertEquals(sortedMap.focus().andThen(sortedMapTraversal).at(1).getAll, List(Some("one")))
+    assertEquals(sortedMap.focus().andThen(sortedMapTraversal).at(0).getAll, List(None))
 
     val listMap          = immutable.ListMap(1 -> "one")
     val listMapTraversal = Iso.id[immutable.ListMap[Int, String]].asTraversal
     assertEquals(listMapTraversal.at(1).getAll(listMap), List(Some("one")))
     assertEquals(listMapTraversal.at(0).getAll(listMap), List(None))
-    assertEquals(listMap.optics.andThen(listMapTraversal).at(1).getAll, List(Some("one")))
-    assertEquals(listMap.optics.andThen(listMapTraversal).at(0).getAll, List(None))
+    assertEquals(listMap.focus().andThen(listMapTraversal).at(1).getAll, List(Some("one")))
+    assertEquals(listMap.focus().andThen(listMapTraversal).at(0).getAll, List(None))
 
     val map          = immutable.Map(1 -> "one")
     val mapTraversal = Iso.id[Map[Int, String]].asTraversal
     assertEquals(mapTraversal.at(1).getAll(map), List(Some("one")))
     assertEquals(mapTraversal.at(0).getAll(map), List(None))
-    assertEquals(map.optics.andThen(mapTraversal).at(1).getAll, List(Some("one")))
-    assertEquals(map.optics.andThen(mapTraversal).at(0).getAll, List(None))
+    assertEquals(map.focus().andThen(mapTraversal).at(1).getAll, List(Some("one")))
+    assertEquals(map.focus().andThen(mapTraversal).at(0).getAll, List(None))
 
     val set          = Set(1)
     val setTraversal = Iso.id[Set[Int]].asTraversal
     assertEquals(setTraversal.at(1).getAll(set), List(true))
     assertEquals(setTraversal.at(0).getAll(set), List(false))
-    assertEquals(set.optics.andThen(setTraversal).at(1).getAll, List(true))
-    assertEquals(set.optics.andThen(setTraversal).at(0).getAll, List(false))
+    assertEquals(set.focus().andThen(setTraversal).at(1).getAll, List(true))
+    assertEquals(set.focus().andThen(setTraversal).at(0).getAll, List(false))
   }
 
   test("index") {
@@ -239,70 +239,70 @@ class TraversalSpec extends MonocleSuite {
     val listTraversal = Iso.id[List[Int]].asTraversal
     assertEquals(listTraversal.index(0).getAll(list), List(1))
     assertEquals(listTraversal.index(1).getAll(list), Nil)
-    assertEquals(list.optics.andThen(listTraversal).index(0).getAll, List(1))
-    assertEquals(list.optics.andThen(listTraversal).index(1).getAll, Nil)
+    assertEquals(list.focus().andThen(listTraversal).index(0).getAll, List(1))
+    assertEquals(list.focus().andThen(listTraversal).index(1).getAll, Nil)
 
     val lazyList          = LazyList(1)
     val lazyListTraversal = Iso.id[LazyList[Int]].asTraversal
     assertEquals(lazyListTraversal.index(0).getAll(lazyList), List(1))
     assertEquals(lazyListTraversal.index(1).getAll(lazyList), Nil)
-    assertEquals(lazyList.optics.andThen(lazyListTraversal).index(0).getAll, List(1))
-    assertEquals(lazyList.optics.andThen(lazyListTraversal).index(1).getAll, Nil)
+    assertEquals(lazyList.focus().andThen(lazyListTraversal).index(0).getAll, List(1))
+    assertEquals(lazyList.focus().andThen(lazyListTraversal).index(1).getAll, Nil)
 
     val listMap          = immutable.ListMap(1 -> "one")
     val listMapTraversal = Iso.id[immutable.ListMap[Int, String]].asTraversal
     assertEquals(listMapTraversal.index(0).getAll(listMap), Nil)
     assertEquals(listMapTraversal.index(1).getAll(listMap), List("one"))
-    assertEquals(listMap.optics.andThen(listMapTraversal).index(0).getAll, Nil)
-    assertEquals(listMap.optics.andThen(listMapTraversal).index(1).getAll, List("one"))
+    assertEquals(listMap.focus().andThen(listMapTraversal).index(0).getAll, Nil)
+    assertEquals(listMap.focus().andThen(listMapTraversal).index(1).getAll, List("one"))
 
     val map          = Map(1 -> "one")
     val mapTraversal = Iso.id[Map[Int, String]].asTraversal
     assertEquals(mapTraversal.index(0).getAll(map), Nil)
     assertEquals(mapTraversal.index(1).getAll(map), List("one"))
-    assertEquals(map.optics.andThen(mapTraversal).index(0).getAll, Nil)
-    assertEquals(map.optics.andThen(mapTraversal).index(1).getAll, List("one"))
+    assertEquals(map.focus().andThen(mapTraversal).index(0).getAll, Nil)
+    assertEquals(map.focus().andThen(mapTraversal).index(1).getAll, List("one"))
 
     val sortedMap          = immutable.SortedMap(1 -> "one")
     val sortedMapTraversal = Iso.id[immutable.SortedMap[Int, String]].asTraversal
     assertEquals(sortedMapTraversal.index(0).getAll(sortedMap), Nil)
     assertEquals(sortedMapTraversal.index(1).getAll(sortedMap), List("one"))
-    assertEquals(sortedMap.optics.andThen(sortedMapTraversal).index(0).getAll, Nil)
-    assertEquals(sortedMap.optics.andThen(sortedMapTraversal).index(1).getAll, List("one"))
+    assertEquals(sortedMap.focus().andThen(sortedMapTraversal).index(0).getAll, Nil)
+    assertEquals(sortedMap.focus().andThen(sortedMapTraversal).index(1).getAll, List("one"))
 
     val vector          = Vector(1)
     val vectorTraversal = Iso.id[Vector[Int]].asTraversal
     assertEquals(vectorTraversal.index(0).getAll(vector), List(1))
     assertEquals(vectorTraversal.index(1).getAll(vector), Nil)
-    assertEquals(vector.optics.andThen(vectorTraversal).index(0).getAll, List(1))
-    assertEquals(vector.optics.andThen(vectorTraversal).index(1).getAll, Nil)
+    assertEquals(vector.focus().andThen(vectorTraversal).index(0).getAll, List(1))
+    assertEquals(vector.focus().andThen(vectorTraversal).index(1).getAll, Nil)
 
     val chain          = Chain.one(1)
     val chainTraversal = Iso.id[Chain[Int]].asTraversal
     assertEquals(chainTraversal.index(0).getAll(chain), List(1))
     assertEquals(chainTraversal.index(1).getAll(chain), Nil)
-    assertEquals(chain.optics.andThen(chainTraversal).index(0).getAll, List(1))
-    assertEquals(chain.optics.andThen(chainTraversal).index(1).getAll, Nil)
+    assertEquals(chain.focus().andThen(chainTraversal).index(0).getAll, List(1))
+    assertEquals(chain.focus().andThen(chainTraversal).index(1).getAll, Nil)
 
     val nec          = NonEmptyChain.one(1)
     val necTraversal = Iso.id[NonEmptyChain[Int]].asTraversal
     assertEquals(necTraversal.index(0).getAll(nec), List(1))
     assertEquals(necTraversal.index(1).getAll(nec), Nil)
-    assertEquals(nec.optics.andThen(necTraversal).index(0).getAll, List(1))
-    assertEquals(nec.optics.andThen(necTraversal).index(1).getAll, Nil)
+    assertEquals(nec.focus().andThen(necTraversal).index(0).getAll, List(1))
+    assertEquals(nec.focus().andThen(necTraversal).index(1).getAll, Nil)
 
     val nev          = NonEmptyVector.one(1)
     val nevTraversal = Iso.id[NonEmptyVector[Int]].asTraversal
     assertEquals(nevTraversal.index(0).getAll(nev), List(1))
     assertEquals(nevTraversal.index(1).getAll(nev), Nil)
-    assertEquals(nev.optics.andThen(nevTraversal).index(0).getAll, List(1))
-    assertEquals(nev.optics.andThen(nevTraversal).index(1).getAll, Nil)
+    assertEquals(nev.focus().andThen(nevTraversal).index(0).getAll, List(1))
+    assertEquals(nev.focus().andThen(nevTraversal).index(1).getAll, Nil)
 
     val nel          = NonEmptyList.one(1)
     val nelTraversal = Iso.id[NonEmptyList[Int]].asTraversal
     assertEquals(nelTraversal.index(0).getAll(nel), List(1))
     assertEquals(nelTraversal.index(1).getAll(nel), Nil)
-    assertEquals(nel.optics.andThen(nelTraversal).index(0).getAll, List(1))
-    assertEquals(nel.optics.andThen(nelTraversal).index(1).getAll, Nil)
+    assertEquals(nel.focus().andThen(nelTraversal).index(0).getAll, List(1))
+    assertEquals(nel.focus().andThen(nelTraversal).index(1).getAll, Nil)
   }
 }

--- a/test/shared/src/test/scala/monocle/function/AtSpec.scala
+++ b/test/shared/src/test/scala/monocle/function/AtSpec.scala
@@ -18,7 +18,7 @@ class AtSpec extends MonocleSuite {
 
   test("at creates a Lens from a Map, SortedMap to an optional value") {
     val map = Map("One" -> 1, "Two" -> 2)
-    assertEquals(map.optics.at("One").replace(Some(-1)), Map("One" -> -1, "Two" -> 2))
-    assertEquals(map.optics.at("Two").get, Some(2))
+    assertEquals(map.focus().at("One").replace(Some(-1)), Map("One" -> -1, "Two" -> 2))
+    assertEquals(map.focus().at("Two").get, Some(2))
   }
 }

--- a/test/shared/src/test/scala/monocle/syntax/FocusSyntax.scala
+++ b/test/shared/src/test/scala/monocle/syntax/FocusSyntax.scala
@@ -1,0 +1,21 @@
+package monocle.syntax
+
+import monocle.{Focus, MonocleSuite}
+
+class FocusSyntax extends MonocleSuite {
+
+  test("Focus[XXX] creates an Iso") {
+    assertEquals(
+      Focus[String]().get("hello"),
+      "hello"
+    )
+  }
+
+  test("foo.focus() creates an ApplyIso") {
+    assertEquals(
+      "hello".focus().get,
+      "hello"
+    )
+  }
+
+}


### PR DESCRIPTION
Fix #1064

## Use paren

I could make `.focus` work but not `Focus[X]`. The problem is that `Focus` uses the trick to partially apply type parameter
```scala
def apply[S] = new MkFocus[S]

class MkFocus[From] {
    def apply: Iso[From, From] = Iso.id
}
```

as a result `Focus[X]` is a `MkFocus[X]` not an `Iso[X, X]`. Adding paren to `apply` fixed the ambiguity.

## Moved syntax

I had to move `.focus()` next to the macro extension `.focus(_.foo.bar)`. When both extension methods where in different classes, it confuses the compiler. 

The main issue is for Scala 2, we need define `.focus()` in the macro module.