### PR TITLE
Field syntax for optics

### DIFF
--- a/docs/src/main/mdoc/focus.md
+++ b/docs/src/main/mdoc/focus.md
@@ -43,7 +43,7 @@ anna
 
 The Scala 2 version is the same, except for the import
 ```scala mdoc
-import monocle.macros.syntax.all._
+import monocle.syntax.all._
 
 anna
   .focus(_.name)
@@ -90,17 +90,18 @@ As you can see, focusing on the street number has no effect on `bob` because thi
 
 In Scala 2
 ```scala mdoc
-import monocle.Focus
-import monocle.macros.syntax.all._
+import monocle.syntax.all._
 
 anna
-  .focus(_.address).some
-  .andThen(Focus[Address](_.streetNumber))
+  .focus(_.address)
+  .some
+  .field(_.streetNumber)
   .modify(_ + 1)
 
 bob
-  .focus(_.address).some
-  .andThen(Focus[Address](_.streetNumber))
+  .focus(_.address)
+  .some
+  .field(_.streetNumber)
   .modify(_ + 1)
 ```
 
@@ -157,19 +158,18 @@ bob
 
 In Scala 2
 ```scala mdoc
-import monocle.Focus
-import monocle.macros.syntax.all._
+import monocle.syntax.all._
 
 anna
   .focus(_.debitCards) 
   .index(1)
-  .andThen(Focus[DebitCard](_.expirationDate))
+  .field(_.expirationDate)
   .replace(YearMonth.of(2026, 2))
 
 bob
   .focus(_.debitCards) 
   .index(1)
-  .andThen(Focus[DebitCard](_.expirationDate))
+  .field(_.expirationDate)
   .replace(YearMonth.of(2026, 2))
 ```
 

--- a/docs/src/main/mdoc/focus.md
+++ b/docs/src/main/mdoc/focus.md
@@ -11,7 +11,7 @@ An important point before we start. `Focus` is a macro available for both Scala 
 However, the macro API has completely changed between Scala 2 and 3, so for each example, we will first show the 
 version for Scala 3 and then Scala 2 (often more verbose). 
 
-## Update a field of a case class
+## Update a field of a case class (Scala 2 & 3)
 
 ```scala mdoc:silent
 case class User(name: String, address: Address)
@@ -20,7 +20,6 @@ case class Address(streetNumber: Int, streetName: String)
 val anna = User("Anna", Address(12, "high street"))
 ```
 
-In Scala 3
 ```scala
 import monocle.syntax.all._
 
@@ -41,21 +40,7 @@ anna
 // )
 ```
 
-The Scala 2 version is the same, except for the import
-```scala mdoc
-import monocle.syntax.all._
-
-anna
-  .focus(_.name)
-  .replace("Bob")
-
-anna
-  .focus(_.address.streetNumber)
-  .modify(_ + 1)
-```
-
-
-## Update an optional field of a case class
+## Update an optional field of a case class (Scala 3 only)
 
 This time a user may or may not have an `Address`. 
 
@@ -88,24 +73,7 @@ bob
 
 As you can see, focusing on the street number has no effect on `bob` because this instance doesn't have an address.
 
-In Scala 2
-```scala mdoc
-import monocle.syntax.all._
-
-anna
-  .focus(_.address)
-  .some
-  .field(_.streetNumber)
-  .modify(_ + 1)
-
-bob
-  .focus(_.address)
-  .some
-  .field(_.streetNumber)
-  .modify(_ + 1)
-```
-
-## Update a single element inside a List
+## Update a single element inside a List (Scala 3 only)
 
 In this example, `User` contains a `List` of `DebitCard`. Let's imagine we want to update the expiration date of
 the second debit card. 
@@ -127,7 +95,6 @@ val anna = User(
 val bob = User("Bob", List())
 ```
 
