### PR TITLE
index is now a direct method, for better Cats compat

### DIFF
--- a/core/shared/src/main/scala/monocle/Fold.scala
+++ b/core/shared/src/main/scala/monocle/Fold.scala
@@ -86,6 +86,9 @@ trait Fold[S, A] extends Serializable { self =>
   def some[A1](implicit ev1: A =:= Option[A1]): Fold[S, A1] =
     adapt[Option[A1]].andThen(std.option.some[A1])
 
+  def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1]): Fold[S, A1] =
+    self.andThen(evIndex.index(i))
+
   private[monocle] def adapt[A1](implicit evA: A =:= A1): Fold[S, A1] =
     evA.substituteCo[Fold[S, *]](this)
 
@@ -164,9 +167,6 @@ final case class FoldSyntax[S, A](private val self: Fold[S, A]) extends AnyVal {
 
   def at[I, A1](i: I)(implicit evAt: At[A, I, A1]): Fold[S, A1] =
     self.andThen(evAt.at(i))
-
-  def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1]): Fold[S, A1] =
-    self.andThen(evIndex.index(i))
 
   /** compose a [[Fold]] with a [[Fold]] */
   @deprecated("use andThen", since = "3.0.0-M1")

--- a/core/shared/src/main/scala/monocle/Getter.scala
+++ b/core/shared/src/main/scala/monocle/Getter.scala
@@ -63,6 +63,9 @@ trait Getter[S, A] extends Fold[S, A] { self =>
   override def some[A1](implicit ev1: A =:= Option[A1]): Fold[S, A1] =
     adapt[Option[A1]].andThen(std.option.some[A1])
 
+  override def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1]): Fold[S, A1] =
+    self.andThen(evIndex.index(i))
+
   override private[monocle] def adapt[A1](implicit evA: A =:= A1): Getter[S, A1] =
     evA.substituteCo[Getter[S, *]](this)
 
@@ -151,9 +154,6 @@ final case class GetterSyntax[S, A](private val self: Getter[S, A]) extends AnyV
 
   def at[I, A1](i: I)(implicit evAt: At[A, I, A1]): Getter[S, A1] =
     self.andThen(evAt.at(i))
-
-  def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1]): Fold[S, A1] =
-    self.andThen(evIndex.index(i))
 
   /** compose a [[Fold]] with a [[Fold]] */
   @deprecated("use andThen", since = "3.0.0-M1")

--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -112,7 +112,9 @@ trait PIso[S, T, A, B] extends PLens[S, T, A, B] with PPrism[S, T, A, B] { self 
   override def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): PPrism[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]].andThen(std.option.pSome[A1, B1])
 
-  override def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A1] =
+  override def index[I, A1](
+    i: I
+  )(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A1] =
     adaptMono.andThen(evIndex.index(i))
 
   override private[monocle] def adaptMono(implicit evMonoS: S =:= T, evMonoA: A =:= B): Iso[S, A] =

--- a/core/shared/src/main/scala/monocle/Iso.scala
+++ b/core/shared/src/main/scala/monocle/Iso.scala
@@ -112,6 +112,12 @@ trait PIso[S, T, A, B] extends PLens[S, T, A, B] with PPrism[S, T, A, B] { self 
   override def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): PPrism[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]].andThen(std.option.pSome[A1, B1])
 
+  override def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A1] =
+    adaptMono.andThen(evIndex.index(i))
+
+  override private[monocle] def adaptMono(implicit evMonoS: S =:= T, evMonoA: A =:= B): Iso[S, A] =
+    evMonoS.substituteContra[PIso[S, *, A, A]](evMonoA.substituteContra[PIso[S, T, A, *]](this))
+
   override private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PIso[S, T, A1, B1] =
     evB.substituteCo[PIso[S, T, A1, *]](evA.substituteCo[PIso[S, T, *, B]](this))
 
@@ -359,7 +365,4 @@ final case class IsoSyntax[S, A](private val self: Iso[S, A]) extends AnyVal {
 
   def at[I, A1](i: I)(implicit evAt: At[A, I, A1]): Lens[S, A1] =
     self.andThen(evAt.at(i))
-
-  def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1]): Optional[S, A1] =
-    self.andThen(evIndex.index(i))
 }

--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -98,7 +98,9 @@ trait PLens[S, T, A, B] extends POptional[S, T, A, B] with Getter[S, A] { self =
   override def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): POptional[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]].andThen(std.option.pSome[A1, B1])
 
