### PR TITLE
Refocus feature

### DIFF
--- a/core/shared/src/main/scala-3.x/monocle/Focus.scala
+++ b/core/shared/src/main/scala-3.x/monocle/Focus.scala
@@ -1,10 +1,10 @@
 package monocle
 
-import monocle.syntax.AppliedFocusSyntax
+import monocle.syntax.{AppliedFocusSyntax, ComposedFocusSyntax}
 import monocle.internal.focus.FocusImpl
 import monocle.function.{Each, At, Index}
 
-object Focus extends AppliedFocusSyntax {
+object Focus extends AppliedFocusSyntax with ComposedFocusSyntax {
 
   sealed trait KeywordContext {
     extension [From] (from: From)

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/ComposedFocusImpl.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/ComposedFocusImpl.scala
@@ -1,0 +1,24 @@
+package monocle.internal.focus
+
+import monocle.{Focus, Lens, Iso, Prism, Optional, Traversal, Getter, Setter, Fold}
+import monocle.syntax.{AppliedPLens, AppliedPPrism, AppliedPIso, AppliedPOptional, AppliedPTraversal }
+import scala.quoted.{Type, Expr, Quotes, quotes}
+
+
+private[monocle] object ComposedFocusImpl {
+
+
+  def apply[S: Type, A: Type,Next: Type](optic: Expr[Setter[S,A]], lambda: Expr[Focus.KeywordContext ?=> A => Next])(using Quotes): Expr[Any] = {
+    import quotes.reflect._
+    val generatedOptic = FocusImpl(lambda)
+
+    generatedOptic.asTerm.tpe.asType match {
+      case '[Lens[f, t]] => '{ ${optic}.andThen[Next, Next](${generatedOptic.asExprOf[Lens[A,Next]]}) }
+      case '[Prism[f, t]] => '{ ${optic}.andThen[Next, Next](${generatedOptic.asExprOf[Prism[A,Next]]}) }
+      case '[Iso[f, t]] => '{ ${optic}.andThen[Next, Next](${generatedOptic.asExprOf[Iso[A,Next]]}) }
+      case '[Optional[f, t]] => '{ ${optic}.andThen[Next, Next](${generatedOptic.asExprOf[Optional[A,Next]]}) }
+      case '[Traversal[f, t]] => '{ ${optic}.andThen[Next, Next](${generatedOptic.asExprOf[Traversal[A,Next]]}) }
+    }
+  }
+}
+

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/ComposedFocusImpl.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/ComposedFocusImpl.scala
@@ -1,66 +1,40 @@
 package monocle.internal.focus
 
-import monocle.{Focus, Lens, Iso, Prism, Optional, Traversal, Getter, Setter, Fold, AppliedSetter}
+import monocle.{Focus, Lens, Iso, Prism, Optional, Traversal, Getter, Setter, Fold, AppliedSetter, AppliedFold, AppliedGetter}
 import scala.quoted.{Type, Expr, Quotes, quotes}
 
-
 private[monocle] object ComposedFocusImpl {
-
-
   def apply[S: Type, A: Type, Next: Type](optic: Expr[Setter[S,A] | Fold[S,A]], lambda: Expr[Focus.KeywordContext ?=> A => Next])(using Quotes): Expr[Any] = {
     import quotes.reflect._
-    val generatedOptic = FocusImpl(lambda)
+    
+    val generatedOptic = FocusImpl(lambda).asTerm
+    val opticType = optic.asTerm.tpe.widen
+    val nextType = TypeRepr.of[Next]
+    
+    def onlyRequiresOneTypeParameter(tpe: TypeRepr): Boolean = 
+      tpe =:= TypeRepr.of[Fold[S,A]] || tpe =:= TypeRepr.of[Getter[S,A]]
 
-    val typedGeneratedOptic = generatedOptic.asTerm.tpe.asType match {
-      case '[Lens[f, t]] => generatedOptic.asExprOf[Lens[A,Next]]
-      case '[Prism[f, t]] => generatedOptic.asExprOf[Prism[A,Next]]
-      case '[Iso[f, t]] => generatedOptic.asExprOf[Iso[A,Next]]
-      case '[Optional[f, t]] => generatedOptic.asExprOf[Optional[A,Next]]
-      case '[Traversal[f, t]] => generatedOptic.asExprOf[Traversal[A,Next]]
-    }
-
-
-    '{
-        ${optic} match {
-          case setter: Setter[S,A] => setter.andThen[Next, Next](${generatedOptic.asExprOf[Setter[A, Next]]})
-          case fold: Fold[S,A] => fold.andThen[Next](${generatedOptic.asExprOf[Fold[A, Next]]})
-        }
-    }
-
-    /*
-    generatedOptic.asTerm.tpe.asType match {
-      case '[Lens[f, t]] => '{ ${setter}.andThen[Next, Next](${generatedOptic.asExprOf[Lens[A,Next]]}) }
-      case '[Prism[f, t]] => '{ ${setter}.andThen[Next, Next](${generatedOptic.asExprOf[Prism[A,Next]]}) }
-      case '[Iso[f, t]] => '{ ${setter}.andThen[Next, Next](${generatedOptic.asExprOf[Iso[A,Next]]}) }
-      case '[Optional[f, t]] => '{ ${setter}.andThen[Next, Next](${generatedOptic.asExprOf[Optional[A,Next]]}) }
-      case '[Traversal[f, t]] => '{ ${setter}.andThen[Next, Next](${generatedOptic.asExprOf[Traversal[A,Next]]}) }
-    }*/
-  }
-
-  def onFold[S: Type, A: Type,Next: Type](optic: Expr[Fold[S,A]], lambda: Expr[Focus.KeywordContext ?=> A => Next])(using Quotes): Expr[Any] = {
-    import quotes.reflect._
-    val generatedOptic = FocusImpl(lambda)
-
-    generatedOptic.asTerm.tpe.asType match {
-      case '[Lens[f, t]] => '{ ${optic}.andThen[Next](${generatedOptic.asExprOf[Lens[A,Next]]}) }
-      case '[Prism[f, t]] => '{ ${optic}.andThen[Next](${generatedOptic.asExprOf[Prism[A,Next]]}) }
-      case '[Iso[f, t]] => '{ ${optic}.andThen[Next](${generatedOptic.asExprOf[Iso[A,Next]]}) }
-      case '[Optional[f, t]] => '{ ${optic}.andThen[Next](${generatedOptic.asExprOf[Optional[A,Next]]}) }
-      case '[Traversal[f, t]] => '{ ${optic}.andThen[Next](${generatedOptic.asExprOf[Traversal[A,Next]]}) }
+    if (onlyRequiresOneTypeParameter(opticType)) {
+      Select.overloaded(optic.asTerm, "andThen", List(nextType), List(generatedOptic)).asExpr
+    } else {
+      Select.overloaded(optic.asTerm, "andThen", List(nextType, nextType), List(generatedOptic)).asExpr
     }
   }
 
-  def applied[S: Type, A: Type,Next: Type](optic: Expr[AppliedSetter[S,A]], lambda: Expr[Focus.KeywordContext ?=> A => Next])(using Quotes): Expr[Any] = {
+  def applied[S: Type, A: Type, Next: Type](optic: Expr[AppliedSetter[S,A] | AppliedFold[S,A]], lambda: Expr[Focus.KeywordContext ?=> A => Next])(using Quotes): Expr[Any] = {
     import quotes.reflect._
-    val generatedOptic = FocusImpl(lambda)
+    
+    val generatedOptic = FocusImpl(lambda).asTerm
+    val opticType = optic.asTerm.tpe.widen
+    val nextType = TypeRepr.of[Next]
 
-    generatedOptic.asTerm.tpe.asType match {
-      case '[Lens[f, t]] => '{ ${optic}.andThen[Next, Next](${generatedOptic.asExprOf[Lens[A,Next]]}) }
-      case '[Prism[f, t]] => '{ ${optic}.andThen[Next, Next](${generatedOptic.asExprOf[Prism[A,Next]]}) }
-      case '[Iso[f, t]] => '{ ${optic}.andThen[Next, Next](${generatedOptic.asExprOf[Iso[A,Next]]}) }
-      case '[Optional[f, t]] => '{ ${optic}.andThen[Next, Next](${generatedOptic.asExprOf[Optional[A,Next]]}) }
-      case '[Traversal[f, t]] => '{ ${optic}.andThen[Next, Next](${generatedOptic.asExprOf[Traversal[A,Next]]}) }
+    def onlyRequiresOneTypeParameter(tpe: TypeRepr): Boolean = 
+      tpe =:= TypeRepr.of[AppliedFold[S,A]] || tpe =:= TypeRepr.of[AppliedGetter[S,A]]
+
+    if (onlyRequiresOneTypeParameter(opticType)) {
+      Select.overloaded(optic.asTerm, "andThen", List(nextType), List(generatedOptic)).asExpr
+    } else {
+      Select.overloaded(optic.asTerm, "andThen", List(nextType, nextType), List(generatedOptic)).asExpr
     }
   }
 }
-

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/ComposedFocusImpl.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/ComposedFocusImpl.scala
@@ -1,14 +1,56 @@
 package monocle.internal.focus
 
-import monocle.{Focus, Lens, Iso, Prism, Optional, Traversal, Getter, Setter, Fold}
-import monocle.syntax.{AppliedPLens, AppliedPPrism, AppliedPIso, AppliedPOptional, AppliedPTraversal }
+import monocle.{Focus, Lens, Iso, Prism, Optional, Traversal, Getter, Setter, Fold, AppliedSetter}
 import scala.quoted.{Type, Expr, Quotes, quotes}
 
 
 private[monocle] object ComposedFocusImpl {
 
 
-  def apply[S: Type, A: Type,Next: Type](optic: Expr[Setter[S,A]], lambda: Expr[Focus.KeywordContext ?=> A => Next])(using Quotes): Expr[Any] = {
+  def apply[S: Type, A: Type, Next: Type](optic: Expr[Setter[S,A] | Fold[S,A]], lambda: Expr[Focus.KeywordContext ?=> A => Next])(using Quotes): Expr[Any] = {
+    import quotes.reflect._
+    val generatedOptic = FocusImpl(lambda)
+
+    val typedGeneratedOptic = generatedOptic.asTerm.tpe.asType match {
+      case '[Lens[f, t]] => generatedOptic.asExprOf[Lens[A,Next]]
+      case '[Prism[f, t]] => generatedOptic.asExprOf[Prism[A,Next]]
+      case '[Iso[f, t]] => generatedOptic.asExprOf[Iso[A,Next]]
+      case '[Optional[f, t]] => generatedOptic.asExprOf[Optional[A,Next]]
+      case '[Traversal[f, t]] => generatedOptic.asExprOf[Traversal[A,Next]]
+    }
+
+
+    '{
+        ${optic} match {
+          case setter: Setter[S,A] => setter.andThen[Next, Next](${generatedOptic.asExprOf[Setter[A, Next]]})
+          case fold: Fold[S,A] => fold.andThen[Next](${generatedOptic.asExprOf[Fold[A, Next]]})
+        }
+    }
+
+    /*
+    generatedOptic.asTerm.tpe.asType match {
+      case '[Lens[f, t]] => '{ ${setter}.andThen[Next, Next](${generatedOptic.asExprOf[Lens[A,Next]]}) }
+      case '[Prism[f, t]] => '{ ${setter}.andThen[Next, Next](${generatedOptic.asExprOf[Prism[A,Next]]}) }
+      case '[Iso[f, t]] => '{ ${setter}.andThen[Next, Next](${generatedOptic.asExprOf[Iso[A,Next]]}) }
+      case '[Optional[f, t]] => '{ ${setter}.andThen[Next, Next](${generatedOptic.asExprOf[Optional[A,Next]]}) }
+      case '[Traversal[f, t]] => '{ ${setter}.andThen[Next, Next](${generatedOptic.asExprOf[Traversal[A,Next]]}) }
+    }*/
+  }
+
+  def onFold[S: Type, A: Type,Next: Type](optic: Expr[Fold[S,A]], lambda: Expr[Focus.KeywordContext ?=> A => Next])(using Quotes): Expr[Any] = {
+    import quotes.reflect._
+    val generatedOptic = FocusImpl(lambda)
+
+    generatedOptic.asTerm.tpe.asType match {
+      case '[Lens[f, t]] => '{ ${optic}.andThen[Next](${generatedOptic.asExprOf[Lens[A,Next]]}) }
+      case '[Prism[f, t]] => '{ ${optic}.andThen[Next](${generatedOptic.asExprOf[Prism[A,Next]]}) }
+      case '[Iso[f, t]] => '{ ${optic}.andThen[Next](${generatedOptic.asExprOf[Iso[A,Next]]}) }
+      case '[Optional[f, t]] => '{ ${optic}.andThen[Next](${generatedOptic.asExprOf[Optional[A,Next]]}) }
+      case '[Traversal[f, t]] => '{ ${optic}.andThen[Next](${generatedOptic.asExprOf[Traversal[A,Next]]}) }
+    }
+  }
+
+  def applied[S: Type, A: Type,Next: Type](optic: Expr[AppliedSetter[S,A]], lambda: Expr[Focus.KeywordContext ?=> A => Next])(using Quotes): Expr[Any] = {
     import quotes.reflect._
     val generatedOptic = FocusImpl(lambda)
 

--- a/core/shared/src/main/scala-3.x/monocle/internal/focus/ComposedFocusImpl.scala
+++ b/core/shared/src/main/scala-3.x/monocle/internal/focus/ComposedFocusImpl.scala
@@ -4,37 +4,23 @@ import monocle.{Focus, Lens, Iso, Prism, Optional, Traversal, Getter, Setter, Fo
 import scala.quoted.{Type, Expr, Quotes, quotes}
 
 private[monocle] object ComposedFocusImpl {
-  def apply[S: Type, A: Type, Next: Type](optic: Expr[Setter[S,A] | Fold[S,A]], lambda: Expr[Focus.KeywordContext ?=> A => Next])(using Quotes): Expr[Any] = {
+
+  type AnyOptic[S,A] = Setter[S,A] | Fold[S,A] | AppliedSetter[S,A] | AppliedFold[S,A]
+
+  def apply[S: Type, A: Type, Next: Type](optic: Expr[AnyOptic[S,A]], lambda: Expr[Focus.KeywordContext ?=> A => Next])(using Quotes): Expr[Any] = {
     import quotes.reflect._
     
     val generatedOptic = FocusImpl(lambda).asTerm
     val opticType = optic.asTerm.tpe.widen
     val nextType = TypeRepr.of[Next]
-    
-    def onlyRequiresOneTypeParameter(tpe: TypeRepr): Boolean = 
-      tpe =:= TypeRepr.of[Fold[S,A]] || tpe =:= TypeRepr.of[Getter[S,A]]
+    val singleTypeParam: Boolean = 
+      opticType =:= TypeRepr.of[Fold[S,A]] || 
+      opticType =:= TypeRepr.of[Getter[S,A]] || 
+      opticType =:= TypeRepr.of[AppliedFold[S,A]] || 
+      opticType =:= TypeRepr.of[AppliedGetter[S,A]]
 
-    if (onlyRequiresOneTypeParameter(opticType)) {
-      Select.overloaded(optic.asTerm, "andThen", List(nextType), List(generatedOptic)).asExpr
-    } else {
-      Select.overloaded(optic.asTerm, "andThen", List(nextType, nextType), List(generatedOptic)).asExpr
-    }
-  }
+    val typeParams = if (singleTypeParam) List(nextType) else List(nextType, nextType)
 
-  def applied[S: Type, A: Type, Next: Type](optic: Expr[AppliedSetter[S,A] | AppliedFold[S,A]], lambda: Expr[Focus.KeywordContext ?=> A => Next])(using Quotes): Expr[Any] = {
-    import quotes.reflect._
-    
-    val generatedOptic = FocusImpl(lambda).asTerm
-    val opticType = optic.asTerm.tpe.widen
-    val nextType = TypeRepr.of[Next]
-
-    def onlyRequiresOneTypeParameter(tpe: TypeRepr): Boolean = 
-      tpe =:= TypeRepr.of[AppliedFold[S,A]] || tpe =:= TypeRepr.of[AppliedGetter[S,A]]
-
-    if (onlyRequiresOneTypeParameter(opticType)) {
-      Select.overloaded(optic.asTerm, "andThen", List(nextType), List(generatedOptic)).asExpr
-    } else {
-      Select.overloaded(optic.asTerm, "andThen", List(nextType, nextType), List(generatedOptic)).asExpr
-    }
+    Select.overloaded(optic.asTerm, "andThen", typeParams, List(generatedOptic)).asExpr
   }
 }

--- a/core/shared/src/main/scala-3.x/monocle/syntax/All.scala
+++ b/core/shared/src/main/scala-3.x/monocle/syntax/All.scala
@@ -2,4 +2,4 @@ package monocle.syntax
 
 object all extends Syntaxes
 
-trait Syntaxes extends AppliedSyntax with AppliedFocusSyntax with MacroSyntax with FieldsSyntax
+trait Syntaxes extends AppliedSyntax with AppliedFocusSyntax with ComposedFocusSyntax with MacroSyntax with FieldsSyntax

--- a/core/shared/src/main/scala-3.x/monocle/syntax/ComposedFocusSyntax.scala
+++ b/core/shared/src/main/scala-3.x/monocle/syntax/ComposedFocusSyntax.scala
@@ -1,0 +1,50 @@
+package monocle.syntax
+
+import monocle._
+import monocle.internal.focus.ComposedFocusImpl
+
+trait ComposedFocusSyntax {
+
+  extension [S, A, Next] (optic: Lens[S, A]) {
+   transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any =
+     ${ComposedFocusImpl[S, A, Next]('optic, 'lambda)}
+  }
+
+  // extension [S, A, Next] (optic: AppliedLens[S, A]) {
+  //  transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any =
+  //    ${AppliedFocusImpl[S, A, Next]('optic, 'lambda)}
+  // }
+  
+  extension [S, A, Next] (optic: Iso[S, A]) {
+    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any =
+      ${ComposedFocusImpl[S, A, Next]('optic, 'lambda)}
+  }
+
+/*
+  extension [From, To] (optic: Prism[From, To]) {
+    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> From => To)): Any =
+      optic.andThen(${FocusImpl[From, To]('lambda)})
+  }
+
+  extension [From, To] (optic: Optional[From, To]) {
+    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> From => To)): Any =
+      optic.andThen(${FocusImpl[From, To]('lambda)})
+  }
+
+
+  extension [From, To] (optic: Traversal[From, To]) {
+    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> From => To)): Any =
+      optic.andThen(${FocusImpl[From, To]('lambda)})
+  }
+
+  extension [From, To] (optic: Getter[From, To]) {
+    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> From => To)): Any =
+      optic.andThen(${FocusImpl[From, To]('lambda)})
+  }
+
+  extension [From, To] (optic: Setter[From, To]) {
+    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> From => To)): Any =
+      optic.andThen(${FocusImpl[From, To]('lambda)})
+  }*/
+
+}

--- a/core/shared/src/main/scala-3.x/monocle/syntax/ComposedFocusSyntax.scala
+++ b/core/shared/src/main/scala-3.x/monocle/syntax/ComposedFocusSyntax.scala
@@ -5,9 +5,14 @@ import monocle.internal.focus.ComposedFocusImpl
 
 trait ComposedFocusSyntax {
 
-  extension [S, A, Next] (optic: Lens[S, A]) {
-   transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any =
-     ${ComposedFocusImpl[S, A, Next]('optic, 'lambda)}
+  extension [S, A, Next] (optic: Setter[S, A] | Fold[S,A]) {
+    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any = 
+      ${ComposedFocusImpl[S, A, Next]('optic, 'lambda)}
+  }
+
+  extension [S, A, Next] (optic: AppliedSetter[S, A]) {
+    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any =
+      ${ComposedFocusImpl.applied[S, A, Next]('optic, 'lambda)}
   }
 
   // extension [S, A, Next] (optic: AppliedLens[S, A]) {
@@ -15,10 +20,10 @@ trait ComposedFocusSyntax {
   //    ${AppliedFocusImpl[S, A, Next]('optic, 'lambda)}
   // }
   
-  extension [S, A, Next] (optic: Iso[S, A]) {
-    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any =
-      ${ComposedFocusImpl[S, A, Next]('optic, 'lambda)}
-  }
+  // extension [S, A, Next] (optic: Iso[S, A]) {
+  //   transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any =
+  //     ${ComposedFocusImpl[S, A, Next]('optic, 'lambda)}
+  // }
 
 /*
   extension [From, To] (optic: Prism[From, To]) {

--- a/core/shared/src/main/scala-3.x/monocle/syntax/ComposedFocusSyntax.scala
+++ b/core/shared/src/main/scala-3.x/monocle/syntax/ComposedFocusSyntax.scala
@@ -10,46 +10,8 @@ trait ComposedFocusSyntax {
       ${ComposedFocusImpl[S, A, Next]('optic, 'lambda)}
   }
 
-  extension [S, A, Next] (optic: AppliedSetter[S, A]) {
+  extension [S, A, Next] (optic: AppliedSetter[S, A] | AppliedFold[S,A]) {
     transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any =
       ${ComposedFocusImpl.applied[S, A, Next]('optic, 'lambda)}
   }
-
-  // extension [S, A, Next] (optic: AppliedLens[S, A]) {
-  //  transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any =
-  //    ${AppliedFocusImpl[S, A, Next]('optic, 'lambda)}
-  // }
-  
-  // extension [S, A, Next] (optic: Iso[S, A]) {
-  //   transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any =
-  //     ${ComposedFocusImpl[S, A, Next]('optic, 'lambda)}
-  // }
-
-/*
-  extension [From, To] (optic: Prism[From, To]) {
-    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> From => To)): Any =
-      optic.andThen(${FocusImpl[From, To]('lambda)})
-  }
-
-  extension [From, To] (optic: Optional[From, To]) {
-    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> From => To)): Any =
-      optic.andThen(${FocusImpl[From, To]('lambda)})
-  }
-
-
-  extension [From, To] (optic: Traversal[From, To]) {
-    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> From => To)): Any =
-      optic.andThen(${FocusImpl[From, To]('lambda)})
-  }
-
-  extension [From, To] (optic: Getter[From, To]) {
-    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> From => To)): Any =
-      optic.andThen(${FocusImpl[From, To]('lambda)})
-  }
-
-  extension [From, To] (optic: Setter[From, To]) {
-    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> From => To)): Any =
-      optic.andThen(${FocusImpl[From, To]('lambda)})
-  }*/
-
 }

--- a/core/shared/src/main/scala-3.x/monocle/syntax/ComposedFocusSyntax.scala
+++ b/core/shared/src/main/scala-3.x/monocle/syntax/ComposedFocusSyntax.scala
@@ -5,13 +5,8 @@ import monocle.internal.focus.ComposedFocusImpl
 
 trait ComposedFocusSyntax {
 
-  extension [S, A, Next] (optic: Setter[S, A] | Fold[S,A]) {
+  extension [S, A, Next] (optic: Setter[S, A] | Fold[S,A] | AppliedSetter[S,A] | AppliedFold[S,A]) {
     transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any = 
       ${ComposedFocusImpl[S, A, Next]('optic, 'lambda)}
-  }
-
-  extension [S, A, Next] (optic: AppliedSetter[S, A] | AppliedFold[S,A]) {
-    transparent inline def refocus(inline lambda: (Focus.KeywordContext ?=> A => Next)): Any =
-      ${ComposedFocusImpl.applied[S, A, Next]('optic, 'lambda)}
   }
 }

--- a/core/shared/src/test/scala-3.x/monocle/focus/ComposedFocusTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/ComposedFocusTest.scala
@@ -1,63 +1,162 @@
 package monocle.focus
 
-import monocle.Focus
-import monocle.Focus._
 import monocle._
+import monocle.syntax.all._
+import monocle.syntax.{AppliedGetter, AppliedSetter}
+
+
+object ComposedFocusTest {
+  enum Roof {
+    case Tiles(numTiles: Int)
+    case Thatch(color: Color)
+    case Glass(tint: Option[String])
+  }
+
+  case class Color(r: Int, g: Int, b: Int)
+
+  case class Mailbox(address: Address)
+  case class User(name: String, address: Address)
+  case class Street(name: String)
+  case class Potato(count: Int)
+  case class Address(streetNumber: Int, street: Option[Street], roof: Roof, potatoes: List[Potato])
+
+  case class MailingList(users: List[User])
+
+  val elise = User("Elise", Address(12, Some(Street("high street")), Roof.Tiles(999), (1 to 4).toList.map(Potato.apply)))
+  val mailbox = Mailbox(Address(1, Some(Street("cherrytree lane")), Roof.Thatch(Color(255, 255, 0)), Nil))
+}
 
 
 final class ComposedFocusTest extends munit.FunSuite {
 
-  enum Roof {
-    case Tiles(numTiles: Int)
-    case Thatch(color: String)
-  }
-
-  case class Mailbox(address: Address)
-  case class User(name: String, address: Address)
-  case class Address(streetNumber: Int, postcode: String, roof: Roof)
-
-  val elise = User("Elise", Address(12, "high street", Roof.Tiles(999)))
-  val mailbox = Mailbox(Address(1, "cherrytree lane", Roof.Thatch("yellow")))
+  import ComposedFocusTest._
 
   test("Lens refocus correctly composes Lens") {
     val addressLens: Lens[User, Address] = Focus[User](_.address)
     val newLens: Lens[User, Int] = addressLens.refocus(_.streetNumber)
-    val newElise = addressLens.refocus(_.streetNumber).replace(50)(elise)
+    val newElise = newLens.replace(50)(elise)
+
+    assertEquals(newElise.address.streetNumber, 50)
+  }
+  
+  test("AppliedLens refocus correctly composes Lens") {
+    val addressLens: AppliedLens[User, Address] = elise.focus(_.address)
+    val newLens: AppliedLens[User, Int] = addressLens.refocus(_.streetNumber)
+    val newElise = newLens.replace(50)
 
     assertEquals(newElise.address.streetNumber, 50)
   }
 
   test("Lens refocus correctly composes Prism") {
     val roofLens: Lens[User, Roof] = Focus[User](_.address.roof)
-    val newLens: Optional[User, Roof.Tiles] = addressLens.refocus(_.as[Roof.Tiles])
+    val newLens: Optional[User, Roof.Tiles] = roofLens.refocus(_.as[Roof.Tiles])
     val newElise = newLens.replace(Roof.Tiles(3))(elise)
+
     assertEquals(newElise.address.roof, Roof.Tiles(3))
   }
 
   test("Lens refocus correctly composes Iso") {
     val addressLens: Lens[User, Address] = Focus[User](_.address)
     val newLens: Lens[User, Int] = addressLens.refocus(_.streetNumber)
-    val newElise = addressLens.refocus(_.streetNumber).replace(50)(elise)
+    val newElise = newLens.replace(50)(elise)
 
     assertEquals(newElise.address.streetNumber, 50)
   }
-/*
-  test("Applied lens refocus correctly composes") {
-    val addressLens: AppliedLens[User, Address] = elise.focus(_.address)
-    val newLens = addressLens.refocus(_.streetNumber)
 
-    assertEquals(newLens.replace(50), User("Elise", Address(50, "high street")))
+  test("Lens refocus correctly composes Optional") {
+    val addressLens: Lens[User, Address] = Focus[User](_.address)
+    val newLens: Optional[User, String] = addressLens.refocus(_.street.some.name)
+    val newElise = newLens.replace("Crunkley Ave")(elise)
+
+    assertEquals(newElise.address.street.map(_.name), Some("Crunkley Ave"))
   }
 
-  test("Iso refocus correctly composes") {
-    val addressLens: Iso[Mailbox, Address] = Focus[Mailbox](_.address)
-    val newMailbox = addressLens.refocus(_.streetNumber).replace(7)(mailbox)
-    assertEquals(newMailbox, Mailbox(Address(7, "cherrytree lane")))
+  test("Lens refocus correctly composes Traversal") {
+    val addressLens: Lens[User, Address] = Focus[User](_.address)
+    val newLens: Traversal[User, Int] = addressLens.refocus(_.potatoes.each.count)
+    val newElise = newLens.modify(_ + 1)(elise)
+
+    assertEquals(newElise.address.potatoes.map(_.count), List(2,3,4,5))
   }
 
-  test("Applied Iso refocus correctly composes") {
-    val addressLens: AppliedLens[User, Address] = elise.focus(_.address)
-    val newElise = addressLens.refocus(_.streetNumber).replace(50)
-    assertEquals(newElise, User("Elise", Address(50, "high street")))
-  }*/
+  test("Prism refocus correctly composes Lens") {
+    val oldLens: Prism[Roof, Roof.Thatch] = Focus[Roof](_.as[Roof.Thatch])
+    val newLens: Optional[Roof, Int] = oldLens.refocus(_.color.r)
+    val newRoof = newLens.replace(77)(Roof.Thatch(Color(255, 255, 255)))
+
+    assertEquals(newRoof, Roof.Thatch(Color(77, 255, 255)))
+  }
+
+  test("Prism refocus correctly composes Prism") {
+    val oldLens: Prism[Roof, Roof.Glass] = Focus[Roof](_.as[Roof.Glass])
+    val newLens: Prism[Roof, String] = oldLens.refocus(_.tint.some)
+    val newRoof = newLens.replace("light")(Roof.Glass(Some("dark")))
+
+    assertEquals(newRoof, Roof.Glass(Some("light")))
+  }
+
+  test("Prism refocus correctly composes Iso") {
+    val oldLens: Prism[Roof, Roof.Tiles] = Focus[Roof](_.as[Roof.Tiles])
+    val newLens: Prism[Roof, Int] = oldLens.refocus(_.numTiles)
+    val newRoof = newLens.replace(100)(Roof.Tiles(3))
+
+    assertEquals(newRoof, Roof.Tiles(100))
+  }
+
+  test("Prism refocus correctly composes Optional") {
+    val oldLens: Prism[Roof, Roof.Glass] = Focus[Roof](_.as[Roof.Glass])
+    val newLens: Optional[Roof, String] = oldLens.refocus(_.tint.some)
+    val newRoof = newLens.replace("light")(Roof.Glass(Some("dark")))
+
+    assertEquals(newRoof, Roof.Glass(Some("light")))
+  }
+
+  test("Fold refocus correctly composes Lens") {
+    val userFold: Fold[MailingList, Address] = Focus[MailingList](_.users.each).andThen(Getter[User, Address](_.address))
+    val newLens: Fold[MailingList, Int] = userFold.refocus(_.streetNumber)
+    val streetNumbers = newLens.getAll(MailingList(List(elise)))
+
+    assertEquals(streetNumbers, List(12))
+  }
+
+  test("AppliedFold refocus correctly composes Lens") {
+    val mailingList = MailingList(List(elise))
+    val userFold: AppliedFold[MailingList, Address] = mailingList.focus(_.users.each).andThen(Getter[User, Address](_.address))
+    val newLens: AppliedFold[MailingList, Int] = userFold.refocus(_.streetNumber)
+    val streetNumbers = newLens.getAll
+
+    assertEquals(streetNumbers, List(12))
+  }
+
+  test("Getter refocus correctly composes Lens") {
+    val addressLens: Getter[User, Address] = Getter[User, Address](_.address)
+    val newLens: Getter[User, Int] = addressLens.refocus(_.streetNumber)
+    val streetNumber = newLens.get(elise)
+
+    assertEquals(streetNumber, 12)
+  }
+
+  test("AppliedGetter refocus correctly composes Lens") {
+    val addressLens: AppliedGetter[User, Address] = AppliedGetter(elise, Getter[User, Address](_.address))
+    val newLens: AppliedGetter[User, Int] = addressLens.refocus(_.streetNumber)
+    val streetNumber = newLens.get
+
+    assertEquals(streetNumber, 12)
+  }
+
+  test("Setter refocus correctly composes Lens") {
+    val addressLens: Setter[User, Address] = Setter(f => user => user.copy(address = f(user.address)))
+    val newLens: Setter[User, Int] = addressLens.refocus(_.streetNumber)
+    val newElise = newLens.replace(50)(elise)
+
+    assertEquals(newElise.address.streetNumber, 50)
+  }
+
+  test("AppliedSetter refocus correctly composes Lens") {
+    val addressLens: AppliedSetter[User, Address] = AppliedSetter(elise, Setter(f => user => user.copy(address = f(user.address))))
+    val newLens: AppliedSetter[User, Int] = addressLens.refocus(_.streetNumber)
+    val newElise = newLens.replace(50)
+
+    assertEquals(newElise.address.streetNumber, 50)
+  }
 }

--- a/core/shared/src/test/scala-3.x/monocle/focus/ComposedFocusTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/ComposedFocusTest.scala
@@ -4,27 +4,50 @@ import monocle.Focus
 import monocle.Focus._
 import monocle._
 
+
 final class ComposedFocusTest extends munit.FunSuite {
+
+  enum Roof {
+    case Tiles(numTiles: Int)
+    case Thatch(color: String)
+  }
 
   case class Mailbox(address: Address)
   case class User(name: String, address: Address)
-  case class Address(streetNumber: Int, postcode: String)
+  case class Address(streetNumber: Int, postcode: String, roof: Roof)
 
-  val elise = User("Elise", Address(12, "high street"))
-  val mailbox = Mailbox(Address(1, "cherrytree lane"))
+  val elise = User("Elise", Address(12, "high street", Roof.Tiles(999)))
+  val mailbox = Mailbox(Address(1, "cherrytree lane", Roof.Thatch("yellow")))
 
-
-  test("Lens refocus correctly composes") {
+  test("Lens refocus correctly composes Lens") {
     val addressLens: Lens[User, Address] = Focus[User](_.address)
+    val newLens: Lens[User, Int] = addressLens.refocus(_.streetNumber)
     val newElise = addressLens.refocus(_.streetNumber).replace(50)(elise)
-    assertEquals(newElise, User("Elise", Address(50, "high street")))
+
+    assertEquals(newElise.address.streetNumber, 50)
   }
 
-  // test("Applied lens refocus correctly composes") {
-  //   val addressLens: AppliedLens[User, Address] = elise.focus(_.address)
-  //   val newElise = addressLens.refocus(_.streetNumber).replace(50)
-  //   assertEquals(newElise, User("Elise", Address(50, "high street")))
-  // }
+  test("Lens refocus correctly composes Prism") {
+    val roofLens: Lens[User, Roof] = Focus[User](_.address.roof)
+    val newLens: Optional[User, Roof.Tiles] = addressLens.refocus(_.as[Roof.Tiles])
+    val newElise = newLens.replace(Roof.Tiles(3))(elise)
+    assertEquals(newElise.address.roof, Roof.Tiles(3))
+  }
+
+  test("Lens refocus correctly composes Iso") {
+    val addressLens: Lens[User, Address] = Focus[User](_.address)
+    val newLens: Lens[User, Int] = addressLens.refocus(_.streetNumber)
+    val newElise = addressLens.refocus(_.streetNumber).replace(50)(elise)
+
+    assertEquals(newElise.address.streetNumber, 50)
+  }
+/*
+  test("Applied lens refocus correctly composes") {
+    val addressLens: AppliedLens[User, Address] = elise.focus(_.address)
+    val newLens = addressLens.refocus(_.streetNumber)
+
+    assertEquals(newLens.replace(50), User("Elise", Address(50, "high street")))
+  }
 
   test("Iso refocus correctly composes") {
     val addressLens: Iso[Mailbox, Address] = Focus[Mailbox](_.address)
@@ -32,9 +55,9 @@ final class ComposedFocusTest extends munit.FunSuite {
     assertEquals(newMailbox, Mailbox(Address(7, "cherrytree lane")))
   }
 
-  // test("Applied Iso refocus correctly composes") {
-  //   val addressLens: AppliedLens[User, Address] = elise.focus(_.address)
-  //   val newElise = addressLens.refocus(_.streetNumber).replace(50)
-  //   assertEquals(newElise, User("Elise", Address(50, "high street")))
-  // }
+  test("Applied Iso refocus correctly composes") {
+    val addressLens: AppliedLens[User, Address] = elise.focus(_.address)
+    val newElise = addressLens.refocus(_.streetNumber).replace(50)
+    assertEquals(newElise, User("Elise", Address(50, "high street")))
+  }*/
 }

--- a/core/shared/src/test/scala-3.x/monocle/focus/ComposedFocusTest.scala
+++ b/core/shared/src/test/scala-3.x/monocle/focus/ComposedFocusTest.scala
@@ -1,0 +1,40 @@
+package monocle.focus
+
+import monocle.Focus
+import monocle.Focus._
+import monocle._
+
+final class ComposedFocusTest extends munit.FunSuite {
+
+  case class Mailbox(address: Address)
+  case class User(name: String, address: Address)
+  case class Address(streetNumber: Int, postcode: String)
+
+  val elise = User("Elise", Address(12, "high street"))
+  val mailbox = Mailbox(Address(1, "cherrytree lane"))
+
+
+  test("Lens refocus correctly composes") {
+    val addressLens: Lens[User, Address] = Focus[User](_.address)
+    val newElise = addressLens.refocus(_.streetNumber).replace(50)(elise)
+    assertEquals(newElise, User("Elise", Address(50, "high street")))
+  }
+
+  // test("Applied lens refocus correctly composes") {
+  //   val addressLens: AppliedLens[User, Address] = elise.focus(_.address)
+  //   val newElise = addressLens.refocus(_.streetNumber).replace(50)
+  //   assertEquals(newElise, User("Elise", Address(50, "high street")))
+  // }
+
+  test("Iso refocus correctly composes") {
+    val addressLens: Iso[Mailbox, Address] = Focus[Mailbox](_.address)
+    val newMailbox = addressLens.refocus(_.streetNumber).replace(7)(mailbox)
+    assertEquals(newMailbox, Mailbox(Address(7, "cherrytree lane")))
+  }
+
+  // test("Applied Iso refocus correctly composes") {
+  //   val addressLens: AppliedLens[User, Address] = elise.focus(_.address)
+  //   val newElise = addressLens.refocus(_.streetNumber).replace(50)
+  //   assertEquals(newElise, User("Elise", Address(50, "high street")))
+  // }
+}


### PR DESCRIPTION
- Adds extension method `refocus` to all optics & applied optics, which is equivalent to `optic.andThen(Focus[Foo](_.....))`.
- Resolves #1056
- Must be an extension method rather than a direct method on optics, so as to cleanly separate the macro code.
- Astonishingly, can treat all optics and applied optics uniformly with only one simple implementation.
- Privately defines a `type AnyOptic[S,A] = Setter[S,A] | Fold[S,A] | AppliedSetter[S,A] | AppliedFold[S,A]`. Should this be a public definition? Probably not, because its usage is not likely to be meaningful beyond this macro, and would be highly susceptible to change.
- Big fat test suite testing many combinations of optic types, and especially `Getter` and `Fold`, since they are special cases, because their `andThen` method only has one type parameter.
- Have not added a Scala 2 equivalent, corresponding to the single-field Focus functionality supported in Scala 2. It makes sense to add this, but perhaps that can be a different ticket