### PR TITLE
Brings `as` into line with the other operators wrt Focus

### DIFF
--- a/core/shared/src/main/scala-3.x/monocle/Focus.scala
+++ b/core/shared/src/main/scala-3.x/monocle/Focus.scala
@@ -7,8 +7,8 @@ import monocle.function.{Each, At, Index}
 object Focus extends AppliedFocusSyntax {
 
   sealed trait KeywordContext {
-    extension (from: Any)
-      def as[CastTo]: CastTo = scala.sys.error("Extension method 'as[CastTo]' should only be used within the monocle.Focus macro.")
+    extension [From] (from: From)
+      def as[CastTo <: From]: CastTo = scala.sys.error("Extension method 'as[CastTo]' should only be used within the monocle.Focus macro.")
 
     extension [A] (opt: Option[A])
       def some: A = scala.sys.error("Extension method 'some' should only be used within the monocle.Focus macro.")

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/KeywordParserBase.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/KeywordParserBase.scala
@@ -18,16 +18,21 @@ private[focus] trait KeywordParserBase extends ParserBase {
   object FocusKeyword {
     def unapply(term: Term): Option[(Name, FromType, TypeArgs, ValueArgs, RemainingCode)] = term match {
       // No value args, inferred type arguments `[T] keyword`
-      case Apply(TypeApply(Select(_, keyword), typeArgs), List(code)) => 
-        Some(Name(keyword), FromType(code.tpe.widen), TypeArgs(typeArgs.map(_.tpe): _*), ValueArgs(), RemainingCode(code))
+      case Apply(TypeApply(Select(_, keyword), inferredTypeArgs), List(code)) => 
+        Some(Name(keyword), FromType(code.tpe.widen), TypeArgs(inferredTypeArgs.map(_.tpe): _*), ValueArgs(), RemainingCode(code))
 
       // Value args required, inferred type arguments `[T] keyword(value)`
-      case Apply(Apply(TypeApply(Select(_, keyword), typeArgs), List(code)), valueArgs) => 
-        Some(Name(keyword), FromType(code.tpe.widen), TypeArgs(typeArgs.map(_.tpe): _*), ValueArgs(valueArgs: _*), RemainingCode(code))
+      case Apply(Apply(TypeApply(Select(_, keyword), inferredTypeArgs), List(code)), valueArgs) => 
+        Some(Name(keyword), FromType(code.tpe.widen), TypeArgs(inferredTypeArgs.map(_.tpe): _*), ValueArgs(valueArgs: _*), RemainingCode(code))
 
       // No value args, direct type arguments `keyword[T]`
-      case TypeApply(Apply(Select(_, keyword), List(code)), typeArgs) => 
-        Some(Name(keyword), FromType(code.tpe.widen), TypeArgs(typeArgs.map(_.tpe): _*), ValueArgs(), RemainingCode(code))
+      case TypeApply(Apply(Select(_, keyword), List(code)), directTypeArgs) => 
+        Some(Name(keyword), FromType(code.tpe.widen), TypeArgs(directTypeArgs.map(_.tpe): _*), ValueArgs(), RemainingCode(code))
+
+      // No value args, inferred and direct type arguments `[T] keyword[U]`
+      case TypeApply(Apply(TypeApply(Select(_, keyword), inferredTypeArgs), List(code)), directTypeArgs) => 
+        val allTypeArgs = inferredTypeArgs ++ directTypeArgs
+        Some(Name(keyword), FromType(code.tpe.widen), TypeArgs(allTypeArgs.map(_.tpe): _*), ValueArgs(), RemainingCode(code))
 
       case _ => None
     }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/as/AsGenerator.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/as/AsGenerator.scala
@@ -2,6 +2,7 @@ package monocle.internal.focus.features.as
 
 import monocle.Prism
 import monocle.internal.focus.FocusBase
+import monocle.syntax.AsPrism
 
 private[focus] trait AsGenerator {
   this: FocusBase => 
@@ -12,9 +13,7 @@ private[focus] trait AsGenerator {
     import action.{fromType, toType}
 
     (fromType.asType, toType.asType) match {
-      case ('[f], '[t]) => '{ 
-        Prism[f, t]((from: f) => if (from.isInstanceOf[t]) Some(from.asInstanceOf[t]) else None)
-                   ((to: t) => to.asInstanceOf[f]) }.asTerm
+      case ('[f], '[t]) => '{ AsPrism[f, t] }.asTerm
     }
   }
 }

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/features/as/AsParser.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/features/as/AsParser.scala
@@ -10,7 +10,7 @@ private[focus] trait AsParser {
 
     def unapply(term: Term): Option[FocusResult[(RemainingCode, FocusAction)]] = term match {
       
-      case FocusKeyword(Name("as"), FromType(fromType), TypeArgs(toType), ValueArgs(), remainingCode) => 
+      case FocusKeyword(Name("as"), FromType(fromType), TypeArgs(_, toType), ValueArgs(), remainingCode) => 
         if (toType <:< fromType) {
           val action = FocusAction.KeywordAs(fromType, toType)
           Some(Right(remainingCode, action))

--- a/core/shared/src/main/scala-3.x/monocle/syntax/MacroSyntax.scala
+++ b/core/shared/src/main/scala-3.x/monocle/syntax/MacroSyntax.scala
@@ -8,37 +8,37 @@ trait MacroSyntax {
 
   extension [From, To] (optic: Prism[From, To]) {
     inline def as[CastTo <: To]: Prism[From, CastTo] =
-      optic.andThen(GenPrism[To, CastTo])
+      optic.andThen(AsPrism[To, CastTo])
   }
 
   extension [From, To] (optic: Optional[From, To]) {
     inline def as[CastTo <: To]: Optional[From, CastTo] =
-      optic.andThen(GenPrism[To, CastTo])
+      optic.andThen(AsPrism[To, CastTo])
   }
 
   extension [From, To] (optic: Traversal[From, To]) {
     inline def as[CastTo <: To]: Traversal[From, CastTo] =
-      optic.andThen(GenPrism[To, CastTo])
+      optic.andThen(AsPrism[To, CastTo])
   }
 
   extension [From, To] (optic: Setter[From, To]) {
     inline def as[CastTo <: To]: Setter[From, CastTo] =
-      optic.andThen(GenPrism[To, CastTo])
+      optic.andThen(AsPrism[To, CastTo])
   }
 
   extension [From, To] (optic: Fold[From, To]) {
     inline def as[CastTo <: To]: Fold[From, CastTo] =
-      optic.andThen(GenPrism[To, CastTo])
+      optic.andThen(AsPrism[To, CastTo])
   }
 
 }
 
-private[monocle] object GenPrism {
-  inline def apply[From, To <: From]: Prism[From, To] =
-    ${ GenPrismImpl.apply }
+private[monocle] object AsPrism {
+  inline def apply[From, To]: Prism[From, To] =
+    ${ AsPrismImpl.apply }
 }
 
-private[monocle] object GenPrismImpl {
+private[monocle] object AsPrismImpl {
   def apply[From: Type, To: Type](using Quotes): Expr[Prism[From, To]] =
     '{
       Prism[From, To]((from: From) => if (from.isInstanceOf[To]) Some(from.asInstanceOf[To]) else None)(

--- a/core/shared/src/test/scala-3.x/monocle/focus/FocusAsTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/FocusAsTest.scala
@@ -1,7 +1,8 @@
 package monocle.focus
 
 import monocle.Focus
-import monocle.Focus._
+import monocle.syntax.all.as
+
 
 import scala.annotation.nowarn
 
@@ -41,5 +42,20 @@ final class FocusAsTest extends munit.FunSuite {
     val mysteryFood = MysteryFood[String]("abc", 44)
 
     assertEquals(getMystery.getOption(mysteryFood), Some("abc"))
+  }
+
+   test("Focus operator `as` commutes with standalone operator `as`") {
+    val asBanana = Focus[Food](_.as[Banana])
+
+    val foodA: Food = Apple(35, "blue")
+    val foodB: Food = Banana(-88, false)
+
+    assertEquals(
+      Focus[Food](_.as[Banana]).getOption(foodB), 
+      Focus[Food]().as[Banana].getOption(foodB))
+
+    assertEquals(
+      Focus[Food](_.as[Banana]).getOption(foodA), 
+      Focus[Food]().as[Banana].getOption(foodA))
   }
 }


### PR DESCRIPTION
- Thanks to Scala 3 RC1, adds a `From` parameter to the Focus `as` keyword, constrained by a type bounds. This is now the same signature as the external `as` operator:
```
extension [From] (from: From)
      def as[CastTo <: From]: CastTo
```
-  Adds a case to the `FocusKeyword` pattern matcher to correctly interpret an extension method with both inferred and direct type parameter lists.
- Renamed `GenPrism` to `AsPrism`. It is no longer analogous to the deprecated `GenXXX` features, and should not forward to `Focus`. It is an implementation detail for the new and supported `as` operator.
- Changed the `AsGenerator` implementation to directly use `AsPrism`, rather than have its own operation. This is now the same as the other features, which all generate code that delegates to the external operator. We are using the implementation class `AsPrism` rather than the direct `as` operator because the external one is only accessible as an optic extension method. The way Focus works, each optic is generated on its own and composed together later, so we can't call an extension method on the last thing generated.
- Removed the `CastTo <: To` constraint in the `AsPrism` implementation, because proving the relationship was hard inside the Focus macro. It is sufficient to enforce the constraint in the public interface.
- Added some tests to confirm that the Focus and external `as` operators commute with respect to each other, just like the other operators