### PR TITLE
Pin docusaurusVersion to V1 so the website deploy works again

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -350,6 +350,7 @@ lazy val docs = project
   .settings(buildInfoSettings)
   .settings(scalacOptions ~= (_.filterNot(Set("-Ywarn-unused:imports", "-Ywarn-dead-code"))))
   .settings(
+    docusaurusVersion := DocusaurusVersion.V1,
     libraryDependencies ++= Seq(cats.value, shapeless.value)
   )
 


### PR DESCRIPTION
The website has not been republished since April. The publish step of every release run fails with:

```
error Command "deploy" not found.
[error] (docs / docusaurusPublishGhpages) java.lang.AssertionError: assertion failed:
        command returned 1: [/tmp/docusaurus...install_ssh.sh]
```

Most recently in the [3.4.0-RC2 release run](https://github.com/optics-dev/Monocle/actions/runs/33870761535), so the site still documents 3.3.0.

### Cause

Scala Steward bumped sbt-mdoc 2.4.0 → 2.9.0 in 7e804379 (2026-04-14).

[2.4.0](https://github.com/scalameta/mdoc/blob/v2.4.0/mdoc-sbt/src/main/scala/mdoc/DocusaurusPlugin.scala#L82) hardcoded the Docusaurus 1 command:

```
USE_SSH=true yarn publish-gh-pages
```

[2.9.x](https://github.com/scalameta/mdoc/blob/v2.9.1/mdoc-sbt/src/main/scala/mdoc/DocusaurusPlugin.scala#L126) introduced a `docusaurusVersion` setting and defaults it to `V3`:

```scala
case object V1 extends DocusaurusVersion { val publishArgs = List("publish-gh-pages") }
case object V3 extends DocusaurusVersion { val publishArgs = List("deploy") }
...
docusaurusVersion := DocusaurusVersion.V3,
```

But `website/` is still Docusaurus 1 — `siteConfig.js`, `sidebars.json`, `pages/`, no `docusaurus.config.js` — and its `package.json` defines `publish-gh-pages`, with no `deploy` script. Hence the error.

Declaring `V1` restores `USE_SSH=true yarn publish-gh-pages`, exactly what 2.4.0 ran.

### Not the deploy key

Worth stating since the error message names `install_ssh.sh`: `GIT_DEPLOY_KEY` is fine. The failing runs show ssh authenticating normally before the script gets to the yarn command:

```
Setting up ssh...
Identity added: /home/runner/.ssh/id_rsa (julien@fp-tower.com)
error Command "deploy" not found.
```

### Verification

`docs/docusaurusCreateSite` — the non-publishing counterpart of the failing task — runs mdoc, `yarn install` and the Docusaurus 1 build end to end, producing 248 html files.

Note `yarn install` needs Node ≥ 20.18.1 (`cheerio@1.2.0`); the CI runner satisfies this, and its `yarn install` already succeeded in the failing runs — only the command after it failed.

### Follow-up

Docusaurus 1 has been end-of-life for years. Migrating `website/` to Docusaurus 3 and dropping this setting is the real fix; this restores publishing in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRbVCYWp3bquNaXPYW12JY
