### PR TITLE
Fix version in API docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -335,13 +335,13 @@ lazy val mdocSettings = Seq(
       .value,
   (ScalaUnidoc / unidoc / scalacOptions) ++= Seq(
     "-doc-source-url",
-    s"https://github.com/optics-dev/Monocle/tree/v${(ThisBuild / tlLatestVersion).value}€{FILE_PATH}.scala",
+    s"https://github.com/optics-dev/Monocle/tree/v${tlLatestVersion.value.getOrElse(version.value)}€{FILE_PATH}.scala",
     "-sourcepath",
     (LocalRootProject / baseDirectory).value.getAbsolutePath,
     "-doc-title",
     "Monocle",
     "-doc-version",
-    s"v${(ThisBuild / tlLatestVersion).value}"
+    s"v${tlLatestVersion.value.getOrElse(version.value)}"
   )
 )
 


### PR DESCRIPTION
This was my mistake in https://github.com/optics-dev/Monocle/pull/1307, causing the version in the API docs to render as `vSome(3.1.0)` and breaking the sourcecode links. Sorry!