-In Scala 3
 ```scala
 import monocle.syntax.all._
 
@@ -154,23 +121,6 @@ bob
   .focus(_.debitCards.index(1).as[DebitCard].expirationDate)
   .replace(YearMonth.of(2026, 2))
 // res: User = User("Bob", List())
-```
-
-In Scala 2
-```scala mdoc
-import monocle.syntax.all._
-
-anna
-  .focus(_.debitCards) 
-  .index(1)
-  .field(_.expirationDate)
-  .replace(YearMonth.of(2026, 2))
-
-bob
-  .focus(_.debitCards) 
-  .index(1)
-  .field(_.expirationDate)
-  .replace(YearMonth.of(2026, 2))
 ```
 
 `replace` had no effect on `bob` because he doesn't have a debit card.

--- a/macro/src/main/scala-2.x/monocle/macros/GenLens.scala
+++ b/macro/src/main/scala-2.x/monocle/macros/GenLens.scala
@@ -7,7 +7,7 @@ class GenLens[A] {
   def apply(): Iso[A, A] = Iso.id
 
   /** generate a [[Lens]] between a case class `S` and one of its field */
-  def apply[B](field: A => B): Lens[A, B] = macro MacroImpl.genLens_impl[A, B]
+  def apply[B](lambda: A => B): Lens[A, B] = macro MacroImpl.genLens_impl[A, B]
 }
 
 object GenLens {

--- a/macro/src/main/scala-2.x/monocle/macros/internal/Macro.scala
+++ b/macro/src/main/scala-2.x/monocle/macros/internal/Macro.scala
@@ -9,7 +9,7 @@ object Macro {
 }
 
 private[macros] class MacroImpl(val c: blackbox.Context) {
-  def genLens_impl[S: c.WeakTypeTag, A: c.WeakTypeTag](field: c.Expr[S => A]): c.Expr[Lens[S, A]] = {
+  def genLens_impl[S: c.WeakTypeTag, A: c.WeakTypeTag](lambda: c.Expr[S => A]): c.Expr[Lens[S, A]] = {
     import c.universe._
 
     /** Extractor for member select chains.
@@ -28,7 +28,7 @@ private[macros] class MacroImpl(val c: blackbox.Context) {
         }
     }
 
-    field match {
+    lambda match {
       // _.field
       case Expr(
             Function(
@@ -55,7 +55,7 @@ private[macros] class MacroImpl(val c: blackbox.Context) {
       case _ =>
         c.abort(
           c.enclosingPosition,
-          s"Illegal field reference ${show(field.tree)}; please use _.field1.field2... instead"
+          s"Illegal field reference ${show(lambda.tree)}; please use _.field1.field2... instead"
         )
     }
   }

--- a/macro/src/main/scala-2.x/monocle/macros/syntax/AppliedFocusSyntax.scala
+++ b/macro/src/main/scala-2.x/monocle/macros/syntax/AppliedFocusSyntax.scala
@@ -27,16 +27,6 @@ class GenAppliedLensOpsImpl(val c: blackbox.Context) {
         c.abort(c.enclosingPosition, s"Invalid prefix tree ${show(t)}")
     }
 
-    lambda match {
-      // _.field
-      case Expr(Function(List(ValDef(_, _, _, EmptyTree)), Select(Ident(_), _))) => ()
-      case _ =>
-        c.abort(
-          c.enclosingPosition,
-          s"Illegal field reference ${show(lambda.tree)}; please use _.field... instead"
-        )
-    }
-
     c.Expr[AppliedLens[A, C]](q"""
       _root_.monocle.syntax.AppliedPLens(
         $subj,

--- a/macro/src/main/scala-2.x/monocle/macros/syntax/AppliedFocusSyntax.scala
+++ b/macro/src/main/scala-2.x/monocle/macros/syntax/AppliedFocusSyntax.scala
@@ -11,14 +11,14 @@ trait AppliedFocusSyntax {
 
 class AppliedFocusOps[A](private val value: A) extends AnyVal {
   @deprecated("use focus", since = "3.0.0-M1")
-  def lens[C](field: A => C): AppliedLens[A, C] = macro GenAppliedLensOpsImpl.lens_impl[A, C]
-  def focus[C](field: A => C): AppliedLens[A, C] = macro GenAppliedLensOpsImpl.lens_impl[A, C]
+  def lens[C](lambda: A => C): AppliedLens[A, C] = macro GenAppliedLensOpsImpl.lens_impl[A, C]
+  def focus[C](lambda: A => C): AppliedLens[A, C] = macro GenAppliedLensOpsImpl.lens_impl[A, C]
 
   def focus(): AppliedIso[A, A] = AppliedPIso(value, Iso.id)
 }
 
 class GenAppliedLensOpsImpl(val c: blackbox.Context) {
-  def lens_impl[A: c.WeakTypeTag, C](field: c.Expr[A => C]): c.Expr[AppliedLens[A, C]] = {
+  def lens_impl[A: c.WeakTypeTag, C](lambda: c.Expr[A => C]): c.Expr[AppliedLens[A, C]] = {
     import c.universe._
 
     val subj = c.prefix.tree match {
@@ -27,10 +27,20 @@ class GenAppliedLensOpsImpl(val c: blackbox.Context) {
         c.abort(c.enclosingPosition, s"Invalid prefix tree ${show(t)}")
     }
 
+    lambda match {
+      // _.field
+      case Expr(Function(List(ValDef(_, _, _, EmptyTree)), Select(Ident(_), _))) => ()
+      case _ =>
+        c.abort(
+          c.enclosingPosition,
+          s"Illegal field reference ${show(lambda.tree)}; please use _.field... instead"
+        )
+    }
+
     c.Expr[AppliedLens[A, C]](q"""
       _root_.monocle.syntax.AppliedPLens(
         $subj,
-        _root_.monocle.macros.GenLens[${c.weakTypeOf[A]}](${field})
+        _root_.monocle.macros.GenLens[${c.weakTypeOf[A]}](${lambda})
       )
     """)
   }

--- a/macro/src/main/scala-2.x/monocle/macros/syntax/MacroSyntax.scala
+++ b/macro/src/main/scala-2.x/monocle/macros/syntax/MacroSyntax.scala
@@ -117,6 +117,16 @@ class MacroOpsImpl(val c: blackbox.Context) {
       case t                               => c.abort(c.enclosingPosition, s"Invalid prefix tree ${show(t)}")
     }
 
+    lambda match {
+      // _.field
+      case Expr(Function(List(ValDef(_, _, _, EmptyTree)), Select(Ident(_), _))) => ()
+      case _ =>
+        c.abort(
+          c.enclosingPosition,
+          s"Illegal field reference ${show(lambda.tree)}; please use _.field... instead"
+        )
+    }
+
     c.Expr[Optic[From, Next]](
       q"""$subj.andThen(_root_.monocle.macros.GenLens[${c.weakTypeOf[To]}](${lambda}))"""
     )

--- a/macro/src/main/scala-2.x/monocle/macros/syntax/MacroSyntax.scala
+++ b/macro/src/main/scala-2.x/monocle/macros/syntax/MacroSyntax.scala
@@ -5,12 +5,16 @@ import monocle._
 import scala.reflect.macros.blackbox
 
 trait MacroSyntax {
+  implicit def toMacroLensOps[S, A](optic: Lens[S, A]): MacroLensOps[S, A]                = new MacroLensOps(optic)
   implicit def toMacroPrismOps[S, A](optic: Prism[S, A]): MacroPrismOps[S, A]             = new MacroPrismOps(optic)
   implicit def toMacroOptionalOps[S, A](optic: Optional[S, A]): MacroOptionalOps[S, A]    = new MacroOptionalOps(optic)
   implicit def toMacroTraversalOps[S, A](optic: Traversal[S, A]): MacroTraversalOps[S, A] = new MacroTraversalOps(optic)
   implicit def toMacroSetterOps[S, A](optic: Setter[S, A]): MacroSetterOps[S, A]          = new MacroSetterOps(optic)
+  implicit def toMacroGetterOps[S, A](optic: Getter[S, A]): MacroGetterOps[S, A]          = new MacroGetterOps(optic)
   implicit def toMacroFoldOps[S, A](optic: Fold[S, A]): MacroFoldOps[S, A]                = new MacroFoldOps(optic)
 
+  implicit def toMacroLensOps[S, A](optic: AppliedLens[S, A]): MacroAppliedLensOps[S, A] =
+    new MacroAppliedLensOps(optic)
   implicit def toMacroAppliedPrismOps[S, A](optic: AppliedPrism[S, A]): MacroAppliedPrismOps[S, A] =
     new MacroAppliedPrismOps(optic)
   implicit def toMacroAppliedOptionalOps[S, A](optic: AppliedOptional[S, A]): MacroAppliedOptionalOps[S, A] =
@@ -19,51 +23,79 @@ trait MacroSyntax {
     new MacroAppliedTraversalOps(optic)
   implicit def toMacroAppliedSetterOps[S, A](optic: AppliedSetter[S, A]): MacroAppliedSetterOps[S, A] =
     new MacroAppliedSetterOps(optic)
+  implicit def toMacroAppliedGetterOps[S, A](optic: AppliedGetter[S, A]): MacroAppliedGetterOps[S, A] =
+    new MacroAppliedGetterOps(optic)
   implicit def toMacroAppliedFoldOps[S, A](optic: AppliedFold[S, A]): MacroAppliedFoldOps[S, A] =
     new MacroAppliedFoldOps(optic)
 }
 
+class MacroLensOps[S, A](private val optic: Lens[S, A]) extends AnyVal {
+  def field[Next](lambda: A => Next): Lens[S, Next] = macro MacroOpsImpl.field_impl[Lens, S, A, Next]
+}
+
 class MacroPrismOps[S, A](private val optic: Prism[S, A]) extends AnyVal {
-  def as[CastTo <: A]: Prism[S, CastTo] = macro MacroAsOpsImpl.as_impl[Prism, S, A, CastTo]
+  def as[CastTo <: A]: Prism[S, CastTo] = macro MacroOpsImpl.as_impl[Prism, S, A, CastTo]
 }
 
 class MacroOptionalOps[S, A](private val optic: Optional[S, A]) extends AnyVal {
-  def as[CastTo <: A]: Optional[S, CastTo] = macro MacroAsOpsImpl.as_impl[Optional, S, A, CastTo]
+  def field[Next](lambda: A => Next): Optional[S, Next] = macro MacroOpsImpl.field_impl[Optional, S, A, Next]
+  def as[CastTo <: A]: Optional[S, CastTo] = macro MacroOpsImpl.as_impl[Optional, S, A, CastTo]
 }
 
 class MacroTraversalOps[S, A](private val optic: Traversal[S, A]) extends AnyVal {
-  def as[CastTo <: A]: Traversal[S, CastTo] = macro MacroAsOpsImpl.as_impl[Traversal, S, A, CastTo]
+  def field[Next](lambda: A => Next): Traversal[S, Next] = macro MacroOpsImpl.field_impl[Traversal, S, A, Next]
+  def as[CastTo <: A]: Traversal[S, CastTo] = macro MacroOpsImpl.as_impl[Traversal, S, A, CastTo]
 }
 
 class MacroSetterOps[S, A](private val optic: Setter[S, A]) extends AnyVal {
-  def as[CastTo <: A]: Setter[S, CastTo] = macro MacroAsOpsImpl.as_impl[Setter, S, A, CastTo]
+  def field[Next](lambda: A => Next): Setter[S, Next] = macro MacroOpsImpl.field_impl[Setter, S, A, Next]
+  def as[CastTo <: A]: Setter[S, CastTo] = macro MacroOpsImpl.as_impl[Setter, S, A, CastTo]
+}
+
+class MacroGetterOps[S, A](private val optic: Getter[S, A]) extends AnyVal {
+  def field[Next](lambda: A => Next): Getter[S, Next] = macro MacroOpsImpl.field_impl[Getter, S, A, Next]
 }
 
 class MacroFoldOps[S, A](private val optic: Fold[S, A]) extends AnyVal {
-  def as[CastTo <: A]: Fold[S, CastTo] = macro MacroAsOpsImpl.as_impl[Fold, S, A, CastTo]
+  def field[Next](lambda: A => Next): Fold[S, Next] = macro MacroOpsImpl.field_impl[Fold, S, A, Next]
+  def as[CastTo <: A]: Fold[S, CastTo] = macro MacroOpsImpl.as_impl[Fold, S, A, CastTo]
+}
+
+class MacroAppliedLensOps[S, A](private val optic: AppliedLens[S, A]) extends AnyVal {
+  def field[Next](lambda: A => Next): AppliedLens[S, Next] = macro MacroOpsImpl.field_impl[AppliedLens, S, A, Next]
 }
 
 class MacroAppliedPrismOps[S, A](private val optic: AppliedPrism[S, A]) extends AnyVal {
-  def as[CastTo <: A]: AppliedPrism[S, CastTo] = macro MacroAsOpsImpl.as_impl[AppliedPrism, S, A, CastTo]
+  def as[CastTo <: A]: AppliedPrism[S, CastTo] = macro MacroOpsImpl.as_impl[AppliedPrism, S, A, CastTo]
 }
 
 class MacroAppliedOptionalOps[S, A](private val optic: AppliedOptional[S, A]) extends AnyVal {
-  def as[CastTo <: A]: AppliedOptional[S, CastTo] = macro MacroAsOpsImpl.as_impl[AppliedOptional, S, A, CastTo]
+  def field[Next](lambda: A => Next): AppliedOptional[S, Next] =
+    macro MacroOpsImpl.field_impl[AppliedOptional, S, A, Next]
+  def as[CastTo <: A]: AppliedOptional[S, CastTo] = macro MacroOpsImpl.as_impl[AppliedOptional, S, A, CastTo]
 }
 
 class MacroAppliedTraversalOps[S, A](private val optic: AppliedTraversal[S, A]) extends AnyVal {
-  def as[CastTo <: A]: AppliedTraversal[S, CastTo] = macro MacroAsOpsImpl.as_impl[AppliedTraversal, S, A, CastTo]
+  def field[Next](lambda: A => Next): AppliedTraversal[S, Next] =
+    macro MacroOpsImpl.field_impl[AppliedTraversal, S, A, Next]
+  def as[CastTo <: A]: AppliedTraversal[S, CastTo] = macro MacroOpsImpl.as_impl[AppliedTraversal, S, A, CastTo]
 }
 
 class MacroAppliedSetterOps[S, A](private val optic: AppliedSetter[S, A]) extends AnyVal {
-  def as[CastTo <: A]: AppliedSetter[S, CastTo] = macro MacroAsOpsImpl.as_impl[AppliedSetter, S, A, CastTo]
+  def field[Next](lambda: A => Next): AppliedSetter[S, Next] = macro MacroOpsImpl.field_impl[AppliedSetter, S, A, Next]
+  def as[CastTo <: A]: AppliedSetter[S, CastTo] = macro MacroOpsImpl.as_impl[AppliedSetter, S, A, CastTo]
+}
+
+class MacroAppliedGetterOps[S, A](private val optic: AppliedGetter[S, A]) extends AnyVal {
+  def field[Next](lambda: A => Next): AppliedGetter[S, Next] = macro MacroOpsImpl.field_impl[AppliedGetter, S, A, Next]
 }
 
 class MacroAppliedFoldOps[S, A](private val optic: AppliedFold[S, A]) extends AnyVal {
-  def as[CastTo <: A]: AppliedFold[S, CastTo] = macro MacroAsOpsImpl.as_impl[AppliedFold, S, A, CastTo]
+  def field[Next](lambda: A => Next): AppliedFold[S, Next] = macro MacroOpsImpl.field_impl[AppliedFold, S, A, Next]
+  def as[CastTo <: A]: AppliedFold[S, CastTo] = macro MacroOpsImpl.as_impl[AppliedFold, S, A, CastTo]
 }
 
-class MacroAsOpsImpl(val c: blackbox.Context) {
+class MacroOpsImpl(val c: blackbox.Context) {
   def as_impl[Optic[_, _], From, To: c.WeakTypeTag, CastTo: c.WeakTypeTag]: c.Expr[Optic[From, CastTo]] = {
     import c.universe._
 
@@ -74,6 +106,19 @@ class MacroAsOpsImpl(val c: blackbox.Context) {
 
     c.Expr[Optic[From, CastTo]](
       q"""$subj.andThen(_root_.monocle.macros.GenPrism[${c.weakTypeOf[To]}, ${c.weakTypeOf[CastTo]}])"""
+    )
+  }
+
+  def field_impl[Optic[_, _], From, To: c.WeakTypeTag, Next](lambda: c.Expr[To => Next]): c.Expr[Optic[From, Next]] = {
+    import c.universe._
+
+    val subj = c.prefix.tree match {
+      case Apply(TypeApply(_, _), List(x)) => x
+      case t                               => c.abort(c.enclosingPosition, s"Invalid prefix tree ${show(t)}")
+    }
+
+    c.Expr[Optic[From, Next]](
+      q"""$subj.andThen(_root_.monocle.macros.GenLens[${c.weakTypeOf[To]}](${lambda}))"""
     )
   }
 }

--- a/macro/src/test/scala-2.x/monocle/macros/FieldSyntaxSpec.scala
+++ b/macro/src/test/scala-2.x/monocle/macros/FieldSyntaxSpec.scala
@@ -30,6 +30,10 @@ class FieldSyntaxSpec extends DisciplineSuite {
   test("getter.field")(assert(getter.field(_.name).get(user) == user.name))
   test("fold.field")(assert(fold.field(_.name).getAll(user) == List(user.name)))
 
+  test("field doesn't work for nested fields"){
+    compileErrors("iso.field(_.address.streetNumber)")
+  }
+
   val appliedIso: AppliedIso[User, User]             = AppliedIso(user, iso)
   val appliedLens: AppliedLens[User, User]           = AppliedIso(user, iso)
   val appliedPrism: AppliedPrism[User, User]         = AppliedIso(user, iso)

--- a/macro/src/test/scala-2.x/monocle/macros/FieldSyntaxSpec.scala
+++ b/macro/src/test/scala-2.x/monocle/macros/FieldSyntaxSpec.scala
@@ -1,0 +1,51 @@
+package monocle.macros
+
+import monocle._
+import monocle.syntax.AppliedIso
+import monocle.syntax.all._
+import munit.DisciplineSuite
+
+class FieldSyntaxSpec extends DisciplineSuite {
+
+  case class User(name: String, address: Address)
+  case class Address(streetNumber: Int, postcode: String)
+
+  val iso: Iso[User, User]             = Iso.id
+  val lens: Lens[User, User]           = Iso.id
+  val prism: Prism[User, User]         = Iso.id
+  val optional: Optional[User, User]   = Iso.id
+  val traversal: Traversal[User, User] = Iso.id
+  val setter: Setter[User, User]       = Iso.id
+  val getter: Getter[User, User]       = Iso.id
+  val fold: Fold[User, User]           = Iso.id
+
+  val user = User("Bob", Address(12, "EC1 7RT"))
+
+  test("iso.field")(assertEquals(iso.field(_.name).get(user), user.name))
+  test("lens.field")(assertEquals(lens.field(_.name).get(user), user.name))
+  test("prism.field")(assertEquals(prism.field(_.name).getOption(user), Some(user.name)))
+  test("optional.field")(assertEquals(optional.field(_.name).getOption(user), Some(user.name)))
+  test("traversal.field")(assertEquals(traversal.field(_.name).getAll(user), List(user.name)))
+  test("setter.field")(assertEquals(setter.field(_.name).replace("Eda")(user), user.copy(name = "Eda")))
+  test("getter.field")(assert(getter.field(_.name).get(user) == user.name))
+  test("fold.field")(assert(fold.field(_.name).getAll(user) == List(user.name)))
+
+  val appliedIso: AppliedIso[User, User]             = AppliedIso(user, iso)
+  val appliedLens: AppliedLens[User, User]           = AppliedIso(user, iso)
+  val appliedPrism: AppliedPrism[User, User]         = AppliedIso(user, iso)
+  val appliedOptional: AppliedOptional[User, User]   = AppliedIso(user, iso)
+  val appliedTraversal: AppliedTraversal[User, User] = AppliedIso(user, iso)
+  val appliedSetter: AppliedSetter[User, User]       = AppliedIso(user, iso)
+  val appliedGetter: AppliedGetter[User, User]       = AppliedIso(user, iso)
+  val appliedFold: AppliedFold[User, User]           = AppliedIso(user, iso)
+
+  test("applied iso.field")(assertEquals(appliedIso.field(_.name).get, user.name))
+  test("applied lens.field")(assertEquals(appliedLens.field(_.name).get, user.name))
+  test("applied prism.field")(assertEquals(appliedPrism.field(_.name).getOption, Some(user.name)))
+  test("applied optional.field")(assertEquals(appliedOptional.field(_.name).getOption, Some(user.name)))
+  test("applied traversal.field")(assertEquals(appliedTraversal.field(_.name).getAll, List(user.name)))
+  test("applied setter.field")(assertEquals(appliedSetter.field(_.name).replace("Eda"), user.copy(name = "Eda")))
+  test("applied getter.field")(assert(appliedGetter.field(_.name).get == user.name))
+  test("applied fold.field")(assert(appliedFold.field(_.name).getAll == List(user.name)))
+
+}

--- a/macro/src/test/scala-2.x/monocle/macros/FieldSyntaxSpec.scala
+++ b/macro/src/test/scala-2.x/monocle/macros/FieldSyntaxSpec.scala
@@ -30,7 +30,7 @@ class FieldSyntaxSpec extends DisciplineSuite {
   test("getter.field")(assert(getter.field(_.name).get(user) == user.name))
   test("fold.field")(assert(fold.field(_.name).getAll(user) == List(user.name)))
 
-  test("field doesn't work for nested fields"){
+  test("field doesn't work for nested fields") {
     compileErrors("iso.field(_.address.streetNumber)")
   }
 

--- a/macro/src/test/scala-2.x/monocle/macros/FieldSyntaxSpec.scala
+++ b/macro/src/test/scala-2.x/monocle/macros/FieldSyntaxSpec.scala
@@ -31,7 +31,12 @@ class FieldSyntaxSpec extends DisciplineSuite {
   test("fold.field")(assert(fold.field(_.name).getAll(user) == List(user.name)))
 
   test("field doesn't work for nested fields") {
-    assertEquals(compileErrors("iso.field(_.address.streetNumber)"), "expect some error")
+    assertEquals(
+      compileErrors("iso.field(_.address.streetNumber)"),
+      """error: Illegal field reference ((x$9: FieldSyntaxSpec.this.User) => x$9.address.streetNumber); please use _.field... instead
+iso.field(_.address.streetNumber)
+         ^"""
+    )
   }
 
   val appliedIso: AppliedIso[User, User]             = AppliedIso(user, iso)
@@ -51,5 +56,14 @@ class FieldSyntaxSpec extends DisciplineSuite {
   test("applied setter.field")(assertEquals(appliedSetter.field(_.name).replace("Eda"), user.copy(name = "Eda")))
   test("applied getter.field")(assert(appliedGetter.field(_.name).get == user.name))
   test("applied fold.field")(assert(appliedFold.field(_.name).getAll == List(user.name)))
+
+  test("field doesn't work for nested fields") {
+    assertEquals(
+      compileErrors("appliedIso.field(_.address.streetNumber)"),
+      """error: Illegal field reference ((x$18: FieldSyntaxSpec.this.User) => x$18.address.streetNumber); please use _.field... instead
+appliedIso.field(_.address.streetNumber)
+                ^"""
+    )
+  }
 
 }

--- a/macro/src/test/scala-2.x/monocle/macros/FieldSyntaxSpec.scala
+++ b/macro/src/test/scala-2.x/monocle/macros/FieldSyntaxSpec.scala
@@ -31,7 +31,7 @@ class FieldSyntaxSpec extends DisciplineSuite {
   test("fold.field")(assert(fold.field(_.name).getAll(user) == List(user.name)))
 
   test("field doesn't work for nested fields") {
-    compileErrors("iso.field(_.address.streetNumber)")
+    assertEquals(compileErrors("iso.field(_.address.streetNumber)"), "expect some error")
   }
 
   val appliedIso: AppliedIso[User, User]             = AppliedIso(user, iso)


### PR DESCRIPTION
Add a `field(lambda)` on all `Optics` such that:

```scala
case class User(name: String, address: Address)
case class Address(streeetNumber: Int, postcode: String)

Focus[User]()
  .field(_.address)
  .field(_.streetNumber) == Focus[User](_.address.streetNumber)
```

It is a bit redundant but this method is meant for updating existing optics:

```scala
val user: Lens[State, User] = ... // suppose we have it defined

user.field(_.name) == user.andThen(Focus[User](_.name))
```

