### PR TITLE
Deprecate first, second, left, right, split. Move choice to cats instance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,11 @@ lazy val buildSettings = Seq(
         "-Wconf:msg=class Possible in package function is deprecated:i",
         "-Wconf:msg=class Reverse in package function is deprecated:i",
         "-Wconf:msg=class Snoc in package function is deprecated:i",
-        "-Wconf:msg=class Snoc1 in package function is deprecated:i"
+        "-Wconf:msg=class Snoc1 in package function is deprecated:i",
+        "-Wconf:msg=method first in trait:i",
+        "-Wconf:msg=method second in trait:i",
+        "-Wconf:msg=method left in trait:i",
+        "-Wconf:msg=method right in trait:i",
       )
   },
   libraryDependencies ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val buildSettings = Seq(
         "-Wconf:msg=method first in trait:i",
         "-Wconf:msg=method second in trait:i",
         "-Wconf:msg=method left in trait:i",
-        "-Wconf:msg=method right in trait:i",
+        "-Wconf:msg=method right in trait:i"
       )
   },
   libraryDependencies ++= {

--- a/core/shared/src/main/scala/monocle/Getter.scala
+++ b/core/shared/src/main/scala/monocle/Getter.scala
@@ -40,15 +40,19 @@ trait Getter[S, A] extends Fold[S, A] { self =>
   def zip[A1](other: Getter[S, A1]): Getter[S, (A, A1)] =
     Getter[S, (A, A1)](s => (self.get(s), other.get(s)))
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   def first[B]: Getter[(S, B), (A, B)] =
     Getter[(S, B), (A, B)] { case (s, b) => (self.get(s), b) }
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   def second[B]: Getter[(B, S), (B, A)] =
     Getter[(B, S), (B, A)] { case (b, s) => (b, self.get(s)) }
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   override def left[C]: Getter[Either[S, C], Either[A, C]] =
     Getter[Either[S, C], Either[A, C]](_.leftMap(get))
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   override def right[C]: Getter[Either[C, S], Either[C, A]] =
     Getter[Either[C, S], Either[C, A]](_.map(get))
 
@@ -96,10 +100,10 @@ sealed abstract class GetterInstances extends GetterInstances0 {
       Getter(f)
 
     def first[A, B, C](f: Getter[A, B]): Getter[(A, C), (B, C)] =
-      f.first
+      Getter[(A, C), (B, C)] { case (a, c) => (f.get(a), c) }
 
     override def second[A, B, C](f: Getter[A, B]): Getter[(C, A), (C, B)] =
-      f.second
+      Getter[(C, A), (C, B)] { case (c, a) => (c, f.get(a)) }
 
     override def id[A]: Getter[A, A] =
       Iso.id

--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -77,6 +77,7 @@ trait PIso[S, T, A, B] extends PLens[S, T, A, B] with PPrism[S, T, A, B] { self 
     _ => reverseGet(b)
 
   /** pair two disjoint [[PIso]] */
+  @deprecated("no replacement", since = "3.0.0-M4")
   def split[S1, T1, A1, B1](other: PIso[S1, T1, A1, B1]): PIso[(S, S1), (T, T1), (A, A1), (B, B1)] =
     PIso[(S, S1), (T, T1), (A, A1), (B, B1)] { case (s, s1) =>
       (get(s), other.get(s1))
@@ -84,6 +85,7 @@ trait PIso[S, T, A, B] extends PLens[S, T, A, B] with PPrism[S, T, A, B] { self 
       (reverseGet(b), other.reverseGet(b1))
     }
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   override def first[C]: PIso[(S, C), (T, C), (A, C), (B, C)] =
     PIso[(S, C), (T, C), (A, C), (B, C)] { case (s, c) =>
       (get(s), c)
@@ -91,6 +93,7 @@ trait PIso[S, T, A, B] extends PLens[S, T, A, B] with PPrism[S, T, A, B] { self 
       (reverseGet(b), c)
     }
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   override def second[C]: PIso[(C, S), (C, T), (C, A), (C, B)] =
     PIso[(C, S), (C, T), (C, A), (C, B)] { case (c, s) =>
       (c, get(s))
@@ -98,9 +101,11 @@ trait PIso[S, T, A, B] extends PLens[S, T, A, B] with PPrism[S, T, A, B] { self 
       (c, reverseGet(b))
     }
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   override def left[C]: PIso[Either[S, C], Either[T, C], Either[A, C], Either[B, C]] =
     PIso[Either[S, C], Either[T, C], Either[A, C], Either[B, C]](_.leftMap(get))(_.leftMap(reverseGet))
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   override def right[C]: PIso[Either[C, S], Either[C, T], Either[C, A], Either[C, B]] =
     PIso[Either[C, S], Either[C, T], Either[C, A], Either[C, B]](_.map(get))(_.map(reverseGet))
 

--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -64,13 +64,8 @@ trait PLens[S, T, A, B] extends POptional[S, T, A, B] with Getter[S, A] { self =
   override def exist(p: A => Boolean): S => Boolean =
     p compose get
 
-  /** join two [[PLens]] with the same target */
-  def choice[S1, T1](other: PLens[S1, T1, A, B]): PLens[Either[S, S1], Either[T, T1], A, B] =
-    PLens[Either[S, S1], Either[T, T1], A, B](_.fold(self.get, other.get))(b =>
-      _.bimap(self.replace(b), other.replace(b))
-    )
-
   /** pair two disjoint [[PLens]] */
+  @deprecated("no replacement", since = "3.0.0-M4")
   def split[S1, T1, A1, B1](other: PLens[S1, T1, A1, B1]): PLens[(S, S1), (T, T1), (A, A1), (B, B1)] =
     PLens[(S, S1), (T, T1), (A, A1), (B, B1)] { case (s, s1) =>
       (self.get(s), other.get(s1))
@@ -80,6 +75,7 @@ trait PLens[S, T, A, B] extends POptional[S, T, A, B] with Getter[S, A] { self =
       }
     }
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   override def first[C]: PLens[(S, C), (T, C), (A, C), (B, C)] =
     PLens[(S, C), (T, C), (A, C), (B, C)] { case (s, c) =>
       (get(s), c)
@@ -89,6 +85,7 @@ trait PLens[S, T, A, B] extends POptional[S, T, A, B] with Getter[S, A] { self =
       }
     }
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   override def second[C]: PLens[(C, S), (C, T), (C, A), (C, B)] =
     PLens[(C, S), (C, T), (C, A), (C, B)] { case (c, s) =>
       (c, get(s))
@@ -189,7 +186,7 @@ object Lens {
 sealed abstract class LensInstances {
   implicit val lensChoice: Choice[Lens] = new Choice[Lens] {
     def choice[A, B, C](f: Lens[A, C], g: Lens[B, C]): Lens[Either[A, B], C] =
-      f choice g
+      Lens[Either[A, B], C](_.fold(f.get, g.get))(b => _.bimap(f.replace(b), g.replace(b)))
 
     def id[A]: Lens[A, A] =
       Iso.id

--- a/core/shared/src/main/scala/monocle/Optional.scala
+++ b/core/shared/src/main/scala/monocle/Optional.scala
@@ -80,12 +80,7 @@ trait POptional[S, T, A, B] extends PTraversal[S, T, A, B] { self =>
       from => self.replaceOption(to)(from).getOrElse(other.replace(to)(from))
     )
 
-  /** join two [[POptional]] with the same target */
-  def choice[S1, T1](other: POptional[S1, T1, A, B]): POptional[Either[S, S1], Either[T, T1], A, B] =
-    POptional[Either[S, S1], Either[T, T1], A, B](
-      _.fold(self.getOrModify(_).leftMap(Either.left), other.getOrModify(_).leftMap(Either.right))
-    )(b => _.bimap(self.replace(b), other.replace(b)))
-
+  @deprecated("no replacement", since = "3.0.0-M4")
   def first[C]: POptional[(S, C), (T, C), (A, C), (B, C)] =
     POptional[(S, C), (T, C), (A, C), (B, C)] { case (s, c) =>
       getOrModify(s).bimap(_ -> c, _ -> c)
@@ -95,6 +90,7 @@ trait POptional[S, T, A, B] extends PTraversal[S, T, A, B] { self =>
       }
     }
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   def second[C]: POptional[(C, S), (C, T), (C, A), (C, B)] =
     POptional[(C, S), (C, T), (C, A), (C, B)] { case (c, s) =>
       getOrModify(s).bimap(c -> _, c -> _)
@@ -242,7 +238,9 @@ object Optional {
 sealed abstract class OptionalInstances {
   implicit val optionalChoice: Choice[Optional] = new Choice[Optional] {
     def choice[A, B, C](f: Optional[A, C], g: Optional[B, C]): Optional[Either[A, B], C] =
-      f choice g
+      Optional[Either[A, B], C](
+        _.fold(f.getOption, g.getOption)
+      )(b => _.bimap(f.replace(b), g.replace(b)))
 
     def id[A]: Optional[A, A] =
       Iso.id[A]

--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -55,6 +55,7 @@ trait PPrism[S, T, A, B] extends POptional[S, T, A, B] { self =>
   def re: Getter[B, T] =
     Getter(reverseGet)
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   override def first[C]: PPrism[(S, C), (T, C), (A, C), (B, C)] =
     PPrism[(S, C), (T, C), (A, C), (B, C)] { case (s, c) =>
       getOrModify(s).bimap(_ -> c, _ -> c)
@@ -62,6 +63,7 @@ trait PPrism[S, T, A, B] extends POptional[S, T, A, B] { self =>
       (reverseGet(b), c)
     }
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   override def second[C]: PPrism[(C, S), (C, T), (C, A), (C, B)] =
     PPrism[(C, S), (C, T), (C, A), (C, B)] { case (c, s) =>
       getOrModify(s).bimap(c -> _, c -> _)
@@ -69,11 +71,13 @@ trait PPrism[S, T, A, B] extends POptional[S, T, A, B] { self =>
       (c, reverseGet(b))
     }
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   override def left[C]: PPrism[Either[S, C], Either[T, C], Either[A, C], Either[B, C]] =
     PPrism[Either[S, C], Either[T, C], Either[A, C], Either[B, C]](
       _.fold(getOrModify(_).bimap(Either.left, Either.left), c => Either.right(Either.right(c)))
     )(_.leftMap(reverseGet))
 
+  @deprecated("no replacement", since = "3.0.0-M4")
   override def right[C]: PPrism[Either[C, S], Either[C, T], Either[C, A], Either[C, B]] =
     PPrism[Either[C, S], Either[C, T], Either[C, A], Either[C, B]](
       _.fold(c => Either.right(Either.left(c)), getOrModify(_).bimap(Either.right, Either.right))

--- a/core/shared/src/main/scala/monocle/Setter.scala
+++ b/core/shared/src/main/scala/monocle/Setter.scala
@@ -38,10 +38,6 @@ trait PSetter[S, T, A, B] extends Serializable { self =>
   @deprecated("use replace instead", since = "3.0.0-M1")
   def set(b: B): S => T = replace(b)
 
-  /** join two [[PSetter]] with the same target */
-  def choice[S1, T1](other: PSetter[S1, T1, A, B]): PSetter[Either[S, S1], Either[T, T1], A, B] =
-    PSetter[Either[S, S1], Either[T, T1], A, B](b => _.bimap(self.modify(b), other.modify(b)))
-
   def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): PSetter[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]].andThen(std.option.pSome[A1, B1])
 
@@ -124,7 +120,7 @@ sealed abstract class SetterInstances {
       Iso.id
 
     def choice[A, B, C](f1: Setter[A, C], f2: Setter[B, C]): Setter[Either[A, B], C] =
-      f1 choice f2
+      Setter[Either[A, B], C](b => _.bimap(f1.modify(b), f2.modify(b)))
   }
 }
 

--- a/example/src/test/scala/monocle/generic/CoproductExample.scala
+++ b/example/src/test/scala/monocle/generic/CoproductExample.scala
@@ -1,6 +1,6 @@
 package monocle.generic
 
-import cats.implicits._
+import cats.arrow.Choice
 import monocle.Lens
 import monocle.macros.GenLens
 import monocle.MonocleSuite
@@ -95,8 +95,13 @@ class CoproductExample extends MonocleSuite with GenericInstances {
     case class C(otherName: String) extends S
 
     val lens: Lens[S, String] =
-      coProductToDisjunction[S].apply andThen
-        GenLens[A](_.name).choice(GenLens[B](_.name).choice(GenLens[C](_.otherName)))
+      coProductToDisjunction[S].apply andThen (Choice[Lens].choice(
+        GenLens[A](_.name),
+        Choice[Lens].choice(
+          GenLens[B](_.name),
+          GenLens[C](_.otherName)
+        )
+      ))
 
     assertEquals(lens.get(A("a")), "a")
     assertEquals(lens.get(B("b")), "b")

--- a/example/src/test/scala/monocle/generic/CoproductExample.scala
+++ b/example/src/test/scala/monocle/generic/CoproductExample.scala
@@ -1,5 +1,6 @@
 package monocle.generic
 
+import cats.implicits._
 import monocle.Lens
 import monocle.macros.GenLens
 import monocle.MonocleSuite


### PR DESCRIPTION
I doubt these methods see much use. We implemented them because we could but it is pain to mainten and it pollutes the interface.