### PR TITLE
Set tlBaseVersion to 3.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 
 inThisBuild(
   List(
-    tlBaseVersion := "3.3",
+    tlBaseVersion := "3.4",
     organization  := "dev.optics",
     homepage      := Some(url("https://github.com/optics-dev/Monocle")),
     licenses      := Seq("MIT" -> url("http://opensource.org/licenses/MIT")),


### PR DESCRIPTION
Prep for the 3.4.0 release (#1618).

`v3.4.0-RC1` was tagged while `tlBaseVersion` was still `"3.3"`, so MiMa resolves its previous-version set from the 3.3.x series instead of treating 3.4.0 as the start of a new binary-compatibility series. It did not block the RC build, but it should be corrected before the final 3.4.0 tag.

No tag is pushed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRbVCYWp3bquNaXPYW12JY