-  override def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A1] =
+  override def index[I, A1](
+    i: I
+  )(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A1] =
     adaptMono.andThen(evIndex.index(i))
 
   override private[monocle] def adaptMono(implicit evMonoS: S =:= T, evMonoA: A =:= B): Lens[S, A] =

--- a/core/shared/src/main/scala/monocle/Lens.scala
+++ b/core/shared/src/main/scala/monocle/Lens.scala
@@ -98,6 +98,12 @@ trait PLens[S, T, A, B] extends POptional[S, T, A, B] with Getter[S, A] { self =
   override def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): POptional[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]].andThen(std.option.pSome[A1, B1])
 
+  override def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A1] =
+    adaptMono.andThen(evIndex.index(i))
+
+  override private[monocle] def adaptMono(implicit evMonoS: S =:= T, evMonoA: A =:= B): Lens[S, A] =
+    evMonoS.substituteContra[PLens[S, *, A, A]](evMonoA.substituteContra[PLens[S, T, A, *]](this))
+
   override private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PLens[S, T, A1, B1] =
     evB.substituteCo[PLens[S, T, A1, *]](evA.substituteCo[PLens[S, T, *, B]](this))
 
@@ -296,7 +302,4 @@ final case class LensSyntax[S, A](private val self: Lens[S, A]) extends AnyVal {
 
   def at[I, A1](i: I)(implicit evAt: At[A, I, A1]): Lens[S, A1] =
     self.andThen(evAt.at(i))
-
-  def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1]): Optional[S, A1] =
-    self.andThen(evIndex.index(i))
 }

--- a/core/shared/src/main/scala/monocle/Optional.scala
+++ b/core/shared/src/main/scala/monocle/Optional.scala
@@ -103,6 +103,12 @@ trait POptional[S, T, A, B] extends PTraversal[S, T, A, B] { self =>
   override def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): POptional[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]].andThen(std.option.pSome[A1, B1])
 
+  override def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A1] =
+    adaptMono.andThen(evIndex.index(i))
+
+  override private[monocle] def adaptMono(implicit evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A] =
+    evMonoS.substituteContra[POptional[S, *, A, A]](evMonoA.substituteContra[POptional[S, T, A, *]](this))
+
   override private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): POptional[S, T, A1, B1] =
     evB.substituteCo[POptional[S, T, A1, *]](evA.substituteCo[POptional[S, T, *, B]](this))
 
@@ -339,7 +345,4 @@ final case class OptionalSyntax[S, A](private val self: Optional[S, A]) extends 
 
   def at[I, A1](i: I)(implicit evAt: At[A, I, A1]): Optional[S, A1] =
     self.andThen(evAt.at(i))
-
-  def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1]): Optional[S, A1] =
-    self.andThen(evIndex.index(i))
 }

--- a/core/shared/src/main/scala/monocle/Optional.scala
+++ b/core/shared/src/main/scala/monocle/Optional.scala
@@ -103,7 +103,9 @@ trait POptional[S, T, A, B] extends PTraversal[S, T, A, B] { self =>
   override def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): POptional[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]].andThen(std.option.pSome[A1, B1])
 
-  override def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A1] =
+  override def index[I, A1](
+    i: I
+  )(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A1] =
     adaptMono.andThen(evIndex.index(i))
 
   override private[monocle] def adaptMono(implicit evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A] =

--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -86,7 +86,9 @@ trait PPrism[S, T, A, B] extends POptional[S, T, A, B] { self =>
   override def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): PPrism[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]].andThen(std.option.pSome[A1, B1])
 
-  override def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A1] =
+  override def index[I, A1](
+    i: I
+  )(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A1] =
     adaptMono.andThen(evIndex.index(i))
 
   override private[monocle] def adaptMono(implicit evMonoS: S =:= T, evMonoA: A =:= B): Prism[S, A] =

--- a/core/shared/src/main/scala/monocle/Prism.scala
+++ b/core/shared/src/main/scala/monocle/Prism.scala
@@ -86,6 +86,12 @@ trait PPrism[S, T, A, B] extends POptional[S, T, A, B] { self =>
   override def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): PPrism[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]].andThen(std.option.pSome[A1, B1])
 
+  override def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Optional[S, A1] =
+    adaptMono.andThen(evIndex.index(i))
+
+  override private[monocle] def adaptMono(implicit evMonoS: S =:= T, evMonoA: A =:= B): Prism[S, A] =
+    evMonoS.substituteContra[PPrism[S, *, A, A]](evMonoA.substituteContra[PPrism[S, T, A, *]](this))
+
   override private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PPrism[S, T, A1, B1] =
     evB.substituteCo[PPrism[S, T, A1, *]](evA.substituteCo[PPrism[S, T, *, B]](this))
 
