### PR TITLE
Fix GenLens issue with evidence shadowing

### DIFF
--- a/macro/src/main/scala-2.x/monocle/macros/internal/Macro.scala
+++ b/macro/src/main/scala-2.x/monocle/macros/internal/Macro.scala
@@ -85,7 +85,8 @@ private[macros] class MacroImpl(val c: blackbox.Context) {
       .find(_.name.decodedName.toString == strFieldName)
       .getOrElse(c.abort(c.enclosingPosition, s"Cannot find constructor field named $fieldName in $sTpe"))
 
-    val F = TypeName(c.freshName("F"))
+    val F  = TypeName(c.freshName("F"))
+    val ev = TermName(c.freshName("evFunctor"))
 
     c.Expr[PLens[S, T, A, B]](q"""
       import _root_.scala.language.higherKinds // prevent warning at call site
@@ -97,7 +98,7 @@ private[macros] class MacroImpl(val c: blackbox.Context) {
         override def replace(a: $bTpe): $sTpe => $tTpe =
           _.copy($field = a)
 
-        override def modifyF[$F[_]: _root_.cats.Functor](f: $aTpe => $F[$bTpe])(s: $sTpe): $F[$tTpe] =
+        override def modifyF[$F[_]](f: $aTpe => $F[$bTpe])(s: $sTpe)(implicit $ev: _root_.cats.Functor[$F]): $F[$tTpe] =
           _root_.cats.Functor[$F].map(f(s.$fieldMethod))(a => s.copy($field = a))
 
         override def modify(f: $aTpe => $bTpe): $sTpe => $tTpe =

--- a/macro/src/test/scala-2.x/monocle/macros/internal/ContextBoundCompilationIssueSpec.scala
+++ b/macro/src/test/scala-2.x/monocle/macros/internal/ContextBoundCompilationIssueSpec.scala
@@ -1,0 +1,29 @@
+package monocle.macros.internal
+
+import monocle.Lens
+import monocle.macros.GenLens
+import munit.DisciplineSuite
+
+class ContextBoundCompilationIssueSpec extends DisciplineSuite {
+
+  private trait Foo[T]
+  private trait Bar[T]
+
+  private case class A[T: Foo](s: A.S[T]) {
+    val lens: Lens[A.S[T], Bar[T]] = GenLens[A.S[T]](_.bar)
+  }
+
+  private object A {
+    case class S[T: Foo](bar: Bar[T])
+  }
+
+  private case object FooImpl extends Foo[Unit]
+  private case object BarImpl extends Bar[Unit]
+
+  private val a: A[Unit] = A(A.S(BarImpl)(FooImpl))(FooImpl)
+
+  test("context.bound.compilation") {
+    assertEquals(a.lens.get(a.s), BarImpl)
+  }
+
+}


### PR DESCRIPTION
Will (mostly) solve #1259 for Scala 2.13.