### PR TITLE
Deprecate all except Lens codiagonal

### DIFF
--- a/core/shared/src/main/scala/monocle/Fold.scala
+++ b/core/shared/src/main/scala/monocle/Fold.scala
@@ -103,11 +103,9 @@ object Fold extends FoldInstances {
   def id[A]: Fold[A, A] =
     Iso.id[A]
 
+  @deprecated("use Lens.codiagonal", since = "3.0.0-M4")
   def codiagonal[A]: Fold[Either[A, A], A] =
-    new Fold[Either[A, A], A] {
-      def foldMap[M: Monoid](f: A => M)(s: Either[A, A]): M =
-        s.fold(f, f)
-    }
+    Lens.codiagonal
 
   def select[A](p: A => Boolean): Fold[A, A] =
     new Fold[A, A] {

--- a/core/shared/src/main/scala/monocle/Getter.scala
+++ b/core/shared/src/main/scala/monocle/Getter.scala
@@ -84,8 +84,9 @@ object Getter extends GetterInstances {
   def id[A]: Getter[A, A] =
     Iso.id[A]
 
+  @deprecated("use Lens.codiagonal", since = "3.0.0-M4")
   def codiagonal[A]: Getter[Either[A, A], A] =
-    Getter[Either[A, A], A](_.fold(identity, identity))
+    Lens.codiagonal
 
   def apply[S, A](_get: S => A): Getter[S, A] =
     (s: S) => _get(s)

--- a/core/shared/src/main/scala/monocle/Optional.scala
+++ b/core/shared/src/main/scala/monocle/Optional.scala
@@ -142,10 +142,9 @@ object POptional extends OptionalInstances {
   def id[S, T]: POptional[S, T, S, T] =
     PIso.id[S, T]
 
+  @deprecated("use PLens.codiagonal", since = "3.0.0-M4")
   def codiagonal[S, T]: POptional[Either[S, S], Either[T, T], S, T] =
-    POptional[Either[S, S], Either[T, T], S, T](
-      _.fold(Either.right, Either.right)
-    )(t => _.bimap(_ => t, _ => t))
+    PLens.codiagonal
 
   /** create a [[POptional]] using the canonical functions: getOrModify and replace */
   def apply[S, T, A, B](_getOrModify: S => Either[T, A])(_set: B => S => T): POptional[S, T, A, B] =
@@ -181,8 +180,9 @@ object Optional {
   def id[A]: Optional[A, A] =
     Iso.id[A]
 
+  @deprecated("use Lens.codiagonal", since = "3.0.0-M4")
   def codiagonal[S]: Optional[Either[S, S], S] =
-    POptional.codiagonal
+    Lens.codiagonal
 
   /** [[Optional]] that points to nothing */
   def void[S, A]: Optional[S, A] =

--- a/core/shared/src/main/scala/monocle/Setter.scala
+++ b/core/shared/src/main/scala/monocle/Setter.scala
@@ -61,8 +61,9 @@ object PSetter extends SetterInstances {
   def id[S, T]: PSetter[S, T, S, T] =
     PIso.id[S, T]
 
+  @deprecated("use PLens.codiagonal", since = "3.0.0-M4")
   def codiagonal[S, T]: PSetter[Either[S, S], Either[T, T], S, T] =
-    PSetter[Either[S, S], Either[T, T], S, T](f => _.bimap(f, f))
+    PLens.codiagonal
 
   /** create a [[PSetter]] using modify function */
   def apply[S, T, A, B](_modify: (A => B) => S => T): PSetter[S, T, A, B] =
@@ -98,8 +99,9 @@ object Setter {
   def id[A]: Setter[A, A] =
     Iso.id[A]
 
+  @deprecated("use Lens.codiagonal", since = "3.0.0-M4")
   def codiagonal[S]: Setter[Either[S, S], S] =
-    PSetter.codiagonal
+    Lens.codiagonal
 
   /** [[Setter]] that points to nothing */
   @deprecated("use Optional.void", since = "3.0.0-M2")

--- a/core/shared/src/main/scala/monocle/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/Traversal.scala
@@ -81,12 +81,9 @@ object PTraversal extends TraversalInstances {
   def id[S, T]: PTraversal[S, T, S, T] =
     PIso.id[S, T]
 
+  @deprecated("use PLens.codiagonal", since = "3.0.0-M4")
   def codiagonal[S, T]: PTraversal[Either[S, S], Either[T, T], S, T] =
-    new PTraversal[Either[S, S], Either[T, T], S, T] {
-      def modifyA[F[_]: Applicative](f: S => F[T])(s: Either[S, S]): F[Either[T, T]] =
-        s.bimap(f, f)
-          .fold(Applicative[F].map(_)(Either.left), Applicative[F].map(_)(Either.right))
-    }
+    PLens.codiagonal
 
   /** create a [[PTraversal]] from a Traverse */
   def fromTraverse[T[_]: Traverse, A, B]: PTraversal[T[A], T[B], A, B] =
@@ -145,8 +142,9 @@ object Traversal {
   def id[A]: Traversal[A, A] =
     Iso.id[A]
 
+  @deprecated("use Lens.codiagonal", since = "3.0.0-M4")
   def codiagonal[S, T]: Traversal[Either[S, S], S] =
-    PTraversal.codiagonal
+    Lens.codiagonal
 
   /** create a [[PTraversal]] from a Traverse */
   def fromTraverse[T[_]: Traverse, A]: Traversal[T[A], A] =


### PR DESCRIPTION
We don't need the other ones now that we have inheritance between optics.