@@ -294,7 +300,4 @@ final case class PrismSyntax[S, A](private val self: Prism[S, A]) extends AnyVal
 
   def at[I, A1](i: I)(implicit evAt: At[A, I, A1]): Optional[S, A1] =
     self.andThen(evAt.at(i))
-
-  def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1]): Optional[S, A1] =
-    self.andThen(evIndex.index(i))
 }

--- a/core/shared/src/main/scala/monocle/Setter.scala
+++ b/core/shared/src/main/scala/monocle/Setter.scala
@@ -41,6 +41,12 @@ trait PSetter[S, T, A, B] extends Serializable { self =>
   def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): PSetter[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]].andThen(std.option.pSome[A1, B1])
 
+  def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Setter[S, A1] =
+    adaptMono.andThen(evIndex.index(i))
+
+  private[monocle] def adaptMono(implicit evMonoS: S =:= T, evMonoA: A =:= B): Setter[S, A] =
+    evMonoS.substituteContra[PSetter[S, *, A, A]](evMonoA.substituteContra[PSetter[S, T, A, *]](this))
+
   private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PSetter[S, T, A1, B1] =
     evB.substituteCo[PSetter[S, T, A1, *]](evA.substituteCo[PSetter[S, T, *, B]](this))
 
@@ -204,7 +210,4 @@ final case class SetterSyntax[S, A](private val self: Setter[S, A]) extends AnyV
 
   def at[I, A1](i: I)(implicit evAt: At[A, I, A1]): Setter[S, A1] =
     self.andThen(evAt.at(i))
-
-  def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1]): Setter[S, A1] =
-    self.andThen(evIndex.index(i))
 }

--- a/core/shared/src/main/scala/monocle/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/Traversal.scala
@@ -54,7 +54,9 @@ trait PTraversal[S, T, A, B] extends PSetter[S, T, A, B] with Fold[S, A] { self 
   override def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): PTraversal[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]].andThen(std.option.pSome[A1, B1])
 
-  override def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Traversal[S, A1] =
+  override def index[I, A1](
+    i: I
+  )(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Traversal[S, A1] =
     adaptMono.andThen(evIndex.index(i))
 
   override private[monocle] def adaptMono(implicit evMonoS: S =:= T, evMonoA: A =:= B): Traversal[S, A] =

--- a/core/shared/src/main/scala/monocle/Traversal.scala
+++ b/core/shared/src/main/scala/monocle/Traversal.scala
@@ -54,6 +54,12 @@ trait PTraversal[S, T, A, B] extends PSetter[S, T, A, B] with Fold[S, A] { self 
   override def some[A1, B1](implicit ev1: A =:= Option[A1], ev2: B =:= Option[B1]): PTraversal[S, T, A1, B1] =
     adapt[Option[A1], Option[B1]].andThen(std.option.pSome[A1, B1])
 
+  override def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1], evMonoS: S =:= T, evMonoA: A =:= B): Traversal[S, A1] =
+    adaptMono.andThen(evIndex.index(i))
+
+  override private[monocle] def adaptMono(implicit evMonoS: S =:= T, evMonoA: A =:= B): Traversal[S, A] =
+    evMonoS.substituteContra[PTraversal[S, *, A, A]](evMonoA.substituteContra[PTraversal[S, T, A, *]](this))
+
   override private[monocle] def adapt[A1, B1](implicit evA: A =:= A1, evB: B =:= B1): PTraversal[S, T, A1, B1] =
     evB.substituteCo[PTraversal[S, T, A1, *]](evA.substituteCo[PTraversal[S, T, *, B]](this))
 
@@ -297,7 +303,4 @@ final case class TraversalSyntax[S, A](private val self: Traversal[S, A]) extend
 
   def at[I, A1](i: I)(implicit evAt: At[A, I, A1]): Traversal[S, A1] =
     self.andThen(evAt.at(i))
-
-  def index[I, A1](i: I)(implicit evIndex: Index[A, I, A1]): Traversal[S, A1] =
-    self.andThen(evIndex.index(i))
 }

--- a/core/shared/src/test/scala/monocle/CatsCompatTest.scala
+++ b/core/shared/src/test/scala/monocle/CatsCompatTest.scala
@@ -1,53 +1,52 @@
-
 package monocle
 
 final class CatsCompatTest extends munit.FunSuite {
 
   test("Setter index doesn't conflict with Cats") {
     import cats.syntax.all._
-    val setter = Setter.id[List[Int]]
+    val setter                           = Setter.id[List[Int]]
     val composed: Setter[List[Int], Int] = setter.index(5)
   }
 
   test("Traversal index doesn't conflict with Cats") {
     import cats.syntax.all._
-    val traversal = Traversal.id[List[Int]]
+    val traversal                           = Traversal.id[List[Int]]
     val composed: Traversal[List[Int], Int] = traversal.index(5)
   }
 
   test("Optional index doesn't conflict with Cats") {
     import cats.syntax.all._
-    val optional = Optional.id[List[Int]]
+    val optional                           = Optional.id[List[Int]]
     val composed: Optional[List[Int], Int] = optional.index(5)
   }
 
   test("Lens index doesn't conflict with Cats") {
     import cats.syntax.all._
-    val lens = Lens.id[List[Int]]
+    val lens                               = Lens.id[List[Int]]
     val composed: Optional[List[Int], Int] = lens.index(5)
   }
 
   test("Prism index doesn't conflict with Cats") {
     import cats.syntax.all._
-    val prism = Prism.id[List[Int]]
+    val prism                              = Prism.id[List[Int]]
     val composed: Optional[List[Int], Int] = prism.index(5)
   }
 
   test("Iso index doesn't conflict with Cats") {
     import cats.syntax.all._
-    val iso = Iso.id[List[Int]]
+    val iso                                = Iso.id[List[Int]]
     val composed: Optional[List[Int], Int] = iso.index(5)
   }
 
   test("Getter index doesn't conflict with Cats") {
     import cats.syntax.all._
-    val getter = Getter.id[List[Int]]
+    val getter                         = Getter.id[List[Int]]
     val composed: Fold[List[Int], Int] = getter.index(5)
   }
 
   test("Fold index doesn't conflict with Cats") {
     import cats.syntax.all._
-    val fold = Fold.id[List[Int]]
+    val fold                           = Fold.id[List[Int]]
     val composed: Fold[List[Int], Int] = fold.index(5)
   }
 }

--- a/core/shared/src/test/scala/monocle/CatsCompatTest.scala
+++ b/core/shared/src/test/scala/monocle/CatsCompatTest.scala
@@ -1,0 +1,53 @@
+
+package monocle
+
+final class CatsCompatTest extends munit.FunSuite {
+
+  test("Setter index doesn't conflict with Cats") {
+    import cats.syntax.all._
+    val setter = Setter.id[List[Int]]
+    val composed: Setter[List[Int], Int] = setter.index(5)
+  }
+
+  test("Traversal index doesn't conflict with Cats") {
+    import cats.syntax.all._
+    val traversal = Traversal.id[List[Int]]
+    val composed: Traversal[List[Int], Int] = traversal.index(5)
+  }
+
+  test("Optional index doesn't conflict with Cats") {
+    import cats.syntax.all._
+    val optional = Optional.id[List[Int]]
+    val composed: Optional[List[Int], Int] = optional.index(5)
+  }
+
+  test("Lens index doesn't conflict with Cats") {
+    import cats.syntax.all._
+    val lens = Lens.id[List[Int]]
+    val composed: Optional[List[Int], Int] = lens.index(5)
+  }
+
+  test("Prism index doesn't conflict with Cats") {
+    import cats.syntax.all._
+    val prism = Prism.id[List[Int]]
+    val composed: Optional[List[Int], Int] = prism.index(5)
+  }
+
+  test("Iso index doesn't conflict with Cats") {
+    import cats.syntax.all._
+    val iso = Iso.id[List[Int]]
+    val composed: Optional[List[Int], Int] = iso.index(5)
+  }
+
+  test("Getter index doesn't conflict with Cats") {
+    import cats.syntax.all._
+    val getter = Getter.id[List[Int]]
+    val composed: Fold[List[Int], Int] = getter.index(5)
+  }
+
+  test("Fold index doesn't conflict with Cats") {
+    import cats.syntax.all._
+    val fold = Fold.id[List[Int]]
+    val composed: Fold[List[Int], Int] = fold.index(5)
+  }
+}


### PR DESCRIPTION
Fix for #1183 

- Index is now a direct method on all optics, instead of an extension method
- new private method on all polymorphic optics `adaptMono`